### PR TITLE
docs: remove matchAdapt references

### DIFF
--- a/docs/guides/automatic-schematic-layout.mdx
+++ b/docs/guides/automatic-schematic-layout.mdx
@@ -16,9 +16,8 @@ import CircuitPreview from "@site/src/components/CircuitPreview"
 
 ## Automatic Schematic Layout
 
-Automatic schematic layout is turned on by default with the `matchAdapt` algorithm,
-this algorithm looks inside a corpus of schematic templates and matches the current
-schematic to the best matching template, then lays out the remaining components.
+Automatic schematic layout is turned on by default, using a pattern matching and
+packing algorithm to arrange components in the current schematic.
 
 <CircuitPreview
   defaultView="schematic"


### PR DESCRIPTION
## Summary
- remove matchAdapt algorithm reference from automatic schematic layout guide
- describe layout using a pattern matching and packing algorithm

## Testing
- `bun test`
- `bun run format`


------
https://chatgpt.com/codex/tasks/task_b_68b126932944832eae79f8f7f340e4f3