### PR TITLE
Add schematictext docs

### DIFF
--- a/docs/docs/elements/schematic-text.mdx
+++ b/docs/docs/elements/schematic-text.mdx
@@ -1,0 +1,35 @@
+---
+title: <schematictext />
+description: The `<schematictext />` element places text directly on the schematic.
+---
+
+## Overview
+
+`<schematictext />` is a primitive element used to display standalone text on the schematic. It does not appear on the PCB.
+
+import CircuitPreview from "@site/src/components/CircuitPreview"
+
+<CircuitPreview
+  defaultView="schematic"
+  code={`
+  export default () => (
+    <board width="10mm" height="10mm">
+      <schematictext text="Hello" schX={2} schY={3} color="red" anchor="center" />
+    </board>
+  )
+  `}
+/>
+
+
+## Properties
+
+| Property | Type | Description |
+|---------|------|-------------|
+| `text` | string | The text string to render. |
+| `schX` | length | X coordinate of the text. |
+| `schY` | length | Y coordinate of the text. |
+| `anchor` | enum | Anchor position such as `"center"`, `"left"`, `"right"`, `"top"`, `"bottom"`, or corner positions. Defaults to `"center"`. |
+| `fontSize` | number | Font size in schematic units. Default `1`. |
+| `color` | string | Color of the text, specified as a hex string. Default `"#000000"`. |
+| `schRotation` | angle | Rotation of the text in degrees. Default `0`. |
+

--- a/docs/elements/schematictext.mdx
+++ b/docs/elements/schematictext.mdx
@@ -10,6 +10,8 @@ description: The `<schematictext />` element places text directly on the schemat
 import CircuitPreview from "@site/src/components/CircuitPreview"
 
 <CircuitPreview
+  hide3DTab
+  hidePCBTab
   defaultView="schematic"
   code={`
   export default () => (

--- a/src/components/YouTubeEmbed.tsx
+++ b/src/components/YouTubeEmbed.tsx
@@ -1,4 +1,4 @@
-import React from "react"
+import type React from "react"
 
 interface YouTubeEmbedProps {
   youtubeId: string
@@ -29,7 +29,7 @@ const YouTubeEmbed: React.FC<YouTubeEmbedProps> = ({ youtubeId }) => {
         allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
         referrerPolicy="strict-origin-when-cross-origin"
         allowFullScreen
-      ></iframe>
+      />
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- document `<schematictext />` component without external references
- keep `YouTubeEmbed.tsx` lint‑compliant with self‑closing iframe

## Testing
- `bun run format`
- `bun run typecheck`
- `bun x @biomejs/biome lint .`


------
https://chatgpt.com/codex/tasks/task_b_68540e46abc883278583b178cf87a5db