### PR TITLE
Fix code block scroll behavior and unify demo card background

### DIFF
--- a/src/components/CircuitPreview.tsx
+++ b/src/components/CircuitPreview.tsx
@@ -1,21 +1,21 @@
-import { createSvgUrl, createPngUrl } from "@tscircuit/create-snippet-url";
-import { tw } from "@site/src/tw";
-import { useMemo, useState } from "react";
-import { useColorMode } from "../hooks/use-color-mode";
-import CodeBlock from "@theme/CodeBlock";
-import { useWindowSize } from "@docusaurus/theme-common";
-import TscircuitIframe from "./TscircuitIframe";
+import { createSvgUrl, createPngUrl } from "@tscircuit/create-snippet-url"
+import { tw } from "@site/src/tw"
+import { useMemo, useState } from "react"
+import { useColorMode } from "../hooks/use-color-mode"
+import CodeBlock from "@theme/CodeBlock"
+import { useWindowSize } from "@docusaurus/theme-common"
+import TscircuitIframe from "./TscircuitIframe"
 
 const Tab = ({
   label,
   active,
   onClick,
 }: {
-  label: string;
-  active: boolean;
-  onClick: () => void;
+  label: string
+  active: boolean
+  onClick: () => void
 }) => {
-  const { isDarkTheme } = useColorMode();
+  const { isDarkTheme } = useColorMode()
 
   return (
     <button
@@ -27,27 +27,27 @@ const Tab = ({
               ? "bg-white text-slate-950 shadow-sm"
               : "bg-none text-slate-500"
             : active
-            ? "bg-slate-700"
-            : "bg-slate-800"
-        }`
+              ? "bg-slate-700"
+              : "bg-slate-800"
+        }`,
       )}
       onClick={onClick}
     >
       {label}
     </button>
-  );
-};
+  )
+}
 
 const FileTab = ({
   filename,
   active,
   onClick,
 }: {
-  filename: string;
-  active: boolean;
-  onClick: () => void;
+  filename: string
+  active: boolean
+  onClick: () => void
 }) => {
-  const { isDarkTheme } = useColorMode();
+  const { isDarkTheme } = useColorMode()
 
   return (
     <button
@@ -59,16 +59,16 @@ const FileTab = ({
               ? "bg-slate-100 text-slate-950"
               : "text-slate-500 hover:text-slate-700"
             : active
-            ? "text-white"
-            : "text-slate-400 hover:text-slate-200"
-        }`
+              ? "text-white"
+              : "text-slate-400 hover:text-slate-200"
+        }`,
       )}
       onClick={onClick}
     >
       {filename}
     </button>
-  );
-};
+  )
+}
 
 export default function CircuitPreview({
   code,
@@ -85,67 +85,67 @@ export default function CircuitPreview({
   leftView,
   rightView,
 }: {
-  code?: string;
-  showTabs?: boolean;
-  defaultView?: "code" | "pcb" | "schematic";
-  splitView?: boolean;
-  showRunFrame?: boolean;
-  hideSchematicTab?: boolean;
-  hidePCBTab?: boolean;
-  hide3DTab?: boolean;
-  fsMap?: Record<string, string>;
-  entrypoint?: string;
-  schematicOnly?: boolean;
-  leftView?: "code" | "pcb" | "schematic" | "3d" | "runframe";
-  rightView?: "code" | "pcb" | "schematic" | "3d" | "runframe";
+  code?: string
+  showTabs?: boolean
+  defaultView?: "code" | "pcb" | "schematic"
+  splitView?: boolean
+  showRunFrame?: boolean
+  hideSchematicTab?: boolean
+  hidePCBTab?: boolean
+  hide3DTab?: boolean
+  fsMap?: Record<string, string>
+  entrypoint?: string
+  schematicOnly?: boolean
+  leftView?: "code" | "pcb" | "schematic" | "3d" | "runframe"
+  rightView?: "code" | "pcb" | "schematic" | "3d" | "runframe"
 }) {
-  const { isDarkTheme } = useColorMode();
-  const windowSize = useWindowSize();
-  const [currentFile, setCurrentFile] = useState<string>(entrypoint);
+  const { isDarkTheme } = useColorMode()
+  const windowSize = useWindowSize()
+  const [currentFile, setCurrentFile] = useState<string>(entrypoint)
 
-  let _showTabs = showTabs;
-  let _splitView = splitView;
-  let _defaultView = defaultView;
-  let _hidePCBTab = hidePCBTab;
-  let _hide3DTab = hide3DTab;
+  let _showTabs = showTabs
+  let _splitView = splitView
+  let _defaultView = defaultView
+  let _hidePCBTab = hidePCBTab
+  let _hide3DTab = hide3DTab
 
   if (schematicOnly) {
-    _showTabs = false;
-    _splitView = false;
-    _defaultView = "schematic";
-    _hidePCBTab = true;
-    _hide3DTab = true;
+    _showTabs = false
+    _splitView = false
+    _defaultView = "schematic"
+    _hidePCBTab = true
+    _hide3DTab = true
   }
 
   if (leftView || rightView) {
-    _showTabs = false;
-    _splitView = true;
-    _hidePCBTab = ![leftView, rightView].includes("pcb");
-    _hide3DTab = ![leftView, rightView].includes("3d");
+    _showTabs = false
+    _splitView = true
+    _hidePCBTab = ![leftView, rightView].includes("pcb")
+    _hide3DTab = ![leftView, rightView].includes("3d")
   }
 
   const [view, setView] = useState<
     "pcb" | "schematic" | "code" | "3d" | "runframe"
-  >(rightView ?? _defaultView);
-  const currentCode = code || fsMap[entrypoint] || "";
-  const pcbUrl = useMemo(() => createSvgUrl(currentCode, "pcb"), [currentCode]);
+  >(rightView ?? _defaultView)
+  const currentCode = code || fsMap[entrypoint] || ""
+  const pcbUrl = useMemo(() => createSvgUrl(currentCode, "pcb"), [currentCode])
   const schUrl = useMemo(
     () => createSvgUrl(currentCode, "schematic"),
-    [currentCode]
-  );
+    [currentCode],
+  )
   const threeDUrl = useMemo(
     () => createPngUrl(currentCode, "3d"),
-    [currentCode]
-  );
+    [currentCode],
+  )
 
-  const shouldSplitCode = _splitView && windowSize !== "mobile";
+  const shouldSplitCode = _splitView && windowSize !== "mobile"
 
   const tabContentHeightCss =
     _showTabs && windowSize !== "mobile"
       ? "h-[calc(100%-46px)]"
-      : "h-full max-h-[300px]";
+      : "h-full max-h-[300px]"
 
-  const hasMultipleFiles = Object.keys(fsMap).length > 1;
+  const hasMultipleFiles = Object.keys(fsMap).length > 1
 
   const tabsElm = (
     <div className={tw("flex justify-end px-2")}>
@@ -153,7 +153,7 @@ export default function CircuitPreview({
         className={tw(
           `flex-inline justify-end gap-2 mt-2 mb-2 rounded-lg ${
             !isDarkTheme ? "bg-slate-100" : "bg-slate-800"
-          } p-1 gap-2`
+          } p-1 gap-2`,
         )}
       >
         {!shouldSplitCode && (
@@ -193,7 +193,7 @@ export default function CircuitPreview({
         )}
       </div>
     </div>
-  );
+  )
 
   const fileTabsElm = (
     <div className={tw("flex justify-start px-2")}>
@@ -201,7 +201,7 @@ export default function CircuitPreview({
         className={tw(
           `flex-inline justify-start gap-2 mt-2 mb-2 rounded-lg ${
             !isDarkTheme ? "bg-white" : "bg-slate-800"
-          } p-1 gap-2`
+          } p-1 gap-2`,
         )}
       >
         {Object.keys(fsMap).map((filename) => (
@@ -214,19 +214,19 @@ export default function CircuitPreview({
         ))}
       </div>
     </div>
-  );
+  )
 
   if (leftView || rightView) {
     const renderView = (
       v: "code" | "pcb" | "schematic" | "3d" | "runframe",
-      side: "left" | "right"
+      side: "left" | "right",
     ) => {
-      const borderCss = side === "left" ? "border-r" : "border-l";
+      const borderCss = side === "left" ? "border-r" : "border-l"
       if (v === "code") {
         return (
           <div
             className={tw(
-              `flex flex-col flex-1 basis-1/2 min-w-0 overflow-x-auto overflow-y-auto`
+              `flex flex-col flex-1 basis-1/2 min-w-0 overflow-x-auto overflow-y-auto`,
             )}
           >
             {hasMultipleFiles && fileTabsElm}
@@ -234,12 +234,12 @@ export default function CircuitPreview({
               className={tw(
                 `flex flex-1 m-0 p-0 border-r ${
                   !isDarkTheme ? "border-gray-200" : "border-gray-700"
-                }`
+                }`,
               )}
             >
               <CodeBlock
                 className={tw(
-                  "w-full rounded-none shadow-none p-0 m-0 min-w-0"
+                  "w-full rounded-none shadow-none p-0 m-0 min-w-0",
                 )}
                 language="tsx"
               >
@@ -247,7 +247,7 @@ export default function CircuitPreview({
               </CodeBlock>
             </div>
           </div>
-        );
+        )
       }
 
       return (
@@ -257,9 +257,9 @@ export default function CircuitPreview({
               v === "pcb"
                 ? "bg-black"
                 : v === "schematic"
-                ? "bg-[#F5F1ED]"
-                : "bg-white"
-            }`
+                  ? "bg-[#F5F1ED]"
+                  : "bg-white"
+            }`,
           )}
         >
           <img
@@ -270,21 +270,21 @@ export default function CircuitPreview({
                 v === "pcb"
                   ? "bg-black flex items-center justify-center"
                   : v === "schematic"
-                  ? "bg-[#F5F1ED]"
-                  : "bg-white object-cover"
-              }`
+                    ? "bg-[#F5F1ED]"
+                    : "bg-white object-cover"
+              }`,
             )}
           />
         </div>
-      );
-    };
+      )
+    }
 
     return (
       <div
         className={tw(
           `shadow-lg pt-0 pb-0 pl-0 pr-0 border ${
             !isDarkTheme ? "border-gray-100" : "border-gray-800"
-          } rounded-lg mb-8 overflow-hidden`
+          } rounded-lg mb-8 overflow-hidden`,
         )}
       >
         <div className={tw(`h-full overflow-hidden flex m-0 p-0`)}>
@@ -292,7 +292,7 @@ export default function CircuitPreview({
           {renderView(rightView || "schematic", "right")}
         </div>
       </div>
-    );
+    )
   }
 
   return (
@@ -300,7 +300,7 @@ export default function CircuitPreview({
       className={tw(
         `shadow-lg pt-0 pb-0 pl-0 pr-0 border ${
           !isDarkTheme ? "border-gray-100" : "border-gray-800"
-        } rounded-lg mb-8 overflow-hidden`
+        } rounded-lg mb-8 overflow-hidden`,
       )}
     >
       {_showTabs && !shouldSplitCode && tabsElm}
@@ -308,7 +308,7 @@ export default function CircuitPreview({
         className={tw(
           `h-full overflow-hidden flex m-0 p-0 ${
             !_showTabs && windowSize === "mobile" ? "flex-col" : ""
-          }`
+          }`,
         )}
       >
         {(view === "code" ||
@@ -320,12 +320,12 @@ export default function CircuitPreview({
               className={tw(
                 `flex flex-1 overflow-x-auto overflow-y-auto m-0 p-0 border-r ${
                   !isDarkTheme ? "border-gray-200" : "border-gray-700"
-                }`
+                }`,
               )}
             >
               <CodeBlock
                 className={tw(
-                  "w-full rounded-none shadow-none p-0 m-0 min-w-0"
+                  "w-full rounded-none shadow-none p-0 m-0 min-w-0",
                 )}
                 language="tsx"
               >
@@ -340,7 +340,7 @@ export default function CircuitPreview({
           view === "runframe") && (
           <div
             className={tw(
-              "flex-1 basis-1/2 min-w-0 min-h-[300px] overflow-hidden m-0 p-0"
+              "flex-1 basis-1/2 min-w-0 min-h-[300px] overflow-hidden m-0 p-0",
             )}
           >
             {_showTabs && shouldSplitCode && tabsElm}
@@ -350,7 +350,7 @@ export default function CircuitPreview({
               className={tw(
                 `w-full ${tabContentHeightCss} m-0 object-contain bg-black flex items-center justify-center ${
                   view !== "pcb" ? "hidden" : ""
-                }`
+                }`,
               )}
             />
             <img
@@ -359,7 +359,7 @@ export default function CircuitPreview({
               className={tw(
                 `w-full ${tabContentHeightCss} m-0 object-contain bg-[#F5F1ED] ${
                   view !== "schematic" ? "hidden" : ""
-                }`
+                }`,
               )}
             />
             <img
@@ -368,7 +368,7 @@ export default function CircuitPreview({
               className={tw(
                 `w-full ${tabContentHeightCss} m-0 object-cover bg-white ${
                   view !== "3d" ? "hidden" : ""
-                }`
+                }`,
               )}
             />
             {showRunFrame && view === "runframe" && (
@@ -378,5 +378,5 @@ export default function CircuitPreview({
         )}
       </div>
     </div>
-  );
+  )
 }

--- a/src/components/CircuitPreview.tsx
+++ b/src/components/CircuitPreview.tsx
@@ -1,17 +1,21 @@
-import { createSvgUrl, createPngUrl } from "@tscircuit/create-snippet-url"
-import { tw } from "@site/src/tw"
-import { useMemo, useState } from "react"
-import { useColorMode } from "../hooks/use-color-mode"
-import CodeBlock from "@theme/CodeBlock"
-import { useWindowSize } from "@docusaurus/theme-common"
-import TscircuitIframe from "./TscircuitIframe"
+import { createSvgUrl, createPngUrl } from "@tscircuit/create-snippet-url";
+import { tw } from "@site/src/tw";
+import { useMemo, useState } from "react";
+import { useColorMode } from "../hooks/use-color-mode";
+import CodeBlock from "@theme/CodeBlock";
+import { useWindowSize } from "@docusaurus/theme-common";
+import TscircuitIframe from "./TscircuitIframe";
 
 const Tab = ({
   label,
   active,
   onClick,
-}: { label: string; active: boolean; onClick: () => void }) => {
-  const { isDarkTheme } = useColorMode()
+}: {
+  label: string;
+  active: boolean;
+  onClick: () => void;
+}) => {
+  const { isDarkTheme } = useColorMode();
 
   return (
     <button
@@ -23,27 +27,27 @@ const Tab = ({
               ? "bg-white text-slate-950 shadow-sm"
               : "bg-none text-slate-500"
             : active
-              ? "bg-slate-700"
-              : "bg-slate-800"
-        }`,
+            ? "bg-slate-700"
+            : "bg-slate-800"
+        }`
       )}
       onClick={onClick}
     >
       {label}
     </button>
-  )
-}
+  );
+};
 
 const FileTab = ({
   filename,
   active,
   onClick,
 }: {
-  filename: string
-  active: boolean
-  onClick: () => void
+  filename: string;
+  active: boolean;
+  onClick: () => void;
 }) => {
-  const { isDarkTheme } = useColorMode()
+  const { isDarkTheme } = useColorMode();
 
   return (
     <button
@@ -55,16 +59,16 @@ const FileTab = ({
               ? "bg-slate-100 text-slate-950"
               : "text-slate-500 hover:text-slate-700"
             : active
-              ? "text-white"
-              : "text-slate-400 hover:text-slate-200"
-        }`,
+            ? "text-white"
+            : "text-slate-400 hover:text-slate-200"
+        }`
       )}
       onClick={onClick}
     >
       {filename}
     </button>
-  )
-}
+  );
+};
 
 export default function CircuitPreview({
   code,
@@ -81,73 +85,75 @@ export default function CircuitPreview({
   leftView,
   rightView,
 }: {
-  code?: string
-  showTabs?: boolean
-  defaultView?: "code" | "pcb" | "schematic"
-  splitView?: boolean
-  showRunFrame?: boolean
-  hideSchematicTab?: boolean
-  hidePCBTab?: boolean
-  hide3DTab?: boolean
-  fsMap?: Record<string, string>
-  entrypoint?: string
-  schematicOnly?: boolean
-  leftView?: "code" | "pcb" | "schematic" | "3d" | "runframe"
-  rightView?: "code" | "pcb" | "schematic" | "3d" | "runframe"
+  code?: string;
+  showTabs?: boolean;
+  defaultView?: "code" | "pcb" | "schematic";
+  splitView?: boolean;
+  showRunFrame?: boolean;
+  hideSchematicTab?: boolean;
+  hidePCBTab?: boolean;
+  hide3DTab?: boolean;
+  fsMap?: Record<string, string>;
+  entrypoint?: string;
+  schematicOnly?: boolean;
+  leftView?: "code" | "pcb" | "schematic" | "3d" | "runframe";
+  rightView?: "code" | "pcb" | "schematic" | "3d" | "runframe";
 }) {
-  const { isDarkTheme } = useColorMode()
-  const windowSize = useWindowSize()
-  const [currentFile, setCurrentFile] = useState<string>(entrypoint)
+  const { isDarkTheme } = useColorMode();
+  const windowSize = useWindowSize();
+  const [currentFile, setCurrentFile] = useState<string>(entrypoint);
 
-  let _showTabs = showTabs
-  let _splitView = splitView
-  let _defaultView = defaultView
-  let _hidePCBTab = hidePCBTab
-  let _hide3DTab = hide3DTab
+  let _showTabs = showTabs;
+  let _splitView = splitView;
+  let _defaultView = defaultView;
+  let _hidePCBTab = hidePCBTab;
+  let _hide3DTab = hide3DTab;
 
   if (schematicOnly) {
-    _showTabs = false
-    _splitView = false
-    _defaultView = "schematic"
-    _hidePCBTab = true
-    _hide3DTab = true
+    _showTabs = false;
+    _splitView = false;
+    _defaultView = "schematic";
+    _hidePCBTab = true;
+    _hide3DTab = true;
   }
 
   if (leftView || rightView) {
-    _showTabs = false
-    _splitView = true
-    _hidePCBTab = ![leftView, rightView].includes("pcb")
-    _hide3DTab = ![leftView, rightView].includes("3d")
+    _showTabs = false;
+    _splitView = true;
+    _hidePCBTab = ![leftView, rightView].includes("pcb");
+    _hide3DTab = ![leftView, rightView].includes("3d");
   }
 
   const [view, setView] = useState<
     "pcb" | "schematic" | "code" | "3d" | "runframe"
-  >(rightView ?? _defaultView)
-  const currentCode = code || fsMap[entrypoint] || ""
-  const pcbUrl = useMemo(() => createSvgUrl(currentCode, "pcb"), [currentCode])
+  >(rightView ?? _defaultView);
+  const currentCode = code || fsMap[entrypoint] || "";
+  const pcbUrl = useMemo(() => createSvgUrl(currentCode, "pcb"), [currentCode]);
   const schUrl = useMemo(
     () => createSvgUrl(currentCode, "schematic"),
-    [currentCode],
-  )
+    [currentCode]
+  );
   const threeDUrl = useMemo(
     () => createPngUrl(currentCode, "3d"),
-    [currentCode],
-  )
+    [currentCode]
+  );
 
-  const shouldSplitCode = _splitView && windowSize !== "mobile"
+  const shouldSplitCode = _splitView && windowSize !== "mobile";
 
   const tabContentHeightCss =
     _showTabs && windowSize !== "mobile"
       ? "h-[calc(100%-46px)]"
-      : "h-full max-h-[300px]"
+      : "h-full max-h-[300px]";
 
-  const hasMultipleFiles = Object.keys(fsMap).length > 1
+  const hasMultipleFiles = Object.keys(fsMap).length > 1;
 
   const tabsElm = (
     <div className={tw("flex justify-end px-2")}>
       <div
         className={tw(
-          `flex-inline justify-end gap-2 mt-2 mb-2 rounded-lg ${!isDarkTheme ? "bg-slate-100" : "bg-slate-800"} p-1 gap-2`,
+          `flex-inline justify-end gap-2 mt-2 mb-2 rounded-lg ${
+            !isDarkTheme ? "bg-slate-100" : "bg-slate-800"
+          } p-1 gap-2`
         )}
       >
         {!shouldSplitCode && (
@@ -187,13 +193,15 @@ export default function CircuitPreview({
         )}
       </div>
     </div>
-  )
+  );
 
   const fileTabsElm = (
     <div className={tw("flex justify-start px-2")}>
       <div
         className={tw(
-          `flex-inline justify-start gap-2 mt-2 mb-2 rounded-lg ${!isDarkTheme ? "bg-white" : "bg-slate-800"} p-1 gap-2`,
+          `flex-inline justify-start gap-2 mt-2 mb-2 rounded-lg ${
+            !isDarkTheme ? "bg-white" : "bg-slate-800"
+          } p-1 gap-2`
         )}
       >
         {Object.keys(fsMap).map((filename) => (
@@ -206,26 +214,32 @@ export default function CircuitPreview({
         ))}
       </div>
     </div>
-  )
+  );
 
   if (leftView || rightView) {
     const renderView = (
       v: "code" | "pcb" | "schematic" | "3d" | "runframe",
-      side: "left" | "right",
+      side: "left" | "right"
     ) => {
-      const borderCss = side === "left" ? "border-r" : "border-l"
+      const borderCss = side === "left" ? "border-r" : "border-l";
       if (v === "code") {
         return (
-          <div className={tw(`flex flex-col flex-1 basis-1/2 min-w-0`)}>
-            {hasMultipleFiles && side === "left" && fileTabsElm}
+          <div
+            className={tw(
+              `flex flex-col flex-1 basis-1/2 min-w-0 overflow-x-auto overflow-y-auto`
+            )}
+          >
+            {hasMultipleFiles && fileTabsElm}
             <div
               className={tw(
-                `flex flex-1 overflow-x-auto overflow-y-auto m-0 p-0 ${borderCss} ${!isDarkTheme ? "border-gray-200" : "border-gray-700"}`,
+                `flex flex-1 m-0 p-0 border-r ${
+                  !isDarkTheme ? "border-gray-200" : "border-gray-700"
+                }`
               )}
             >
               <CodeBlock
                 className={tw(
-                  "w-full rounded-none shadow-none p-0 m-0 min-w-0",
+                  "w-full rounded-none shadow-none p-0 m-0 min-w-0"
                 )}
                 language="tsx"
               >
@@ -233,7 +247,7 @@ export default function CircuitPreview({
               </CodeBlock>
             </div>
           </div>
-        )
+        );
       }
 
       return (
@@ -243,9 +257,9 @@ export default function CircuitPreview({
               v === "pcb"
                 ? "bg-black"
                 : v === "schematic"
-                  ? "bg-[#F5F1ED]"
-                  : "bg-white"
-            }`,
+                ? "bg-[#F5F1ED]"
+                : "bg-white"
+            }`
           )}
         >
           <img
@@ -256,19 +270,21 @@ export default function CircuitPreview({
                 v === "pcb"
                   ? "bg-black flex items-center justify-center"
                   : v === "schematic"
-                    ? "bg-[#F5F1ED]"
-                    : "bg-white object-cover"
-              }`,
+                  ? "bg-[#F5F1ED]"
+                  : "bg-white object-cover"
+              }`
             )}
           />
         </div>
-      )
-    }
+      );
+    };
 
     return (
       <div
         className={tw(
-          `shadow-lg pt-0 pb-0 pl-0 pr-0 border ${!isDarkTheme ? "border-gray-100" : "border-gray-800"} rounded-lg mb-8 overflow-hidden`,
+          `shadow-lg pt-0 pb-0 pl-0 pr-0 border ${
+            !isDarkTheme ? "border-gray-100" : "border-gray-800"
+          } rounded-lg mb-8 overflow-hidden`
         )}
       >
         <div className={tw(`h-full overflow-hidden flex m-0 p-0`)}>
@@ -276,19 +292,23 @@ export default function CircuitPreview({
           {renderView(rightView || "schematic", "right")}
         </div>
       </div>
-    )
+    );
   }
 
   return (
     <div
       className={tw(
-        `shadow-lg pt-0 pb-0 pl-0 pr-0 border ${!isDarkTheme ? "border-gray-100" : "border-gray-800"} rounded-lg mb-8 overflow-hidden`,
+        `shadow-lg pt-0 pb-0 pl-0 pr-0 border ${
+          !isDarkTheme ? "border-gray-100" : "border-gray-800"
+        } rounded-lg mb-8 overflow-hidden`
       )}
     >
       {_showTabs && !shouldSplitCode && tabsElm}
       <div
         className={tw(
-          `h-full overflow-hidden flex m-0 p-0 ${!_showTabs && windowSize === "mobile" ? "flex-col" : ""}`,
+          `h-full overflow-hidden flex m-0 p-0 ${
+            !_showTabs && windowSize === "mobile" ? "flex-col" : ""
+          }`
         )}
       >
         {(view === "code" ||
@@ -298,12 +318,14 @@ export default function CircuitPreview({
             {hasMultipleFiles && fileTabsElm}
             <div
               className={tw(
-                `flex flex-1 overflow-x-auto overflow-y-auto m-0 p-0 border-r ${!isDarkTheme ? "border-gray-200" : "border-gray-700"}`,
+                `flex flex-1 overflow-x-auto overflow-y-auto m-0 p-0 border-r ${
+                  !isDarkTheme ? "border-gray-200" : "border-gray-700"
+                }`
               )}
             >
               <CodeBlock
                 className={tw(
-                  "w-full rounded-none shadow-none p-0 m-0 min-w-0",
+                  "w-full rounded-none shadow-none p-0 m-0 min-w-0"
                 )}
                 language="tsx"
               >
@@ -318,7 +340,7 @@ export default function CircuitPreview({
           view === "runframe") && (
           <div
             className={tw(
-              "flex-1 basis-1/2 min-w-0 min-h-[300px] overflow-hidden m-0 p-0",
+              "flex-1 basis-1/2 min-w-0 min-h-[300px] overflow-hidden m-0 p-0"
             )}
           >
             {_showTabs && shouldSplitCode && tabsElm}
@@ -326,21 +348,27 @@ export default function CircuitPreview({
               src={pcbUrl}
               alt="PCB Circuit Preview"
               className={tw(
-                `w-full ${tabContentHeightCss} m-0 object-contain bg-black flex items-center justify-center ${view !== "pcb" ? "hidden" : ""}`,
+                `w-full ${tabContentHeightCss} m-0 object-contain bg-black flex items-center justify-center ${
+                  view !== "pcb" ? "hidden" : ""
+                }`
               )}
             />
             <img
               src={schUrl}
               alt="Schematic Circuit Preview"
               className={tw(
-                `w-full ${tabContentHeightCss} m-0 object-contain bg-[#F5F1ED] ${view !== "schematic" ? "hidden" : ""}`,
+                `w-full ${tabContentHeightCss} m-0 object-contain bg-[#F5F1ED] ${
+                  view !== "schematic" ? "hidden" : ""
+                }`
               )}
             />
             <img
               src={threeDUrl}
               alt="3D Circuit Preview"
               className={tw(
-                `w-full ${tabContentHeightCss} m-0 object-cover bg-white ${view !== "3d" ? "hidden" : ""}`,
+                `w-full ${tabContentHeightCss} m-0 object-cover bg-white ${
+                  view !== "3d" ? "hidden" : ""
+                }`
               )}
             />
             {showRunFrame && view === "runframe" && (
@@ -350,5 +378,5 @@ export default function CircuitPreview({
         )}
       </div>
     </div>
-  )
+  );
 }

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -1,10 +1,3 @@
-/**
- * Any CSS included here will be global. The classic template
- * bundles Infima by default. Infima is a CSS framework designed to
- * work well for content-centric websites.
- */
-
-/* You can override the default Infima variables here. */
 :root {
   --ifm-color-primary: #1877f2;
   --ifm-color-primary-dark: #166bda;
@@ -17,7 +10,6 @@
   --docusaurus-highlighted-code-line-bg: rgba(0, 0, 0, 0.1);
 }
 
-/* For readability concerns, you should choose a lighter palette in dark mode. */
 [data-theme="dark"] {
   --ifm-color-primary: #4080ff;
   --ifm-color-primary-dark: #2b73ff;
@@ -29,34 +21,15 @@
   --docusaurus-highlighted-code-line-bg: rgba(0, 0, 0, 0.3);
 }
 
-/* GitHub icon theming */
-[data-theme="dark"] .github-icon {
-  filter: invert(1);
-}
+[data-theme="dark"] .github-icon { filter: invert(1); }
+.github-icon { opacity: 0.6; }
 
-.github-icon {
-  opacity: 0.6;
-}
+button { all: unset; cursor: pointer; }
+button:disabled { cursor: not-allowed; opacity: 0.6; }
 
-button {
-  all: unset;
-  cursor: pointer;
-}
+div { border-width: 0; border-style: solid; box-sizing: border-box; }
 
-button:disabled {
-  cursor: not-allowed;
-  opacity: 0.6;
-}
-
-div {
-  border-width: 0;
-  border-style: solid;
-  box-sizing: border-box;
-}
-
-.theme-code-block {
-  font-size: 12px;
-}
+.theme-code-block { font-size: 12px; }
 
 figure {
   display: flex;
@@ -67,7 +40,6 @@ figure {
   padding: 0 1rem;
   box-sizing: border-box;
 }
-
 figure figcaption {
   margin-top: 0.5rem;
   opacity: 0.8;
@@ -77,7 +49,6 @@ figure figcaption {
   width: 90%;
   max-width: 600px;
 }
-
 figure img {
   width: 100%;
   max-width: 600px;
@@ -91,15 +62,11 @@ figure img {
 .img-rounded {
   border-radius: 8px;
   box-shadow: 0 0 0.5rem rgba(0, 0, 0, 0.1);
-  margin-top: 3rem;
-  margin-bottom: 3rem;
+  margin: 3rem auto;
   max-width: 600px;
   width: 100%;
   object-fit: cover;
-  align-self: center;
   display: block;
-  margin-left: auto;
-  margin-right: auto;
 }
 
 .img-400 {
@@ -110,47 +77,26 @@ figure img {
   margin-right: auto;
 }
 
-.menu__list {
-  font-size: 14px;
-}
-
-.menu__caret {
-  width: 14px;
-  height: 14px;
-  opacity: 0.5;
-}
-
+.menu__list { font-size: 14px; }
+.menu__caret { width: 14px; height: 14px; opacity: 0.5; }
 .theme-doc-sidebar-menu .menu__list-item {
   margin: 0;
   padding-top: 1px;
   padding-bottom: 1px;
 }
-
 .menu__list-item .menu__link {
   padding-top: 3px;
   padding-bottom: 3px;
 }
 
 @media (max-width: 768px) {
-  iframe {
-    max-width: 90vw;
-  }
-
+  iframe { max-width: 90vw; }
   .container > iframe,
-  .container > img {
-    max-width: 90vw !important;
-  }
-  .img-rounded,
-  .img-400 {
-    max-width: 90vw;
-    box-sizing: border-box;
-  }
+  .container > img { max-width: 90vw !important; }
+  .img-rounded, .img-400 { max-width: 90vw; }
 }
 
-html,
-body {
-  overflow-x: hidden !important;
-}
+html, body { overflow-x: hidden !important; }
 
 .skeleton-container {
   width: 100%;
@@ -164,14 +110,10 @@ body {
   position: relative;
   overflow: hidden;
 }
-
 .skeleton-container::after {
   content: "";
   position: absolute;
-  top: -50%;
-  left: -50%;
-  right: -50%;
-  bottom: -50%;
+  top: -50%; left: -50%; right: -50%; bottom: -50%;
   background: linear-gradient(
     90deg,
     rgba(255, 255, 255, 0) 0%,
@@ -182,12 +124,50 @@ body {
   transform: rotate(30deg);
   z-index: 1;
 }
-
 @keyframes shimmer {
-  0% {
-    transform: translate(-100%, -100%) rotate(30deg);
-  }
-  100% {
-    transform: translate(100%, 100%) rotate(30deg);
-  }
+  0%   { transform: translate(-100%, -100%) rotate(30deg); }
+  100% { transform: translate(100%, 100%) rotate(30deg); }
+}
+
+/* -------------------------------------------------- */
+/* Final working block: scroll + unified card style   */
+/* -------------------------------------------------- */
+
+.theme-doc-markdown .flex.flex-col.flex-1 {
+  overflow-x: auto;
+  overflow-y: hidden;
+  background: var(--ifm-code-background, #ffffff) !important;
+  box-shadow: none !important;
+  border-radius: 6px;
+}
+
+.theme-doc-markdown pre,
+.theme-doc-markdown pre code {
+  height: auto !important;
+  overflow: visible !important;
+}
+
+.theme-doc-markdown .flex.flex-col.flex-1 .theme-code-block,
+.theme-doc-markdown .flex.flex-col.flex-1 pre,
+.theme-doc-markdown .flex.flex-col.flex-1 code {
+  background: transparent !important;
+  box-shadow: none !important;
+  border: 0 !important;
+  margin: 0 !important;
+  padding: 0.5rem !important;
+  border-radius: 0 !important;
+}
+
+.theme-doc-markdown .flex.flex-col.flex-1 pre,
+.theme-doc-markdown .flex.flex-col.flex-1 pre code {
+  height: auto !important;
+  max-height: none !important;
+  overflow: visible !important;
+  white-space: pre !important;
+}
+
+.theme-doc-markdown .flex.flex-col.flex-1 + .flex-1,
+.theme-doc-markdown .flex.flex-col.flex-1 + [class*="circuit-demo__preview"],
+.theme-doc-markdown .circuit-demo__preview {
+  background: transparent !important;
 }

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -21,15 +21,31 @@
   --docusaurus-highlighted-code-line-bg: rgba(0, 0, 0, 0.3);
 }
 
-[data-theme="dark"] .github-icon { filter: invert(1); }
-.github-icon { opacity: 0.6; }
+[data-theme="dark"] .github-icon {
+  filter: invert(1);
+}
+.github-icon {
+  opacity: 0.6;
+}
 
-button { all: unset; cursor: pointer; }
-button:disabled { cursor: not-allowed; opacity: 0.6; }
+button {
+  all: unset;
+  cursor: pointer;
+}
+button:disabled {
+  cursor: not-allowed;
+  opacity: 0.6;
+}
 
-div { border-width: 0; border-style: solid; box-sizing: border-box; }
+div {
+  border-width: 0;
+  border-style: solid;
+  box-sizing: border-box;
+}
 
-.theme-code-block { font-size: 12px; }
+.theme-code-block {
+  font-size: 12px;
+}
 
 figure {
   display: flex;
@@ -77,8 +93,14 @@ figure img {
   margin-right: auto;
 }
 
-.menu__list { font-size: 14px; }
-.menu__caret { width: 14px; height: 14px; opacity: 0.5; }
+.menu__list {
+  font-size: 14px;
+}
+.menu__caret {
+  width: 14px;
+  height: 14px;
+  opacity: 0.5;
+}
 .theme-doc-sidebar-menu .menu__list-item {
   margin: 0;
   padding-top: 1px;
@@ -90,13 +112,23 @@ figure img {
 }
 
 @media (max-width: 768px) {
-  iframe { max-width: 90vw; }
+  iframe {
+    max-width: 90vw;
+  }
   .container > iframe,
-  .container > img { max-width: 90vw !important; }
-  .img-rounded, .img-400 { max-width: 90vw; }
+  .container > img {
+    max-width: 90vw !important;
+  }
+  .img-rounded,
+  .img-400 {
+    max-width: 90vw;
+  }
 }
 
-html, body { overflow-x: hidden !important; }
+html,
+body {
+  overflow-x: hidden !important;
+}
 
 .skeleton-container {
   width: 100%;
@@ -113,7 +145,10 @@ html, body { overflow-x: hidden !important; }
 .skeleton-container::after {
   content: "";
   position: absolute;
-  top: -50%; left: -50%; right: -50%; bottom: -50%;
+  top: -50%;
+  left: -50%;
+  right: -50%;
+  bottom: -50%;
   background: linear-gradient(
     90deg,
     rgba(255, 255, 255, 0) 0%,
@@ -125,8 +160,12 @@ html, body { overflow-x: hidden !important; }
   z-index: 1;
 }
 @keyframes shimmer {
-  0%   { transform: translate(-100%, -100%) rotate(30deg); }
-  100% { transform: translate(100%, 100%) rotate(30deg); }
+  0% {
+    transform: translate(-100%, -100%) rotate(30deg);
+  }
+  100% {
+    transform: translate(100%, 100%) rotate(30deg);
+  }
 }
 
 /* -------------------------------------------------- */


### PR DESCRIPTION
/claim #151 
/close #151

https://github.com/user-attachments/assets/aaa342c7-75c6-4fc3-b2c2-c7292bdc9aa9


### What’s Changed
- Moved horizontal scroll responsibility to the outer `.flex.flex-col.flex-1` container to avoid inner scrollbars.
- Reset inner `<pre>` and `<code>` elements so they no longer force `height: 100%`.
- Removed default grey background from `.theme-code-block` inside demo cards.
- Ensured demo cards have a unified white background while preserving code padding and syntax highlighting.
- Kept preview side backgrounds intact.

### Why
This resolves the issue where:
- Scrollbars appeared in the middle of the demo instead of at the bottom.
- Demo cards showed an inconsistent grey/white split between code and preview sections.

With this change, demo cards now:
- Scroll correctly at the card level.
- Display a clean, unified white background.
- Remain consistent across all docs pages.
