### PR TITLE
style: wrap documentation media in rounded containers

### DIFF
--- a/docs/intro/quickstart-ChatGPT.mdx
+++ b/docs/intro/quickstart-ChatGPT.mdx
@@ -14,12 +14,22 @@ import finalResult from "@site/static/img/guides/how-to-use-chatgpt/final-result
 import instructionsImg from "@site/static/img/guides/how-to-use-chatgpt/instructions.png"
 
 <div>
-    <p>Create a project and click "Instructions", then paste in the text block below</p>
-    <img style={{maxHeight: 400}} src={instructionsImg} alt="Paste in Instructions" />
-    <p>Click the <strong>Preview</strong> button in the chat to run the code.</p>
-    <img style={{maxHeight: 400}} src={pressPreview} alt="Click the Preview button" />
-    <p>The tscircuit preview appears. You can edit the code and use this sandbox as a playground.</p>
-    <img style={{maxHeight: 400}} src={finalResult} alt="Rendered preview result" />
+  <p>Create a project and click "Instructions", then paste in the text block below</p>
+  <div className="media-frame">
+    <img
+      style={{ maxHeight: 400 }}
+      src={instructionsImg}
+      alt="Paste in Instructions"
+    />
+  </div>
+  <p>Click the <strong>Preview</strong> button in the chat to run the code.</p>
+  <div className="media-frame">
+    <img style={{ maxHeight: 400 }} src={pressPreview} alt="Click the Preview button" />
+  </div>
+  <p>The tscircuit preview appears. You can edit the code and use this sandbox as a playground.</p>
+  <div className="media-frame">
+    <img style={{ maxHeight: 400 }} src={finalResult} alt="Rendered preview result" />
+  </div>
 </div>
 
 ## Copy this to your ChatGPT project instructions!

