### PR TITLE
Fix sidebar chevron rotation

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -144,7 +144,7 @@ figure img {
   height: 0.75rem;
   background-size: 0.75rem 0.75rem;
   background-repeat: no-repeat;
-  transform: rotate(0deg);
+  transform: rotate(-90deg);
 }
 
 .menu__list-item--collapsed .menu__link--sublist:after,


### PR DESCRIPTION
## Summary
- rotate the sidebar category chevrons upward when expanded while keeping collapsed categories pointing downward

## Testing
- bunx tsc --noEmit

------
https://chatgpt.com/codex/tasks/task_b_68e437aabc44832ea4797c6b950d6df2