### PR TITLE
Add details for <jumper /> docs

### DIFF
--- a/docs/elements/jumper.mdx
+++ b/docs/elements/jumper.mdx
@@ -38,9 +38,46 @@ export interface JumperProps extends CommonComponentProps {
   schPortArrangement?: SchematicPortArrangement
   /** Number of pins on the jumper (2 or 3) */
   pinCount?: 2 | 3
-  /** Groups of pins that are internally connected */
+  /**
+   * Groups of pins that are internally connected
+   * e.g., [["1","2"], ["2","3"]]
+   */
   internallyConnectedPins?: string[][]
 }
 ```
 
 Jumpers are often placed using footprints such as `pinrow8` or `pinrow6_female_rows2`, but you can also provide a custom `<footprint />` just like with `<chip />`.
+
+### Internally Connected Pins
+
+Use the `internallyConnectedPins` prop when the jumper has pins that should be shorted (bridged) together by default. Pins can be referenced by their labels.
+
+<CircuitPreview
+  defaultView="schematic"
+  code={`
+  export default () => (
+    <board width="10mm" height="10mm">
+      <jumper
+        name="J2"
+        footprint="pinrow3"
+        pinCount={3}
+        pinLabels={{ 1: "A", 2: "B", 3: "C" }}
+        internallyConnectedPins={[["A", "B"], ["B", "C"]]}
+      />
+    </board>
+  )
+  `}
+/>
+
+| Property | Type | Description |
+| -------- | ---- | ----------- |
+| `pinCount` | `2` \| `3` | Number of pins on the jumper |
+| `internallyConnectedPins` | `string[][]` | Groups of pins that are internally connected |
+| `manufacturerPartNumber` | `string` | Manufacturer part number |
+| `pinLabels` | `Record<number \| string, string \| string[]>` | Labels for pins or sets of pins |
+| `schPinStyle` | `SchematicPinStyle` | Style used for pins in the schematic |
+| `schPinSpacing` | `number` \| `string` | Spacing between schematic pins |
+| `schWidth` | `number` \| `string` | Width of the schematic symbol |
+| `schHeight` | `number` \| `string` | Height of the schematic symbol |
+| `schDirection` | `"left"` \| `"right"` | Direction the jumper faces in the schematic |
+| `schPortArrangement` | `SchematicPortArrangement` | Arrangement of ports in the schematic |


### PR DESCRIPTION
## Summary
- expand `<jumper />` docs with bridge pin example
- document jumper properties
- refine bridging description and use pin labels in example

## Testing
- `bun run format`


------
https://chatgpt.com/codex/tasks/task_b_68543cfdaec0832ebd2701a111cfd085