### PR TITLE
Fix CircuitPreview split view width

### DIFF
--- a/src/components/CircuitPreview.tsx
+++ b/src/components/CircuitPreview.tsx
@@ -196,7 +196,7 @@ export default function CircuitPreview({
         {(view === "code" ||
           shouldSplitCode ||
           (!showTabs && windowSize === "mobile")) && (
-          <div className={tw(`flex flex-col flex-1`)}>
+          <div className={tw(`flex flex-col flex-1 basis-1/2`)}>
             {hasMultipleFiles && fileTabsElm}
             <div
               className={tw(
@@ -218,7 +218,7 @@ export default function CircuitPreview({
           view === "runframe") && (
           <div
             className={tw(
-              "flex-1 min-h-[300px] flex-shrink-0 overflow-hidden m-0 p-0",
+              "flex flex-1 basis-1/2 min-h-[300px] overflow-hidden m-0 p-0",
             )}
           >
             {showTabs && shouldSplitCode && tabsElm}

--- a/src/components/CircuitPreview.tsx
+++ b/src/components/CircuitPreview.tsx
@@ -196,7 +196,7 @@ export default function CircuitPreview({
         {(view === "code" ||
           shouldSplitCode ||
           (!showTabs && windowSize === "mobile")) && (
-          <div className={tw(`flex flex-col flex-1 basis-1/2`)}>
+          <div className={tw(`flex flex-col flex-1 basis-1/2 min-w-0`)}>
             {hasMultipleFiles && fileTabsElm}
             <div
               className={tw(
@@ -204,7 +204,7 @@ export default function CircuitPreview({
               )}
             >
               <CodeBlock
-                className={tw("w-full rounded-none shadow-none p-0 m-0")}
+                className={tw("w-full rounded-none shadow-none p-0 m-0 min-w-0")}
                 language="tsx"
               >
                 {fsMap[currentFile]?.trim() || code?.trim() || ""}
@@ -218,7 +218,7 @@ export default function CircuitPreview({
           view === "runframe") && (
           <div
             className={tw(
-              "flex flex-1 basis-1/2 min-h-[300px] overflow-hidden m-0 p-0",
+              "flex-1 basis-1/2 min-w-0 min-h-[300px] overflow-hidden m-0 p-0",
             )}
           >
             {showTabs && shouldSplitCode && tabsElm}

--- a/src/components/CircuitPreview.tsx
+++ b/src/components/CircuitPreview.tsx
@@ -204,7 +204,9 @@ export default function CircuitPreview({
               )}
             >
               <CodeBlock
-                className={tw("w-full rounded-none shadow-none p-0 m-0 min-w-0")}
+                className={tw(
+                  "w-full rounded-none shadow-none p-0 m-0 min-w-0",
+                )}
                 language="tsx"
               >
                 {fsMap[currentFile]?.trim() || code?.trim() || ""}


### PR DESCRIPTION
## Summary
- ensure both panes in `CircuitPreview` use equal width

## Testing
- `bun run format:check`
- `bun run typecheck`


------
https://chatgpt.com/codex/tasks/task_b_684a96dd95bc832784344665d734e5df