### PR TITLE
Add datasheet API docs

### DIFF
--- a/docs/command-line/tsci-auth-print-token.md
+++ b/docs/command-line/tsci-auth-print-token.md
@@ -1,0 +1,13 @@
+---
+title: tsci auth print-token
+---
+
+`tsci auth print-token` prints your current tscircuit API token. This token can be used with the advanced web APIs such as the [Datasheet API](../web-apis/datasheet-api.md).
+
+## Usage
+
+```bash
+tsci auth print-token
+```
+
+Make sure you have previously logged in with [`tsci login`](./tsci-login.md). The command will output a token string that you can pass in the `Authorization: Bearer <token>` header of API requests.

--- a/docs/web-apis/datasheet-api.md
+++ b/docs/web-apis/datasheet-api.md
@@ -41,7 +41,6 @@ This endpoint requires an API token. You can print your token with the [`tsci au
 POST /datasheets/create
 {
   "chip_name": "<name>",
-  "datasheet_pdf_urls": ["https://..."]
 }
 ```
 
@@ -50,9 +49,9 @@ POST /datasheets/create
 {
   "datasheet_id": "<uuid>",
   "chip_name": "<name>",
-  "datasheet_pdf_urls": ["https://..."],
+  "datasheet_pdf_urls": null,
   "pin_information": null
 }
 ```
 
-After creation the datasheet will be processed asynchronously to extract pin information.
+After creation the datasheet will be processed asynchronously to find pdf urls and extract pin information.

--- a/docs/web-apis/datasheet-api.md
+++ b/docs/web-apis/datasheet-api.md
@@ -1,0 +1,58 @@
+---
+title: Datasheet API
+sidebar_position: 4
+---
+
+The tscircuit Datasheet API allows you to store and retrieve parsed datasheet information for electronic components.
+
+Use `https://api.tscircuit.com` as the base URL for these endpoints.
+
+## `/datasheets/get`
+
+Retrieves stored datasheet information. You can look up a datasheet either by its UUID or by the chip name.
+
+```http
+GET /datasheets/get?chip_name=<name>
+POST /datasheets/get { "datasheet_id": "<uuid>" }
+```
+
+**Parameters**
+- `datasheet_id` – Optional UUID of the datasheet.
+- `chip_name` – Optional string chip identifier.
+
+**Response**
+```json
+{
+  "datasheet": {
+    "datasheet_id": "<uuid>",
+    "chip_name": "<name>",
+    "datasheet_pdf_urls": ["https://..."],
+    "pin_information": { /* ... */ }
+  }
+}
+```
+
+## `/datasheets/create`
+
+Creates a new datasheet entry so it can later be parsed and fetched.
+This endpoint requires an API token. You can print your token with the [`tsci auth print-token`](../command-line/tsci-auth-print-token.md) command.
+
+```http
+POST /datasheets/create
+{
+  "chip_name": "<name>",
+  "datasheet_pdf_urls": ["https://..."]
+}
+```
+
+**Response**
+```json
+{
+  "datasheet_id": "<uuid>",
+  "chip_name": "<name>",
+  "datasheet_pdf_urls": ["https://..."],
+  "pin_information": null
+}
+```
+
+After creation the datasheet will be processed asynchronously to extract pin information.


### PR DESCRIPTION
## Summary
- document `/datasheets/get` and `/datasheets/create` endpoints
- add CLI reference for `tsci auth print-token`

## Testing
- `bun run format`

------
https://chatgpt.com/codex/tasks/task_b_6858b0ede328832eb97c0a9a0df5b38f