### PR TITLE
feat(docs): Add pinout SVG guide and preview support

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -19,7 +19,7 @@
         "@docusaurus/module-type-aliases": "3.8.1",
         "@docusaurus/tsconfig": "3.8.1",
         "@docusaurus/types": "3.8.1",
-        "@tscircuit/create-snippet-url": "^0.0.8",
+        "@tscircuit/create-snippet-url": "^0.0.9",
         "@tscircuit/footprinter": "^0.0.135",
         "@tscircuit/math-utils": "^0.0.18",
         "@twind/core": "^1.1.3",
@@ -614,7 +614,7 @@
 
     "@trysound/sax": ["@trysound/sax@0.2.0", "", {}, "sha512-L7z9BgrNEcYyUYtF+HaEfiS5ebkh9jXqbszz7pC0hRBPaatV0XjSD3+eHrpqFemQfgwiFF0QPIarnIihIDn7OA=="],
 
-    "@tscircuit/create-snippet-url": ["@tscircuit/create-snippet-url@0.0.8", "", { "dependencies": { "fflate": "^0.8.2" }, "peerDependencies": { "typescript": "^5.0.0" } }, "sha512-VMixgwQRsOXlQGwVh2RZIFLLtsn8YWl2Bht61T26MHNM71A1Wzo5qGZtqcdbVkFnvlA42KmdVVjvxYDvEyWdJw=="],
+    "@tscircuit/create-snippet-url": ["@tscircuit/create-snippet-url@0.0.9", "", { "dependencies": { "fflate": "^0.8.2" }, "peerDependencies": { "typescript": "^5.0.0" } }, "sha512-CI+PDOy28Q9pycIyjx0vLpnh6wuyocYPMAJqhr/uAbOBBdY3sz3zTWHvdy7giqTGo0+v5x0nhN6o60RT82grZA=="],
 
     "@tscircuit/footprinter": ["@tscircuit/footprinter@0.0.135", "", { "dependencies": { "@tscircuit/mm": "^0.0.8", "zod": "^3.23.8" }, "peerDependencies": { "circuit-json": "*" } }, "sha512-+8MasMGTNQL/NINnlWk2v6zw/NDerfdIBG3uqhrTr0r7VOHh4lK1ymTkQR7IeoypkxTIHYGB9wHbOt39XAF3mg=="],
 

--- a/docs/guides/tscircuit-essentials/pinout-svg.mdx
+++ b/docs/guides/tscircuit-essentials/pinout-svg.mdx
@@ -1,0 +1,34 @@
+---
+title: Pinout SVG
+---
+
+import CircuitPreview from "@site/src/components/CircuitPreview"
+
+You can generate a pinout diagram for your board. This is useful for creating reference diagrams for modules or development boards.
+
+To include a pin in the pinout diagram, you need to add the `pinAttributes` prop to your component and set `includeInBoardPinout: true` for the desired pins.
+
+Here is an example using a Raspberry Pi Pico W component. We enable all pins to be included in the pinout.
+
+<CircuitPreview
+  showPinoutTab={true}
+  defaultView="pinout"
+  fsMap={{
+    "index.tsx": `
+import { PICO_W } from "@tsci/ShiboSoftwareDev.pico-w"
+
+export default () => {
+  const pinAttributes: any = {}
+  for (let i = 1; i <= 46; i++) {
+    pinAttributes[\`pin\${i}\`] = { includeInBoardPinout: true }
+  }
+
+  return (
+    <board>
+      <PICO_W name="U1" pcbRotation="-90deg" pinAttributes={pinAttributes} />
+    </board>
+  )
+}
+`
+  }}
+/>

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@docusaurus/module-type-aliases": "3.8.1",
     "@docusaurus/tsconfig": "3.8.1",
     "@docusaurus/types": "3.8.1",
-    "@tscircuit/create-snippet-url": "^0.0.8",
+    "@tscircuit/create-snippet-url": "^0.0.9",
     "@tscircuit/footprinter": "^0.0.135",
     "@tscircuit/math-utils": "^0.0.18",
     "@twind/core": "^1.1.3",

