### PR TITLE
docs: update math utils grid example

### DIFF
--- a/docs/advanced/math-utils.mdx
+++ b/docs/advanced/math-utils.mdx
@@ -45,7 +45,7 @@ export default () => (
   <board width="10mm" height="10mm" pcbRelative>
     {gridCells.map((cell) => (
       <led
-        name={`LED${cell.index}`}
+        name={'LED' + cell.index}
         footprint="0402"
         schX={cell.center.x}
         schY={cell.center.y}
@@ -70,7 +70,7 @@ export default () => (
 | `ySpacing` | Vertical spacing between cells when `height` is not provided. | `1` |
 | `offsetX` | Horizontal offset applied to every cell. | `0` |
 | `offsetY` | Vertical offset applied to every cell. | `0` |
-| `yDirection` | Orientation of the Y axis (`"cartesian"` for positive-up or `"up-is-negative"` for positive-down). | `"cartesian"` |
+| `yDirection` | Sets positive Y direction: `"cartesian"` keeps positive-up, `"up-is-negative"` flips it. | `"cartesian"` |
 | `centered` | Centers the grid around the origin when `true`. | `true` |
 
 ## Grid Cell Data

--- a/docs/advanced/math-utils.mdx
+++ b/docs/advanced/math-utils.mdx
@@ -6,6 +6,8 @@ description: >-
   generally available in any platform that uses `tscircuit`.
 ---
 
+import CircuitPreview from "@site/src/components/CircuitPreview"
+
 ## Overview
 
 The `@tscircuit/math-utils` package provides a set of utilities that are
@@ -19,28 +21,32 @@ The source code for the `@tscircuit/math-utils` package [is available here](http
 
 A utility function that generates a grid of cells with configurable dimensions, spacing, and positioning. Each cell contains its index, position (row/column), and coordinate points (center, top-left, bottom-right).
 
-```tsx
+<CircuitPreview
+  splitView
+  leftView="code"
+  rightView="pcb"
+  code={`
 import { grid } from "@tscircuit/math-utils"
 
 const gridCells = grid({
-  rows: 3,
-  cols: 3,
-  width: 300,   // optional
-  height: 300,  // optional
-  xSpacing: 100,  // optional, default: 1
-  ySpacing: 100,  // optional, default: 1
-  offsetX: 0,     // optional, default: 0
-  offsetY: 0,     // optional, default: 0
+  rows: 4,
+  cols: 4,
+  width: 10,
+  height: 10,
+  // xSpacing: 6, // if you want to provide the spacing instead of width
+  // ySpacing: 6, // if you want to provide the spacing instead of height
+  offsetX: 0, // optional
+  offsetY: 0, // optional
   yDirection: "cartesian", // optional, default: "cartesian"
   centered: true  // optional, default: true
 })
 
 export default () => (
-  <board width="30mm" height="30mm">
+  <board width="10mm" height="10mm" pcbRelative>
     {gridCells.map((cell) => (
       <led
         name={`LED${cell.index}`}
-        footprint="led_0402"
+        footprint="0402"
         schX={cell.center.x}
         schY={cell.center.y}
         pcbX={cell.center.x}
@@ -49,9 +55,32 @@ export default () => (
     ))}
   </board>
 )
-```
+`}
+/>
 
-The array of `GridCellPositions` contains:
-- `index`: Sequential cell number
-- `row`, `col`: Grid position
-- `center`, `topLeft`, `bottomRight`: Coordinate points
+## Grid Options
+
+| Option | Description | Default |
+| ------ | ----------- | ------- |
+| `rows` | Number of rows in the generated grid. | Required |
+| `cols` | Number of columns in the generated grid. | Required |
+| `width` | Total width of the grid. When omitted, uses `cols * xSpacing`. | `cols * xSpacing` |
+| `height` | Total height of the grid. When omitted, uses `rows * ySpacing`. | `rows * ySpacing` |
+| `xSpacing` | Horizontal spacing between cells when `width` is not provided. | `1` |
+| `ySpacing` | Vertical spacing between cells when `height` is not provided. | `1` |
+| `offsetX` | Horizontal offset applied to every cell. | `0` |
+| `offsetY` | Vertical offset applied to every cell. | `0` |
+| `yDirection` | Orientation of the Y axis (`"cartesian"` for positive-up or `"up-is-negative"` for positive-down). | `"cartesian"` |
+| `centered` | Centers the grid around the origin when `true`. | `true` |
+
+## Grid Cell Data
+
+Each object returned by `grid` represents a cell with useful positional metadata:
+
+| Property | Description |
+| -------- | ----------- |
+| `index` | Sequential identifier for the cell. |
+| `row` / `col` | Grid coordinates of the cell starting from zero. |
+| `center` | `{ x, y }` coordinates of the cell center. |
+| `topLeft` | `{ x, y }` coordinates of the cell's top-left corner. |
+| `bottomRight` | `{ x, y }` coordinates of the cell's bottom-right corner. |


### PR DESCRIPTION

<img width="2188" height="1534" alt="image" src="https://github.com/user-attachments/assets/b8bef4e0-63af-481a-a90f-fb4e5cccbcbe" />


## Summary
- switch the math utils grid example to a live CircuitPreview using the latest code snippet
- document grid configuration options and grid cell metadata with tables for quick reference

## Testing
- bunx tsc --noEmit
- bun run format

------
https://chatgpt.com/codex/tasks/task_b_68c867bf6fb8832ea9ab43685f3b47e4