### PR TITLE
Fix Quickstart CLI localhost URL scheme

### DIFF
--- a/docs/intro/quickstart-cli.md
+++ b/docs/intro/quickstart-cli.md
@@ -33,7 +33,7 @@ Next, start the development server by running `tsci dev`. This will start a loca
 
 ![tsci dev result](../../static/img/tsci-dev.png)
 
-Go to https://localhost:3020. You can now see PCB, Schematic and 3D views of your circuit, which update in real-time as you make changes to your code.
+Go to http://localhost:3020. You can now see PCB, Schematic and 3D views of your circuit, which update in real-time as you make changes to your code.
 
 ![browser](../../static/img/pcb-runframe.png)
 


### PR DESCRIPTION
## Summary
- correct the Quickstart CLI guide to use the HTTP localhost URL when accessing the dev server

## Testing
- bunx tsc --noEmit
- bun run format

------
https://chatgpt.com/codex/tasks/task_b_68e68605f920832e8949965112eb2fe0