### PR TITLE
docs: move component property guidance

### DIFF
--- a/docs/building-electronics/ordering-prototypes.mdx
+++ b/docs/building-electronics/ordering-prototypes.mdx
@@ -15,30 +15,7 @@ ordering prototypes are [JLCPCB](https://jlcpcb.com) and [PCBWay](https://pcbway
 
 ## Ordering Through tscircuit Platform
 
-The easiest way to order your prototypes is through the tscircuit platform, which handles the entire ordering process for you. Before placing your order, there are two important component properties that affect the ordering process:
-
-### Using `doNotPlace` Prop
-
-Components with the `doNotPlace` prop set to `true` will not be included in the parts selection for ordering. This is useful for components that you plan to solder manually or that are not available through the supplier.
-
-```tsx
-<resistor resistance="10k" name="R1" footprint="0402" doNotPlace />
-```
-
-### Using `supplierPartNumbers` Prop
-
-The `supplierPartNumbers` prop allows you to specify exact part numbers from suppliers, helping to ensure the correct components are selected during ordering. This is particularly useful for specific or critical components.
-
-```tsx
-<capacitor 
-  capacitance="100nF" 
-  supplierPartNumbers={{
-    jlcpcb: "C14663"
-  }}
-  name="C1"
-  footprint="0402"
-/>
-```
+The easiest way to order your prototypes is through the tscircuit platform, which handles the entire ordering process for you.
 
 ### Ordering Steps
 
@@ -105,3 +82,26 @@ the orientation of each component as you place it.
 <figure>
 <img src="/img/assembly-view-in-editor.png" />
 </figure>
+
+## Controlling Part Selection
+
+Before placing your order, there are two important component properties that affect the ordering process. The `supplierPartNumbers` prop allows you to specify exact part numbers from suppliers, helping to ensure the correct components are selected during ordering. This is particularly useful for specific or critical components.
+
+```tsx
+<capacitor
+  capacitance="100nF"
+  supplierPartNumbers={{
+    jlcpcb: "C14663",
+  }}
+  name="C1"
+  footprint="0402"
+/>
+```
+
+## Do Not Place Components
+
+Components with the `doNotPlace` prop set to `true` will not be included in the parts selection for ordering. This is useful for components that you plan to solder manually or that are not available through the supplier.
+
+```tsx
+<resistor resistance="10k" name="R1" footprint="0402" doNotPlace />
+```


### PR DESCRIPTION
## Summary
- clarify ordering prototypes flow
- move part selection and do-not-place guidance to dedicated sections

## Testing
- `bunx tsc --noEmit`
- `bun test`
- `bun run format`


------
https://chatgpt.com/codex/tasks/task_b_68c3376c9a0c832eaaa03121e3384c87