--- a/src/components/CircuitPreview.tsx
+++ b/src/components/CircuitPreview.tsx
@@ -75,6 +75,7 @@ export default function CircuitPreview({
   hideSchematicTab = false,
   hidePCBTab = false,
   hide3DTab = false,
+  showPinoutTab = false,
   fsMap = {},
   entrypoint = "index.tsx",
   schematicOnly = false,
@@ -83,17 +84,18 @@ export default function CircuitPreview({
 }: {
   code?: string
   showTabs?: boolean
-  defaultView?: "code" | "pcb" | "schematic"
+  defaultView?: "code" | "pcb" | "schematic" | "pinout"
   splitView?: boolean
   showRunFrame?: boolean
   hideSchematicTab?: boolean
   hidePCBTab?: boolean
   hide3DTab?: boolean
+  showPinoutTab?: boolean
   fsMap?: Record<string, string>
   entrypoint?: string
   schematicOnly?: boolean
-  leftView?: "code" | "pcb" | "schematic" | "3d" | "runframe"
-  rightView?: "code" | "pcb" | "schematic" | "3d" | "runframe"
+  leftView?: "code" | "pcb" | "schematic" | "3d" | "runframe" | "pinout"
+  rightView?: "code" | "pcb" | "schematic" | "3d" | "runframe" | "pinout"
 }) {
   const { isDarkTheme } = useColorMode()
   const windowSize = useWindowSize()
@@ -121,12 +123,16 @@ export default function CircuitPreview({
   }
 
   const [view, setView] = useState<
-    "pcb" | "schematic" | "code" | "3d" | "runframe"
+    "pcb" | "schematic" | "code" | "3d" | "runframe" | "pinout"
   >(rightView ?? _defaultView)
   const currentCode = code || fsMap[entrypoint] || ""
   const pcbUrl = useMemo(() => createSvgUrl(currentCode, "pcb"), [currentCode])
   const schUrl = useMemo(
     () => createSvgUrl(currentCode, "schematic"),
+    [currentCode],
+  )
+  const pinoutUrl = useMemo(
+    () => createSvgUrl(currentCode, "pinout"),
     [currentCode],
   )
   const threeDUrl = useMemo(
@@ -171,6 +177,13 @@ export default function CircuitPreview({
             onClick={() => setView("schematic")}
           />
         )}
+        {showPinoutTab && (
+          <Tab
+            label="Pinout"
+            active={view === "pinout"}
+            onClick={() => setView("pinout")}
+          />
+        )}
         {!_hide3DTab && (
           <Tab
             label="3D"
@@ -210,7 +223,7 @@ export default function CircuitPreview({
 
   if (leftView || rightView) {
     const renderView = (
-      v: "code" | "pcb" | "schematic" | "3d" | "runframe",
+      v: "code" | "pcb" | "schematic" | "3d" | "runframe" | "pinout",
       side: "left" | "right",
     ) => {
       const borderCss = side === "left" ? "border-r" : "border-l"
@@ -249,7 +262,15 @@ export default function CircuitPreview({
           )}
         >
           <img
-            src={v === "pcb" ? pcbUrl : v === "schematic" ? schUrl : threeDUrl}
+            src={
+              v === "pcb"
+                ? pcbUrl
+                : v === "schematic"
+                  ? schUrl
+                  : v === "pinout"
+                    ? pinoutUrl
+                    : threeDUrl
+            }
             alt={`${v.toUpperCase()} Circuit Preview`}
             className={tw(
               `w-full ${tabContentHeightCss} m-0 object-contain ${
@@ -257,7 +278,9 @@ export default function CircuitPreview({
                   ? "bg-black flex items-center justify-center"
                   : v === "schematic"
                     ? "bg-[#F5F1ED]"
-                    : "bg-white object-cover"
+                    : v === "pinout"
+                      ? "bg-white"
+                      : "bg-white object-cover"
               }`,
             )}
           />
@@ -315,7 +338,8 @@ export default function CircuitPreview({
         {(view === "pcb" ||
           view === "schematic" ||
           view === "3d" ||
-          view === "runframe") && (
+          view === "runframe" ||
+          view === "pinout") && (
           <div
             className={tw(
               "flex-1 basis-1/2 min-w-0 min-h-[300px] overflow-hidden m-0 p-0",
@@ -334,6 +358,13 @@ export default function CircuitPreview({
               alt="Schematic Circuit Preview"
               className={tw(
                 `w-full ${tabContentHeightCss} m-0 object-contain bg-[#F5F1ED] ${view !== "schematic" ? "hidden" : ""}`,
+              )}
+            />
+            <img
+              src={pinoutUrl}
+              alt="Pinout Circuit Preview"
+              className={tw(
+                `w-full ${tabContentHeightCss} m-0 object-contain bg-white ${view !== "pinout" ? "hidden" : ""}`,
               )}
             />
             <img


### PR DESCRIPTION
This pull request introduces a new guide for the pinout SVG feature and updates the CircuitPreview component to support    
rendering pinout diagrams.                                                                                                 

 • New Documentation (docs/guides/tscircuit-essentials/pinout-svg.mdx)                                                     
    • Added a new guide to showcase the pinout SVG generation feature, including a code example using a Raspberry Pi Pico W component.                                                                                                           
 • Component Update (src/components/CircuitPreview.tsx)                                                                    
    • Added a new pinout view option.                                                                                      
    • Introduced a showPinoutTab prop to conditionally display the "Pinout" tab.                                           
    • Updated the background for the pinout view to be white for better contrast and readability.   

/claim https://github.com/tscircuit/tscircuit/issues/788
/closes https://github.com/tscircuit/tscircuit/issues/788

<img width="1360" height="730" alt="Screenshot 2025-10-03 at 10 12 53 PM" src="https://github.com/user-attachments/assets/f9cca908-a44a-49e1-9eae-aaa4911397f5" />

