### PR TITLE
fix: remove stray trim from ChatGPT quickstart

### DIFF
--- a/docs/intro/quickstart-ChatGPT.mdx
+++ b/docs/intro/quickstart-ChatGPT.mdx
@@ -226,7 +226,6 @@ Selectors are used in the `connections` prop and the `from` and `to` props of th
   with a <trace /> or a connections={{ pin1: ..., pin2: ... }} prop
 - Every normal element has a footprint prop
 
-`.trim()
 ```
 
 ## Example Prompt:

--- a/scripts/update-prompt-in-chatgpt-guide.js
+++ b/scripts/update-prompt-in-chatgpt-guide.js
@@ -44,8 +44,16 @@ async function updateMdxFile() {
       throw new Error("Could not find markdown code block in MDX file")
     }
 
-    // Extract the TypeScript content (remove export statement if present)
-    const cleanTsContent = tsContent.replace(/^export\s+.*$/gm, "").trim()
+    // Extract the TypeScript content inside the template literal
+    const tsMatch = tsContent.match(
+      /export const [^=]*=`([\s\S]*?)`\s*\.trim\(\)\s*$/,
+    )
+    if (!tsMatch) {
+      throw new Error(
+        "Could not extract template literal from fetched tscircuit syntax file",
+      )
+    }
+    const cleanTsContent = tsMatch[1].trim()
 
     // Identify the primer region in both the fetched content and the existing MDX code fence
     const primerMarker = "Here's a quick primer on how to use tscircuit:"


### PR DESCRIPTION
## Summary
- strip trailing `.trim()` when pulling tscircuit syntax primer so generated docs stay clean
- remove accidental `.trim()` left in quickstart guide

## Testing
- `bunx tsc --noEmit`
- `bun run format`
- `node scripts/update-prompt-in-chatgpt-guide.js` *(fails: ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_b_68c395f3392c832e8f5d9d7408c4b0a2