### PR TITLE
fix: properly fix the empty white space

### DIFF
--- a/src/components/CircuitPreview.tsx
+++ b/src/components/CircuitPreview.tsx
@@ -239,7 +239,13 @@ export default function CircuitPreview({
       return (
         <div
           className={tw(
-            `flex-1 basis-1/2 min-w-0 min-h-[300px] overflow-hidden m-0 p-0`,
+            `flex-1 basis-1/2 min-w-0 min-h-[300px] overflow-hidden m-0 p-0 flex items-center justify-center ${
+              v === "pcb"
+                ? "bg-black"
+                : v === "schematic"
+                  ? "bg-[#F5F1ED]"
+                  : "bg-white"
+            }`,
           )}
         >
           <img


### PR DESCRIPTION
# Fix: circuit preview layout

- Cleaned up the container so previews (pcb, schematic, 3d) render consistently

- Moved background color logic to the parent `<div>` to avoid breaking docs

- Double-checked that all previews display correctly and the docs look fine again

<img width="582" height="559" alt="image" src="https://github.com/user-attachments/assets/30f84116-8892-49e9-88f7-569bef1efc78" />
<img width="550" height="500" alt="image" src="https://github.com/user-attachments/assets/e90304ee-53f6-4be1-8ffb-ac4a068fbd26" />
