### PR TITLE
feat: remove breadcurmp and make body content center

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -178,13 +178,13 @@ const config: Config = {
         {
           href: "https://discord.com/invite/V7FGE5ZCbA",
           position: "right",
-          className: "header-discord-link",
+          className: "header-discord-link header-icon-link",
           html: '<img src="/img/discord.svg" alt="Discord" style="height: 18px; width: 18px; margin-bottom: -4px;" class="github-icon" />',
         },
         {
           href: "https://github.com/tscircuit/tscircuit",
           position: "right",
-          className: "header-github-link",
+          className: "header-github-link header-icon-link",
           html: '<img src="/img/github.svg" alt="GitHub" style="height: 18px; width: 18px; margin-bottom: -4px; margin-right: 6px;" class="github-icon" />',
         },
       ],

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -43,6 +43,7 @@ const config: Config = {
           sidebarPath: "./sidebars.ts",
           routeBasePath: "/", // Serve docs at root
           editUrl: "https://github.com/tscircuit/docs/tree/main/",
+          breadcrumbs: false,
         },
         theme: {
           customCss: "./src/css/custom.css",

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -252,6 +252,12 @@ figure img {
   font-size: 14px;
 }
 
+/* Reduce navbar toggle button SVG size */
+.navbar__toggle svg {
+  width: 20px !important;
+  height: 20px !important;
+}
+
 .navbar__brand {
   margin-right: 0rem !important;
 }

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -594,7 +594,6 @@ article header h1 {
   justify-content: center !important;
 }
 
-
 article,
 .markdown {
   max-width: 100% !important;

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -238,6 +238,15 @@ figure img {
   font-size: 14px;
 }
 
+/* Remove left padding from nested menu lists */
+.menu__list .menu__list {
+  padding-left: 0 !important;
+}
+
+.navbar-sidebar__item {
+  padding: 1rem;
+}
+
 /* Make top navbar links smaller */
 .navbar__link {
   font-size: 14px;
@@ -290,7 +299,15 @@ figure img {
 }
 /* Sidebar section styling - only for top-level categories */
 .theme-doc-sidebar-item-category-level-1 > .menu__list-item-collapsible {
-  margin-left: 12px;
+  margin-left: 0;
+}
+
+/* Add 8px padding to each top-level section and its dropdown contents */
+@media (min-width: 1000px) {
+  .theme-doc-sidebar-item-category-level-1 {
+    padding-left: 8px;
+    padding-right: 8px;
+  }
 }
 
 .theme-doc-sidebar-item-category-level-1
@@ -502,7 +519,15 @@ figure img {
 .menu__list-item .menu__link {
   padding-top: 5px;
   padding-bottom: 5px;
-  padding-left: 20px;
+  padding-left: 16px !important;
+  padding-right: 16px !important;
+}
+
+/* Ensure hover and active states maintain padding */
+.menu__link:hover,
+.menu__link--active {
+  padding-left: 16px !important;
+  padding-right: 16px !important;
 }
 
 @media (max-width: 768px) {

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -575,6 +575,26 @@ article header h1 {
   margin-right: auto !important;
 }
 
+/* Force section overview to center */
+.generatedIndexPage_vN6x {
+  max-width: 980px;
+  margin: 0 auto;
+  float: none;
+}
+
+.generatedIndexPage_vN6x .row .col--6 {
+  flex: 0 0 calc(50% - 0.75rem) !important;
+  max-width: calc(50% - 0.75rem) !important;
+}
+
+.generatedIndexPage_vN6x .row {
+  display: flex !important;
+  flex-wrap: wrap !important;
+  gap: 1.5rem !important;
+  justify-content: center !important;
+}
+
+
 article,
 .markdown {
   max-width: 100% !important;
@@ -610,5 +630,12 @@ article,
       rgba(255, 255, 255, 1) 8%,
       rgba(0, 0, 0, 0) 0%
     );
+  }
+}
+
+@media (max-width: 768px) {
+  .generatedIndexPage_vN6x .row .col--6 {
+    flex: 0 0 100% !important;
+    max-width: 100% !important;
   }
 }

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -501,6 +501,7 @@ body {
   font-weight: 700;
   color: var(--ifm-color-primary);
   margin-bottom: 0.5rem;
+  margin-top: 1.8rem;
   line-height: 1.2;
   text-align: left;
   white-space: nowrap;

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -248,13 +248,13 @@ figure img {
   > .menu__list-item-collapsible
   > .menu__link {
   font-weight: 600;
-  color: #000000;
+  color: #181c1a;
 }
 [data-theme="dark"]
   .theme-doc-sidebar-item-category-level-1
   > .menu__list-item-collapsible
   > .menu__link {
-  color: #ffffff;
+  color: #cbd5e0;
 }
 
 /* Add icons to top-level sidebar sections only */
@@ -518,7 +518,8 @@ body {
 article header h1 {
   text-align: left !important;
   font-size: 2rem !important;
-  font-weight: 650 !important;
+  font-weight: 600 !important;
+  text-shadow: 0 0 0.8px currentColor;
 }
 
 article h2 {
@@ -529,6 +530,7 @@ article h2 {
 article h3 {
   font-size: 1.25rem !important;
   font-weight: 600 !important;
+  text-shadow: 0 0 0.5px currentColor;
 }
 
 article h4 {

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -502,11 +502,12 @@ body {
   line-height: 1.2;
   text-align: left;
   white-space: nowrap;
-  max-width: 900px;
+  max-width: 970px;
   margin-left: auto;
   margin-right: auto;
-  padding-left: 2rem;
+  padding-left: 4rem;
   padding-right: 2rem;
+  box-sizing: border-box;
 }
 
 [data-theme="dark"] .doc-section-subtitle {

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -532,7 +532,7 @@ article header h1 {
   text-align: left !important;
   font-size: 1.9rem !important;
   font-weight: 600 !important;
-  text-shadow: 0 0 0.8px currentColor;
+  text-shadow: 0 0 0.1px currentColor;
   letter-spacing: -0.025em;
   margin-bottom: 0.6rem !important;
 }
@@ -547,7 +547,7 @@ article h2 {
 article h3 {
   font-size: 1.25rem !important;
   font-weight: 600 !important;
-  text-shadow: 0 0 0.5px currentColor;
+  text-shadow: 0 0 0.1px currentColor;
   letter-spacing: -0.025em;
 }
 

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -570,7 +570,7 @@ article header h1 {
 
 /* Force center all documentation content */
 .col:not(.col--3) {
-  max-width: 900px !important;
+  max-width: 1000px !important;
   margin-left: auto !important;
   margin-right: auto !important;
 }

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -497,7 +497,6 @@ body {
   font-size: 1rem;
   font-weight: 700;
   color: var(--ifm-color-primary);
-  letter-spacing: 0.05em;
   margin-bottom: 0.5rem;
   line-height: 1.2;
   text-align: left;

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -448,6 +448,7 @@ figure img {
 .menu__list-item .menu__link {
   padding-top: 5px;
   padding-bottom: 5px;
+  padding-left: 20px;
 }
 
 @media (max-width: 768px) {

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -503,7 +503,7 @@ body {
 .doc-section-subtitle {
   font-size: 1rem;
   font-weight: 700;
-  color: var(--ifm-color-primary);
+  color: #6aa4f6;
   margin-bottom: 0.5rem;
   margin-top: 1.8rem;
   line-height: 1.2;
@@ -525,7 +525,7 @@ body {
 }
 
 [data-theme="dark"] .doc-section-subtitle {
-  color: var(--ifm-color-primary-lighter);
+  color: #8bb2ff;
 }
 
 article header h1 {

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -575,19 +575,19 @@ article header h1 {
   margin-right: auto !important;
 }
 
-/* Force section overview to center */
-.generatedIndexPage {
+/* Force section overview to center - using stable attribute selector */
+[class*="generatedIndexPage"] {
   max-width: 980px;
   margin: 0 auto;
   float: none;
 }
 
-.generatedIndexPage .row .col--6 {
+[class*="generatedIndexPage"] .row .col--6 {
   flex: 0 0 calc(50% - 0.75rem) !important;
   max-width: calc(50% - 0.75rem) !important;
 }
 
-.generatedIndexPage .row {
+[class*="generatedIndexPage"] .row {
   display: flex !important;
   flex-wrap: wrap !important;
   gap: 1.5rem !important;
@@ -633,7 +633,7 @@ article,
 }
 
 @media (max-width: 768px) {
-  .generatedIndexPage_vN6x .row .col--6 {
+  [class*="generatedIndexPage"] .row .col--6 {
     flex: 0 0 100% !important;
     max-width: 100% !important;
   }

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -678,15 +678,15 @@ article h4 {
 }
 
 [class*="generatedIndexPage"] .row .col--6 {
-  flex: 0 0 calc(50% - 0.75rem) !important;
-  max-width: calc(50% - 0.75rem) !important;
+  flex: 0 0 100% !important;
+  max-width: 100% !important;
 }
 
 [class*="generatedIndexPage"] .row {
   display: flex !important;
-  flex-wrap: wrap !important;
-  gap: 1.5rem !important;
-  justify-content: center !important;
+  flex-direction: column !important;
+  gap: 1rem !important;
+  align-items: stretch !important;
 }
 
 article,

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -557,6 +557,10 @@ article h4 {
   letter-spacing: -0.025em;
 }
 
+.markdown > p:first-of-type {
+  margin-bottom: 2rem !important;
+}
+
 .skeleton-container {
   width: 100%;
   height: 600px;

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -512,6 +512,13 @@ body {
   box-sizing: border-box;
 }
 
+@media (max-width: 768px) {
+  .doc-section-subtitle {
+    padding-left: 2rem;
+    padding-right: 1rem;
+  }
+}
+
 [data-theme="dark"] .doc-section-subtitle {
   color: var(--ifm-color-primary-lighter);
 }
@@ -622,6 +629,14 @@ article,
   max-width: 100% !important;
   padding-left: 2rem !important;
   padding-right: 2rem !important;
+}
+
+@media (max-width: 768px) {
+  article,
+  .markdown {
+    padding-left: 0.9rem !important;
+    padding-right: 0.9rem !important;
+  }
 }
 
 .tscircuit-iframe {

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -243,6 +243,51 @@ figure img {
   font-size: 14px;
 }
 
+.navbar__brand {
+  margin-right: 0rem !important;
+}
+
+.navbar__items--right {
+  display: flex !important;
+  align-items: center !important;
+  gap: 0.5rem !important;
+}
+
+.navbar__items--right .navbar__item {
+  margin: 0 !important;
+  display: flex !important;
+  align-items: center !important;
+}
+
+.header-discord-link,
+.header-github-link {
+  padding: 0.5rem !important;
+  display: flex !important;
+  align-items: center !important;
+  justify-content: center !important;
+  margin: 0 !important;
+}
+
+.header-github-link img,
+.header-discord-link img {
+  margin: 0 !important;
+  display: block;
+}
+
+/* Ensure theme toggle aligns with icons */
+.navbar__items--right > div,
+.navbar__items--right button {
+  display: flex !important;
+  align-items: center !important;
+  margin: 0 !important;
+}
+
+/* Hide GitHub and Discord icons on mobile */
+@media (max-width: 770px) {
+  .navbar__item.header-icon-link {
+    display: none !important;
+  }
+}
 /* Sidebar section styling - only for top-level categories */
 .theme-doc-sidebar-item-category-level-1 > .menu__list-item-collapsible {
   margin-left: 12px;
@@ -264,15 +309,20 @@ figure img {
 /* Add icons to top-level sidebar sections only */
 .theme-doc-sidebar-item-category-level-1
   > .menu__list-item-collapsible
+  > .menu__link {
+  display: flex !important;
+  align-items: center !important;
+}
+
+.theme-doc-sidebar-item-category-level-1
+  > .menu__list-item-collapsible
   > .menu__link::before {
   content: "";
   display: inline-block;
+  flex-shrink: 0;
   width: 14px;
   height: 14px;
   margin-right: 10px;
-  vertical-align: baseline;
-  position: relative;
-  top: 1px;
   background-size: contain;
   background-repeat: no-repeat;
   background-position: center;

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -503,7 +503,7 @@ body {
 .doc-section-subtitle {
   font-size: 1rem;
   font-weight: 700;
-  color: #6aa4f6;
+  color: var(--ifm-color-primary-light);
   margin-bottom: 0.5rem;
   margin-top: 1.8rem;
   line-height: 1.2;
@@ -525,7 +525,7 @@ body {
 }
 
 [data-theme="dark"] .doc-section-subtitle {
-  color: #8bb2ff;
+  color: var(--ifm-color-primary-lightest);
 }
 
 article header h1 {

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -263,10 +263,12 @@ figure img {
   > .menu__link::before {
   content: "";
   display: inline-block;
-  width: 18px;
-  height: 18px;
-  margin-right: 12px;
-  vertical-align: middle;
+  width: 14px;
+  height: 14px;
+  margin-right: 10px;
+  vertical-align: baseline;
+  position: relative;
+  top: 1px;
   background-size: contain;
   background-repeat: no-repeat;
   background-position: center;

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -576,18 +576,18 @@ article header h1 {
 }
 
 /* Force section overview to center */
-.generatedIndexPage_vN6x {
+.generatedIndexPage {
   max-width: 980px;
   margin: 0 auto;
   float: none;
 }
 
-.generatedIndexPage_vN6x .row .col--6 {
+.generatedIndexPage .row .col--6 {
   flex: 0 0 calc(50% - 0.75rem) !important;
   max-width: calc(50% - 0.75rem) !important;
 }
 
-.generatedIndexPage_vN6x .row {
+.generatedIndexPage .row {
   display: flex !important;
   flex-wrap: wrap !important;
   gap: 1.5rem !important;

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -586,7 +586,8 @@ article h4 {
 }
 
 .table-of-contents,
-.theme-doc-toc-desktop {
+.theme-doc-toc-desktop,
+.theme-doc-toc-mobile {
   display: none !important;
 }
 

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -258,6 +258,18 @@ figure img {
   height: 20px !important;
 }
 
+/* Reduce navbar close button SVG size */
+.navbar-sidebar__close svg {
+  width: 15px !important;
+  height: 15px !important;
+}
+
+/* Reduce theme toggle button SVG size */
+.toggleButton_gllP svg {
+  width: 20px !important;
+  height: 20px !important;
+}
+
 .navbar__brand {
   margin-right: 0rem !important;
 }

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -493,6 +493,30 @@ body {
   overflow-x: hidden;
 }
 
+.doc-section-subtitle {
+  font-size: 1rem;
+  font-weight: 700;
+  color: var(--ifm-color-primary);
+  letter-spacing: 0.05em;
+  margin-bottom: 0.5rem;
+  line-height: 1.2;
+  text-align: left;
+  white-space: nowrap;
+  max-width: 900px;
+  margin-left: auto;
+  margin-right: auto;
+  padding-left: 2rem;
+  padding-right: 2rem;
+}
+
+[data-theme="dark"] .doc-section-subtitle {
+  color: var(--ifm-color-primary-lighter);
+}
+
+article header h1 {
+  text-align: left !important;
+}
+
 .skeleton-container {
   width: 100%;
   height: 600px;
@@ -531,4 +555,26 @@ body {
   100% {
     transform: translate(100%, 100%) rotate(30deg);
   }
+}
+
+.col.col--3 {
+  display: none !important;
+}
+
+.table-of-contents,
+.theme-doc-toc-desktop {
+  display: none !important;
+}
+
+.col:not(.col--3) {
+  max-width: 1000px !important;
+  margin-left: auto !important;
+  margin-right: auto !important;
+}
+
+article,
+.markdown {
+  max-width: 100% !important;
+  padding-left: 2rem !important;
+  padding-right: 2rem !important;
 }

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -515,6 +515,23 @@ body {
 
 article header h1 {
   text-align: left !important;
+  font-size: 2rem !important;
+  font-weight: 650 !important;
+}
+
+article h2 {
+  font-size: 1.5rem !important;
+  font-weight: 630 !important;
+}
+
+article h3 {
+  font-size: 1.25rem !important;
+  font-weight: 600 !important;
+}
+
+article h4 {
+  font-size: 1.1rem !important;
+  font-weight: 600 !important;
 }
 
 .skeleton-container {

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -4,8 +4,12 @@
  * work well for content-centric websites.
  */
 
+@import url("https://fonts.googleapis.com/css2?family=Google+Sans:wght@400;500;600;700&display=swap");
+
 /* You can override the default Infima variables here. */
 :root {
+  --ifm-font-family-base: "Google Sans", system-ui, -apple-system, sans-serif;
+  --ifm-heading-font-family: "Google Sans", system-ui, -apple-system, sans-serif;
   --ifm-color-primary: #1877f2;
   --ifm-color-primary-dark: #166bda;
   --ifm-color-primary-darker: #1564ce;
@@ -526,25 +530,31 @@ body {
 
 article header h1 {
   text-align: left !important;
-  font-size: 2rem !important;
+  font-size: 1.9rem !important;
   font-weight: 600 !important;
   text-shadow: 0 0 0.8px currentColor;
+  letter-spacing: -0.025em;
+  margin-bottom: 0.6rem !important;
 }
 
 article h2 {
   font-size: 1.5rem !important;
   font-weight: 630 !important;
+  letter-spacing: -0.025em;
+  margin-bottom: 0.8rem !important;
 }
 
 article h3 {
   font-size: 1.25rem !important;
   font-weight: 600 !important;
   text-shadow: 0 0 0.5px currentColor;
+  letter-spacing: -0.025em;
 }
 
 article h4 {
   font-size: 1.1rem !important;
   font-weight: 600 !important;
+  letter-spacing: -0.025em;
 }
 
 .skeleton-container {

--- a/src/theme/DocItem/index.tsx
+++ b/src/theme/DocItem/index.tsx
@@ -1,0 +1,20 @@
+import React from "react"
+import DocItem from "@theme-original/DocItem"
+import type DocItemType from "@theme/DocItem"
+import type { WrapperProps } from "@docusaurus/types"
+import { useCurrentSidebarCategory } from "@docusaurus/theme-common/internal"
+type Props = WrapperProps<typeof DocItemType>
+
+export default function DocItemWrapper(props: Props): React.JSX.Element {
+  const currentCategory = useCurrentSidebarCategory() as
+    | { label: string }
+    | undefined
+  return (
+    <>
+      {currentCategory && (
+        <div className="doc-section-subtitle">{currentCategory.label}</div>
+      )}
+      <DocItem {...props} />
+    </>
+  )
+}


### PR DESCRIPTION
fix #179
/claim #179

Targets issues:
- There should be a small subtitle with the section name at the top of docs
- Docs should be centered without the right-side outline
- Removed hash dependency
- Fixed subtitle alignment on smaller screens
- Removed subtitle kerning
- Reduced header/subheader sizes to match Mintlify
- Adjusted icon size and height to match title
- Fixed pitch-black color of left headers
- Matched left margin length with sidebar content
- and more...