### PR TITLE
Fix code tab height

### DIFF
--- a/src/components/CircuitPreview.tsx
+++ b/src/components/CircuitPreview.tsx
@@ -200,12 +200,12 @@ export default function CircuitPreview({
             {hasMultipleFiles && fileTabsElm}
             <div
               className={tw(
-                `flex flex-1 overflow-x-auto overflow-y-auto m-0 p-0 border-r ${!isDarkTheme ? "border-gray-200" : "border-gray-700"}`,
+                `flex flex-1 overflow-hidden m-0 p-0 border-r ${!isDarkTheme ? "border-gray-200" : "border-gray-700"}`,
               )}
             >
               <CodeBlock
                 className={tw(
-                  "w-full rounded-none shadow-none p-0 m-0 min-w-0",
+                  "w-full h-full overflow-auto rounded-none shadow-none p-0 m-0 min-w-0",
                 )}
                 language="tsx"
               >


### PR DESCRIPTION
## Summary
- keep code block container from showing scroll bars mid-panel

## Testing
- `bun x @biomejs/biome lint src/components/CircuitPreview.tsx`
- `bun run typecheck`


------
https://chatgpt.com/codex/tasks/task_b_6850144152f08327b8e7f7bd097c8785