### PR TITLE
Add left/right view props to CircuitPreview

### DIFF
--- a/docs/elements/netlabel.mdx
+++ b/docs/elements/netlabel.mdx
@@ -14,10 +14,12 @@ show where a net connects.
 
 import CircuitPreview from "@site/src/components/CircuitPreview"
 
-The preview below uses the `schematicOnly` prop so that only the schematic is shown.
+The preview below uses `leftView="code"` and `rightView="schematic"` to show the
+schematic alongside the example code.
 
 <CircuitPreview
-  schematicOnly
+  leftView="code"
+  rightView="schematic"
   code={`
     import { sel } from "tscircuit"
     export default () => (


### PR DESCRIPTION
## Summary
- extend `CircuitPreview` with `leftView` and `rightView` props
- hide tabs and disable extra previews when `leftView`/`rightView` are used
- update netlabel documentation to use these props
- keep dependencies current

## Testing
- `bun update --latest @tscircuit/create-snippet-url`
- `bun run format`


------
https://chatgpt.com/codex/tasks/task_b_68545dc8ec0c832e875809ecb82a4e61