### PR TITLE
Add description to the built in component cards

### DIFF
--- a/docs/elements/board.mdx
+++ b/docs/elements/board.mdx
@@ -1,6 +1,9 @@
 ---
 title: <board />
 sidebar_position: 1
+description: >-
+  The `<board />` element is a root element that contains all the chips and traces
+  to create a PCB. You can think of a `<board />` like a `<body />` element in HTML.
 ---
 
 The `<board />` element is a root element that contains all the chips and traces

--- a/docs/elements/board.mdx
+++ b/docs/elements/board.mdx
@@ -2,8 +2,7 @@
 title: <board />
 sidebar_position: 1
 description: >-
-  The `<board />` element is a root element that contains all the chips and traces
-  to create a PCB. You can think of a `<board />` like a `<body />` element in HTML. 
+  Root element that contains all chips and traces to create a printed circuit board.
 ---
 
 The `<board />` element is a root element that contains all the chips and traces

--- a/docs/elements/board.mdx
+++ b/docs/elements/board.mdx
@@ -3,7 +3,7 @@ title: <board />
 sidebar_position: 1
 description: >-
   The `<board />` element is a root element that contains all the chips and traces
-  to create a PCB. You can think of a `<board />` like a `<body />` element in HTML.
+  to create a PCB. You can think of a `<board />` like a `<body />` element in HTML. 
 ---
 
 The `<board />` element is a root element that contains all the chips and traces

--- a/docs/elements/chip.mdx
+++ b/docs/elements/chip.mdx
@@ -1,6 +1,9 @@
 ---
 title: <chip />
 sidebar_position: 1
+description: >-
+  The `<chip />` is the most common and most powerful built-in tscircuit element.
+  You can represent virtually any "single-part" electronic component with `<chip />`.
 ---
 
 import CircuitPreview from "@site/src/components/CircuitPreview"

--- a/docs/elements/chip.mdx
+++ b/docs/elements/chip.mdx
@@ -2,8 +2,7 @@
 title: <chip />
 sidebar_position: 1
 description: >-
-  The `<chip />` is the most common and most powerful built-in tscircuit element.
-  You can represent virtually any "single-part" electronic component with `<chip />`.
+  Used to represent virtually any single-part electronic component. Extremely flexible and supports custom footprints and pin arrangements.
 ---
 
 import CircuitPreview from "@site/src/components/CircuitPreview"

--- a/docs/elements/footprint.mdx
+++ b/docs/elements/footprint.mdx
@@ -1,7 +1,7 @@
 ---
 title: <footprint />
 description: >-
-  The `<footprint />` is used to define the physical layout and connection points for components on a printed circuit board.
+  Used to define the physical layout and connection points for components on a printed circuit board.
 ---
 import CircuitPreview from '@site/src/components/CircuitPreview';
 

--- a/docs/elements/footprint.mdx
+++ b/docs/elements/footprint.mdx
@@ -1,5 +1,8 @@
 ---
 title: <footprint />
+description: >-
+  Within a `<footprint />` element you can define PCB elements such as [`<platedhole />`](../footprints/platedhole.mdx)
+  or [`<smtpad />`](../footprints/smtpad.mdx).
 ---
 import CircuitPreview from '@site/src/components/CircuitPreview';
 

--- a/docs/elements/footprint.mdx
+++ b/docs/elements/footprint.mdx
@@ -1,8 +1,7 @@
 ---
 title: <footprint />
 description: >-
-  Within a `<footprint />` element you can define PCB elements such as [`<platedhole />`](../footprints/platedhole.mdx)
-  or [`<smtpad />`](../footprints/smtpad.mdx).
+  The `<footprint />` is used to define the physical layout and connection points for components on a printed circuit board.
 ---
 import CircuitPreview from '@site/src/components/CircuitPreview';
 

--- a/docs/elements/hole.mdx
+++ b/docs/elements/hole.mdx
@@ -1,8 +1,7 @@
 ---
 title: <hole />
 description: >-
-  A hole can be used for mounting and doesn't have any conductive properties, for
-  a hole with a conductive ring of copper see [`<platedhole />`](../footprints/platedhole.mdx).
+  Used for mounting and does not have conductive properties.
 ---
 
 ## Overview

--- a/docs/elements/hole.mdx
+++ b/docs/elements/hole.mdx
@@ -1,5 +1,8 @@
 ---
 title: <hole />
+description: >-
+  A hole can be used for mounting and doesn't have any conductive properties, for
+  a hole with a conductive ring of copper see [`<platedhole />`](../footprints/platedhole.mdx).
 ---
 
 ## Overview

--- a/docs/elements/resonator.mdx
+++ b/docs/elements/resonator.mdx
@@ -1,5 +1,8 @@
 ---
 title: <resonator />
+description: >-
+  Resonators are common components used to provide a stable frequency reference for
+  circuits. They are often used in clock circuits or as a timing element.
 ---
 
 ## Overview

--- a/docs/elements/resonator.mdx
+++ b/docs/elements/resonator.mdx
@@ -1,8 +1,7 @@
 ---
 title: <resonator />
 description: >-
-  Resonators are common components used to provide a stable frequency reference for
-  circuits. They are often used in clock circuits or as a timing element.
+  Provides a stable frequency reference for circuits, often used in clock or timing applications.
 ---
 
 ## Overview


### PR DESCRIPTION
### Before:

- Was not showing the component names for board and chip in the card
- Description was not there for hole, footprint and resonator

<img width="1151" height="592" alt="image" src="https://github.com/user-attachments/assets/c800e0a6-fe4b-4979-b23d-4120d848fe14" />

<img width="1127" height="436" alt="image" src="https://github.com/user-attachments/assets/e88da733-5d2d-454d-91a2-c28b4c6e981a" />


### After:
<img width="1151" height="563" alt="image" src="https://github.com/user-attachments/assets/4efd8710-ba0f-45d8-a60d-1b7ba2677326" />

<img width="1208" height="407" alt="image" src="https://github.com/user-attachments/assets/e09392d5-d283-46a6-8ba3-bb7a632f32a7" />

