### PR TITLE
fix: eliminate whitespace in circuit preview containers

### DIFF
--- a/src/components/CircuitPreview.tsx
+++ b/src/components/CircuitPreview.tsx
@@ -239,7 +239,7 @@ export default function CircuitPreview({
       return (
         <div
           className={tw(
-            `flex-1 basis-1/2 min-w-0 min-h-[300px] overflow-hidden m-0 p-0 ${
+            `flex-1 basis-1/2 min-w-0 min-h-[300px] overflow-hidden m-0 p-0 flex items-center justify-center ${
               v === "pcb"
                 ? "bg-black"
                 : v === "schematic"
@@ -314,7 +314,7 @@ export default function CircuitPreview({
           view === "runframe") && (
           <div
             className={tw(
-              `flex-1 basis-1/2 min-w-0 min-h-[300px] overflow-hidden m-0 p-0 ${
+              `flex-1 basis-1/2 min-w-0 min-h-[300px] overflow-hidden m-0 p-0 flex items-center justify-center ${
                 view === "pcb"
                   ? "bg-black"
                   : view === "schematic"

--- a/src/components/CircuitPreview.tsx
+++ b/src/components/CircuitPreview.tsx
@@ -239,19 +239,21 @@ export default function CircuitPreview({
       return (
         <div
           className={tw(
-            `flex-1 basis-1/2 min-w-0 min-h-[300px] overflow-hidden m-0 p-0`,
+            `flex-1 basis-1/2 min-w-0 min-h-[300px] overflow-hidden m-0 p-0 ${
+              v === "pcb"
+                ? "bg-black"
+                : v === "schematic"
+                  ? "bg-[#F5F1ED]"
+                  : "bg-white"
+            }`,
           )}
         >
           <img
             src={v === "pcb" ? pcbUrl : v === "schematic" ? schUrl : threeDUrl}
             alt={`${v.toUpperCase()} Circuit Preview`}
             className={tw(
-              `w-full ${tabContentHeightCss} m-0 object-contain ${
-                v === "pcb"
-                  ? "bg-black flex items-center justify-center"
-                  : v === "schematic"
-                    ? "bg-[#F5F1ED]"
-                    : "bg-white object-cover"
+              `w-full ${tabContentHeightCss} m-0 block ${
+                v === "3d" ? "object-cover" : "object-contain"
               }`,
             )}
           />
@@ -312,7 +314,15 @@ export default function CircuitPreview({
           view === "runframe") && (
           <div
             className={tw(
-              "flex-1 basis-1/2 min-w-0 min-h-[300px] overflow-hidden m-0 p-0",
+              `flex-1 basis-1/2 min-w-0 min-h-[300px] overflow-hidden m-0 p-0 ${
+                view === "pcb"
+                  ? "bg-black"
+                  : view === "schematic"
+                    ? "bg-[#F5F1ED]"
+                    : view === "3d"
+                      ? "bg-white"
+                      : ""
+              }`,
             )}
           >
             {_showTabs && shouldSplitCode && tabsElm}
@@ -320,21 +330,21 @@ export default function CircuitPreview({
               src={pcbUrl}
               alt="PCB Circuit Preview"
               className={tw(
-                `w-full ${tabContentHeightCss} m-0 object-contain bg-black flex items-center justify-center ${view !== "pcb" ? "hidden" : ""}`,
+                `w-full ${tabContentHeightCss} m-0 block object-contain ${view !== "pcb" ? "hidden" : ""}`,
               )}
             />
             <img
               src={schUrl}
               alt="Schematic Circuit Preview"
               className={tw(
-                `w-full ${tabContentHeightCss} m-0 object-contain bg-[#F5F1ED] ${view !== "schematic" ? "hidden" : ""}`,
+                `w-full ${tabContentHeightCss} m-0 block object-contain ${view !== "schematic" ? "hidden" : ""}`,
               )}
             />
             <img
               src={threeDUrl}
               alt="3D Circuit Preview"
               className={tw(
-                `w-full ${tabContentHeightCss} m-0 object-cover bg-white ${view !== "3d" ? "hidden" : ""}`,
+                `w-full ${tabContentHeightCss} m-0 block object-cover ${view !== "3d" ? "hidden" : ""}`,
               )}
             />
             {showRunFrame && view === "runframe" && (


### PR DESCRIPTION
- Move background colors from img tags to parent containers
- Use object-contain for PCB/schematic to prevent cropping
- Keep object-cover for 3D previews for better visual appearance
- Apply fixes to both split-view and single-view layouts
#### fix #128

PIC: 
<img width="641" height="589" alt="image" src="https://github.com/user-attachments/assets/2121c953-f069-4dd1-a506-94a5ca9c5bea" />
<img width="509" height="570" alt="image" src="https://github.com/user-attachments/assets/57324263-d75d-407c-870d-7db98cdf86f9" />

