### PR TITLE
Remove ChatGPT link

### DIFF
--- a/docs/advanced/ai-context.mdx
+++ b/docs/advanced/ai-context.mdx
@@ -15,6 +15,5 @@ the [`ai.txt`](https://docs.tscircuit.com/ai.txt) file and dropping it into your
 This will teach Claude and OpenAI about tscircuit so it can help you design
 boards or access tricky or hidden pieces of the documentation!
 
-You can also use our [Official GPT on ChatGPT](https://chatgpt.com/g/g-67b2911b5af08191bdde2d4a0c8c1076-tscircuit-helper) or [chat.tscircuit.com](https://chat.tscircuit.com)
-for prebuilt versions of the AI. Note: [chat.tscircuit.com](https://chat.tscircuit.com)
-contains live preview for a great development experience.
+You can also use [chat.tscircuit.com](https://chat.tscircuit.com) for a prebuilt version of the AI.
+It contains live preview for a great development experience.


### PR DESCRIPTION
## Summary
- remove ChatGPT GPT link from `ai-context` docs

## Testing
- `bun test`
- `bun run format`

------
https://chatgpt.com/codex/tasks/task_b_686ad24ec518832eb88ce957d0e6f8b3