### PR TITLE
Fix: Social Meta Tags 

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -59,6 +59,12 @@ const config: Config = {
   ],
 
   themeConfig: {
+    metadata: [
+      { name: "twitter:card", content: "summary" }, // Small preview with logo
+      { name: "twitter:title", content: "tscircuit Docs" },
+      { name: "twitter:description", content: "Create Electronics with TypeScript and React" },
+      { name: "twitter:image", content: "https://docs.tscircuit.com/logo/logo.svg" },
+    ],
     navbar: {
       logo: {
         alt: "tscircuit logo",

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -60,10 +60,18 @@ const config: Config = {
 
   themeConfig: {
     metadata: [
+      // Twitter Meta Tags
       { name: "twitter:card", content: "summary" }, // Small preview with logo
       { name: "twitter:title", content: "tscircuit Docs" },
       { name: "twitter:description", content: "Create Electronics with TypeScript and React" },
       { name: "twitter:image", content: "https://docs.tscircuit.com/logo/logo.svg" },
+
+      // LinkedIn & Open Graph Meta Tags
+      { property: "og:type", content: "website" },
+      { property: "og:title", content: "tscircuit Docs" },
+      { property: "og:description", content: "Create Electronics with TypeScript and React" },
+      { property: "og:image", content: "https://docs.tscircuit.com/logo/logo.svg" },
+      { property: "og:url", content: "https://docs.tscircuit.com/" },
     ],
     navbar: {
       logo: {


### PR DESCRIPTION
## Fixes

- #21 

### Changes
- Added Twitter & LinkedIn meta tags inside `docusaurus.config.ts` to improve social media sharing.  
- Verified metadata using `curl -A Twitterbot` & `curl -A LinkedInBot`.

### Attachments
![image](https://github.com/user-attachments/assets/ac137d30-15ab-4ae1-9e42-1b9fa3015709)

### Note
These tags can be used for preview, but there is still an issue where the image does not appear in the preview.  

1. The preview image must be at least **1200px** wide.  
2. We need to convert the **SVG logo** to **PNG** if we want to display the logo instead of the blog’s **OG image** preview, as Twitter does not support SVG for previews.
 