--- a/src/components/YouTubeEmbed.tsx
+++ b/src/components/YouTubeEmbed.tsx
@@ -6,30 +6,18 @@ interface YouTubeEmbedProps {
 
 const YouTubeEmbed: React.FC<YouTubeEmbedProps> = ({ youtubeId }) => {
   return (
-    <div
-      style={{
-        position: "relative",
-        paddingBottom: "56.25%",
-        height: 0,
-        overflow: "hidden",
-        maxWidth: "100%",
-      }}
-    >
-      <iframe
-        style={{
-          position: "absolute",
-          top: 0,
-          left: 0,
-          width: "100%",
-          height: "100%",
-        }}
-        src={`https://www.youtube.com/embed/${youtubeId}`}
-        title="YouTube video player"
-        frameBorder="0"
-        allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
-        referrerPolicy="strict-origin-when-cross-origin"
-        allowFullScreen
-      />
+    <div className="youtube-embed__container">
+      <div className="youtube-embed__frame">
+        <iframe
+          className="youtube-embed__iframe"
+          src={`https://www.youtube.com/embed/${youtubeId}`}
+          title="YouTube video player"
+          frameBorder="0"
+          allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+          referrerPolicy="strict-origin-when-cross-origin"
+          allowFullScreen
+        />
+      </div>
     </div>
   )
 }

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -116,6 +116,7 @@ figure img {
   border-radius: 12px;
 }
 
+.media-frame,
 .markdown p:has(> img:only-child),
 .markdown p:has(> a:only-child > img:only-child),
 .markdown li:has(> img:only-child),
@@ -141,6 +142,13 @@ figure img {
   overflow: hidden;
 }
 
+.media-frame {
+  display: block;
+  width: 100%;
+}
+
+.media-frame > img,
+.media-frame > iframe,
 .markdown p > img:only-child,
 .markdown p > a:only-child > img:only-child,
 .markdown li > img:only-child,
@@ -273,6 +281,7 @@ figure img {
     box-sizing: border-box;
   }
 
+  .media-frame,
   .markdown p:has(> img:only-child),
   .markdown p:has(> a:only-child > img:only-child),
   .markdown li:has(> img:only-child),

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -86,38 +86,42 @@ figure {
   flex-direction: column;
   align-items: center;
   margin: 3rem auto 2rem;
-  max-width: 100%;
-  padding: 0 1rem;
+  max-width: 760px;
+  width: 100%;
+  padding: 0.75rem;
   box-sizing: border-box;
+  background: var(--media-container-bg);
+  border: 1px solid var(--media-container-border);
+  border-radius: 16px;
+  box-shadow: var(--media-container-shadow);
 }
 
 figure figcaption {
-  margin-top: 0.5rem;
+  margin-top: 0.75rem;
   opacity: 0.8;
   text-align: center;
-  font-size: 0.8rem;
-  line-height: 1.2rem;
+  font-size: 0.85rem;
+  line-height: 1.35rem;
   width: 90%;
   max-width: 600px;
 }
 
 figure img {
-  width: 100%;
-  max-width: 600px;
-  height: auto;
   display: block;
-  object-fit: cover;
+  width: auto;
+  max-width: 100%;
+  height: auto;
   margin-left: auto;
   margin-right: auto;
+  border-radius: 12px;
 }
 
-.markdown p > img:only-child,
-.markdown p > a:only-child > img:only-child,
-.markdown li > img:only-child,
-.markdown li > a:only-child > img:only-child,
-.markdown figure > img,
-.markdown div:not([class]) > img:only-child,
-.markdown div:not([class]) > a:only-child > img:only-child,
+.markdown p:has(> img:only-child),
+.markdown p:has(> a:only-child > img:only-child),
+.markdown li:has(> img:only-child),
+.markdown li:has(> a:only-child > img:only-child),
+.markdown div:not([class]):has(> img:only-child),
+.markdown div:not([class]):has(> a:only-child > img:only-child),
 .markdown p > iframe:only-child:not(.youtube-embed__iframe),
 .markdown li > iframe:only-child:not(.youtube-embed__iframe),
 .markdown p > a:only-child > iframe:only-child:not(.youtube-embed__iframe),
@@ -144,8 +148,13 @@ figure img {
 .markdown figure > img,
 .markdown div:not([class]) > img:only-child,
 .markdown div:not([class]) > a:only-child > img:only-child {
+  display: block;
+  width: auto;
+  max-width: 100%;
   height: auto;
-  background: var(--media-container-bg);
+  margin-left: auto;
+  margin-right: auto;
+  border-radius: 12px;
 }
 
 .markdown p > iframe:only-child:not(.youtube-embed__iframe),
@@ -264,13 +273,13 @@ figure img {
     box-sizing: border-box;
   }
 
-  .markdown p > img:only-child,
-  .markdown p > a:only-child > img:only-child,
-  .markdown li > img:only-child,
-  .markdown li > a:only-child > img:only-child,
-  .markdown figure > img,
-  .markdown div:not([class]) > img:only-child,
-  .markdown div:not([class]) > a:only-child > img:only-child,
+  .markdown p:has(> img:only-child),
+  .markdown p:has(> a:only-child > img:only-child),
+  .markdown li:has(> img:only-child),
+  .markdown li:has(> a:only-child > img:only-child),
+  .markdown div:not([class]):has(> img:only-child),
+  .markdown div:not([class]):has(> a:only-child > img:only-child),
+  figure,
   .markdown p > iframe:only-child:not(.youtube-embed__iframe),
   .markdown li > iframe:only-child:not(.youtube-embed__iframe),
   .markdown p > a:only-child > iframe:only-child:not(.youtube-embed__iframe),

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -16,6 +16,9 @@
   --ifm-code-font-size: 95%;
   --docusaurus-highlighted-code-line-bg: rgba(0, 0, 0, 0.1);
   --ifm-menu-link-sublist-icon: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='14' height='14' viewBox='0 0 24 24' fill='none' stroke='rgba(0,0,0,0.6)' stroke-width='2.4' stroke-linecap='round' stroke-linejoin='round'><polyline points='9 5 16 12 9 19'/></svg>");
+  --media-container-bg: #f4f6fb;
+  --media-container-border: rgba(13, 39, 80, 0.08);
+  --media-container-shadow: 0 12px 30px rgba(15, 23, 42, 0.08);
 }
 
 /* For readability concerns, you should choose a lighter palette in dark mode. */
@@ -28,6 +31,9 @@
   --ifm-color-primary-lighter: #6296ff;
   --ifm-color-primary-lightest: #8bb2ff;
   --docusaurus-highlighted-code-line-bg: rgba(0, 0, 0, 0.3);
+  --media-container-bg: rgba(255, 255, 255, 0.07);
+  --media-container-border: rgba(255, 255, 255, 0.12);
+  --media-container-shadow: 0 16px 40px rgba(0, 0, 0, 0.3);
 }
 
 /* GitHub icon theming */
@@ -105,6 +111,86 @@ figure img {
   margin-right: auto;
 }
 
