### PR TITLE
Move fabricationnotetext doc to footprints

### DIFF
--- a/docs/footprints/fabricationnotetext.mdx
+++ b/docs/footprints/fabricationnotetext.mdx
@@ -53,5 +53,5 @@ Below is a simple board with a fabrication note reminding the assembler about a 
 
 - Keep fabrication notes concise so they remain legible when exported to Gerbers or assembly drawings.
 - Use distinct `anchorAlignment` values to align the note with the area or component it refers to.
-- Combine fabrication notes with [`<group />`](./group.mdx) to move related callouts together when laying out subassemblies.
+- Combine fabrication notes with [`<group />`](../elements/group.mdx) to move related callouts together when laying out subassemblies.
 - Fabrication notes are separate from silkscreen text—they will not print on the final PCB silkscreen layer.


### PR DESCRIPTION
## Summary
- move the `<fabricationnotetext />` documentation file under the footprints section
- update the internal link to reference the group element from the new location

## Testing
- bunx tsc --noEmit


------
https://chatgpt.com/codex/tasks/task_b_68c9b0e36b94832ea89bb6af9c8a048d