### PR TITLE
docs: add expressions guide

### DIFF
--- a/docs/guides/using-expressions.mdx
+++ b/docs/guides/using-expressions.mdx
@@ -11,7 +11,8 @@ Tscircuit lets you use normal JavaScript expressions to calculate component valu
 Here we pick `R2` so that a divider powered from `vin` produces `vout`. Changing any of the parameters automatically recomputes `R2`.
 
 <CircuitPreview
-  schematicOnly
+  leftView="code"
+  rightView="schematic"
   code={`
 export default () => {
   const vin = 5
@@ -45,7 +46,8 @@ export default () => {
 The resonant frequency of an LC tank is `f = 1/(2π√(LC))`. Knowing the desired frequency and an inductance, we can compute the required capacitance.
 
 <CircuitPreview
-  schematicOnly
+  leftView="code"
+  rightView="schematic"
   code={`
 export default () => {
   const f = 1e6 // 1 MHz

--- a/docs/guides/using-expressions.mdx
+++ b/docs/guides/using-expressions.mdx
@@ -1,0 +1,72 @@
+---
+title: Using Expressions for Component Values
+---
+
+import CircuitPreview from "@site/src/components/CircuitPreview"
+
+Tscircuit lets you use normal JavaScript expressions to calculate component values. This is useful when a part's value depends on other parameters, like setting a voltage divider's output or picking the capacitor for an LC resonant circuit.
+
+## Voltage divider
+
+Here we pick `R2` so that a divider powered from `vin` produces `vout`. Changing any of the parameters automatically recomputes `R2`.
+
+<CircuitPreview
+  schematicOnly
+  code={`
+export default () => {
+  const vin = 5
+  const vout = 3.3
+  const r1 = 1e3
+  const r2 = r1 * (vout / (vin - vout))
+  return (
+    <board>
+      <voltagesource
+        name="V1"
+        voltage={vin}
+        connections={{ pin1: "net.VCC", pin2: "net.GND" }}
+      />
+      <resistor
+        name="R1"
+        resistance={r1}
+        connections={{ pin1: "net.VCC", pin2: "net.OUT" }}
+      />
+      <resistor
+        name="R2"
+        resistance={r2}
+        connections={{ pin1: "net.OUT", pin2: "net.GND" }}
+      />
+    </board>
+  )
+}
+`} />
+
+## LC resonant circuit
+
+The resonant frequency of an LC tank is `f = 1/(2π√(LC))`. Knowing the desired frequency and an inductance, we can compute the required capacitance.
+
+<CircuitPreview
+  schematicOnly
+  code={`
+export default () => {
+  const f = 1e6 // 1 MHz
+  const L = 10e-6 // 10 µH
+  const C = 1 / ((2 * Math.PI * f) ** 2 * L)
+  return (
+    <board>
+      <inductor
+        name="L1"
+        inductance={L}
+        connections={{ pin1: "net.IN", pin2: "net.OUT" }}
+      />
+      <capacitor
+        name="C1"
+        capacitance={C}
+        connections={{ pin1: "net.OUT", pin2: "net.GND" }}
+      />
+    </board>
+  )
+}
+`} />
+
+These examples show how expressions make it easy to drive component values from formulas so designs can adapt when requirements change.
+


### PR DESCRIPTION
## Summary
- add guide on using JavaScript expressions to derive component values
- demonstrate calculating resistor for voltage divider and capacitor for LC resonant circuit
- fix examples to use `<board>` rather than `<circuit>`
- escape template placeholders in snippets so site builds successfully
- supply component values as numbers instead of strings in examples
- use `<voltagesource>` and schematic-only previews in expressions guide

## Testing
- `bun test`
- `bun run build`
- `bun run format`


------
https://chatgpt.com/codex/tasks/task_b_68ba43bdb1c4832ea6d0d51027d83fb7