### PR TITLE
Document dynamic sel selectors

### DIFF
--- a/docs/guides/using-sel-references.mdx
+++ b/docs/guides/using-sel-references.mdx
@@ -221,7 +221,7 @@ import { RP2040 } from "./rp2040"
 
 const selU1 = sel.U1(RP2040)
 
-// Not recommended, but works
+// More explicit version for custom scenarios 
 const selSJ1 = sel<"A" | "B" | "C">("SJ1")
 
 selSJ1.A // Returns ".SJ1 > .A"

--- a/docs/guides/using-sel-references.mdx
+++ b/docs/guides/using-sel-references.mdx
@@ -209,6 +209,24 @@ selU2.custompin2 // Returns ".U2 > .custompin2"
 // selU2.doesnotexist // TypeScript error!
 ```
 
+### Dynamic Reference Designators
+
+You can now call `sel` itself to create selectors for any reference designator.
+It's best to assign the resulting selector set to a variable so that you keep
+type safety throughout your code:
+
+```tsx
+import { sel } from "tscircuit"
+import { RP2040 } from "./rp2040"
+
+const selU1 = sel.U1(RP2040)
+
+// Not recommended, but works
+const selSJ1 = sel<"A" | "B" | "C">("SJ1")
+
+selSJ1.A // Returns ".SJ1 > .A"
+```
+
 
 So `sel` is a more type-safe, conventional way of writing
 [port selectors](./port-and-net-selectors.md).

--- a/docs/guides/using-sel-references.mdx
+++ b/docs/guides/using-sel-references.mdx
@@ -211,7 +211,7 @@ selU2.custompin2 // Returns ".U2 > .custompin2"
 
 ### Dynamic Reference Designators
 
-You can now call `sel` itself to create selectors for any reference designator.
+You can call `sel` as a function to create selectors for any reference designator.
 It's best to assign the resulting selector set to a variable so that you keep
 type safety throughout your code:
 


### PR DESCRIPTION
## Summary
- document the new feature for calling `sel()` with a reference designator
- recommend saving the selector set to a variable

## Testing
- `bun run format`

------
https://chatgpt.com/codex/tasks/task_b_68557a9ef4bc832e80eb8cd1d7a4deb9