### PR TITLE
Document schOrientation feature

### DIFF
--- a/docs/elements/capacitor.mdx
+++ b/docs/elements/capacitor.mdx
@@ -61,3 +61,31 @@ Capacitors can be configured with these key properties:
 
 Like resistors, tscircuit will automatically select suitable capacitor parts based on your specifications through the [platform parts engine](../guides/platform-configuration.md). For specialized capacitors (e.g., low ESR, high voltage), you may want to specify `supplierPartNumbers` explicitly.
 
+## Schematic Orientation
+
+Polarized capacitors can display their positive and negative pins in different orientations. Use the `schOrientation` property to control the symbol orientation instead of manually setting `schRotation`.
+
+Valid orientation values are:
+
+- `horizontal`
+- `vertical`
+- `pos_left`
+- `pos_right`
+- `pos_top`
+- `pos_bottom`
+- `neg_left`
+- `neg_right`
+- `neg_top`
+- `neg_bottom`
+
+```tsx
+<capacitor
+  name="C1"
+  capacitance="1uF"
+  polarized
+  schOrientation="pos_left"
+  schX={0}
+  schY={0}
+  connections={{ pos: "net.POS", neg: "net.NEG" }}
+/>```
+

--- a/docs/guides/layout-properties.mdx
+++ b/docs/guides/layout-properties.mdx
@@ -83,6 +83,7 @@ The following properties can be placed on a schematic element to control its pos
 | `schX`   | Set the center X position of the element | `0` |
 | `schY`   | Set the center Y position of the element | `0` |
 | `schRotation` | Set the rotation of the element | `"90deg"` |
+| `schOrientation` | Orient the symbol based on positive/negative pin direction. Accepts `"horizontal"`, `"vertical"`, `"pos_left"`, `"pos_right"`, `"pos_top"`, `"pos_bottom"`, `"neg_left"`, `"neg_right"`, `"neg_top"`, or `"neg_bottom"`. | `"pos_left"` |
 
 Here's an example of moving a resistor with default properties versus custom
 schematic layout properties:


### PR DESCRIPTION
## Summary
- document `schOrientation` in layout property guide
- explain how to orient polarized capacitors using `schOrientation`

## Testing
- `bun run format`

------
https://chatgpt.com/codex/tasks/task_b_6860d0741c38832eb34449f1714f31cd