### PR TITLE
Remove nine-key keyboard circuit preview

### DIFF
--- a/docs/intro/what-is-tscircuit.mdx
+++ b/docs/intro/what-is-tscircuit.mdx
@@ -75,13 +75,6 @@ tscircuit isn't limited to simple circuits like this. You can keep adding
 elements, creating modules and combining them to create more and more complex
 circuits. Here's an example of a [simple 3x3 macrokeypad based on the PICO2!](https://tscircuit.com/seveibar/nine-key-keyboard)
 
-
-<CircuitPreview code={`
-import NineKeyKeyboard from "@tsci/seveibar.nine-key-keyboard"
-
-export default () => <NineKeyKeyboard />
-`} />
-
 We ordered this one too!
 
 import macrokeypad from "@site/static/img/macrokeypad.png"


### PR DESCRIPTION
## Summary
- remove the embedded CircuitPreview snippet for the nine key keyboard from the intro page

## Testing
- bunx tsc --noEmit
- bun run format

------
https://chatgpt.com/codex/tasks/task_b_68e41726ab54832e811c8e5aa1f2f4a9