+.markdown p > img:only-child,
+.markdown p > a:only-child > img:only-child,
+.markdown li > img:only-child,
+.markdown li > a:only-child > img:only-child,
+.markdown figure > img,
+.markdown div:not([class]) > img:only-child,
+.markdown div:not([class]) > a:only-child > img:only-child,
+.markdown p > iframe:only-child:not(.youtube-embed__iframe),
+.markdown li > iframe:only-child:not(.youtube-embed__iframe),
+.markdown p > a:only-child > iframe:only-child:not(.youtube-embed__iframe),
+.markdown iframe[src*="youtube.com"]:not(.youtube-embed__iframe),
+.markdown iframe[src*="youtube-nocookie.com"]:not(.youtube-embed__iframe),
+.markdown iframe[src*="youtu.be"]:not(.youtube-embed__iframe) {
+  display: block;
+  width: 100%;
+  max-width: 760px;
+  margin: 2rem auto;
+  padding: 0.75rem;
+  border-radius: 16px;
+  box-sizing: border-box;
+  background: var(--media-container-bg);
+  border: 1px solid var(--media-container-border);
+  box-shadow: var(--media-container-shadow);
+  overflow: hidden;
+}
+
+.markdown p > img:only-child,
+.markdown p > a:only-child > img:only-child,
+.markdown li > img:only-child,
+.markdown li > a:only-child > img:only-child,
+.markdown figure > img,
+.markdown div:not([class]) > img:only-child,
+.markdown div:not([class]) > a:only-child > img:only-child {
+  height: auto;
+  background: var(--media-container-bg);
+}
+
+.markdown p > iframe:only-child:not(.youtube-embed__iframe),
+.markdown li > iframe:only-child:not(.youtube-embed__iframe),
+.markdown p > a:only-child > iframe:only-child:not(.youtube-embed__iframe),
+.markdown iframe[src*="youtube.com"]:not(.youtube-embed__iframe),
+.markdown iframe[src*="youtube-nocookie.com"]:not(.youtube-embed__iframe),
+.markdown iframe[src*="youtu.be"]:not(.youtube-embed__iframe) {
+  border: none;
+  background: var(--media-container-bg);
+  aspect-ratio: 16 / 9;
+  height: auto !important;
+}
+
+.youtube-embed__container {
+  background: var(--media-container-bg);
+  border: 1px solid var(--media-container-border);
+  border-radius: 16px;
+  box-shadow: var(--media-container-shadow);
+  padding: 0.75rem;
+  margin: 2rem auto;
+  max-width: 760px;
+  width: 100%;
+  box-sizing: border-box;
+}
+
+.youtube-embed__frame {
+  position: relative;
+  padding-bottom: 56.25%;
+  height: 0;
+  overflow: hidden;
+  border-radius: 12px;
+  background: var(--media-container-bg);
+}
+
+.youtube-embed__iframe {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  border: 0;
+  border-radius: 12px;
+}
+
 .img-rounded {
   border-radius: 8px;
   box-shadow: 0 0 0.5rem rgba(0, 0, 0, 0.1);
@@ -176,6 +262,29 @@ figure img {
   .img-400 {
     max-width: 90vw;
     box-sizing: border-box;
+  }
+
+  .markdown p > img:only-child,
+  .markdown p > a:only-child > img:only-child,
+  .markdown li > img:only-child,
+  .markdown li > a:only-child > img:only-child,
+  .markdown figure > img,
+  .markdown div:not([class]) > img:only-child,
+  .markdown div:not([class]) > a:only-child > img:only-child,
+  .markdown p > iframe:only-child:not(.youtube-embed__iframe),
+  .markdown li > iframe:only-child:not(.youtube-embed__iframe),
+  .markdown p > a:only-child > iframe:only-child:not(.youtube-embed__iframe),
+  .markdown iframe[src*="youtube.com"]:not(.youtube-embed__iframe),
+  .markdown iframe[src*="youtube-nocookie.com"]:not(.youtube-embed__iframe),
+  .markdown iframe[src*="youtu.be"]:not(.youtube-embed__iframe) {
+    max-width: 100%;
+    margin: 1.5rem auto;
+    padding: 0.5rem;
+  }
+
+  .youtube-embed__container {
+    padding: 0.5rem;
+    margin: 1.5rem auto;
   }
 }
 


### PR DESCRIPTION
## Summary
- add shared theme variables and selectors so markdown images and embedded media render inside padded, rounded containers in both light and dark themes
- style the reusable YouTubeEmbed component with the same container treatment for consistent responsive iframes

## Testing
- bunx tsc --noEmit

------
https://chatgpt.com/codex/tasks/task_b_68e436dfb170832e97dc96da56715e8e