### PR TITLE
Implemented Mintlify-like Copy Page button #191

### DIFF
--- a/src/components/CopyPageButton.tsx
+++ b/src/components/CopyPageButton.tsx
@@ -1,0 +1,133 @@
+import React, { useState, useRef, useEffect } from "react";
+import { useDoc } from "@docusaurus/theme-common/internal";
+import { useLocation } from "@docusaurus/router";
+
+const CopyPageButton: React.FC = () => {
+  const {
+    metadata: { permalink, title, source },
+  } = useDoc();
+  const location = useLocation();
+  const [dropdownOpen, setDropdownOpen] = useState(false);
+  const [copyStatus, setCopyStatus] = useState("");
+  const dropdownRef = useRef<HTMLDivElement>(null);
+
+  const handleCopy = async (type: "markdown" | "url") => {
+    let contentToCopy = "";
+    if (type === "markdown") {
+      if (source) {
+        const markdownPath = source.replace(/^@site\//, "/"); // Convert @site/docs/x to /docs/x
+        try {
+          const response = await fetch(markdownPath);
+          if (!response.ok) {
+            throw new Error(`HTTP error! status: ${response.status}`);
+          }
+          contentToCopy = await response.text();
+          setCopyStatus("Copied Markdown");
+        } catch (err) {
+          console.error("Failed to fetch markdown: ", err);
+          contentToCopy = `[${title}](${window.location.href})`; // Fallback to URL
+          setCopyStatus("Failed to copy Markdown (copied URL instead)");
+        }
+      } else {
+        contentToCopy = `[${title}](${window.location.href})`; // Fallback to URL
+        setCopyStatus("Markdown source not found (copied URL instead)");
+      }
+    } else if (type === "url") {
+      contentToCopy = window.location.href;
+      setCopyStatus("Copied URL");
+    }
+
+    try {
+      await navigator.clipboard.writeText(contentToCopy);
+      setTimeout(() => setCopyStatus(""), 2000); // Clear status after 2 seconds
+    } catch (err) {
+      console.error("Failed to copy: ", err);
+      setCopyStatus("Failed to copy!");
+      setTimeout(() => setCopyStatus(""), 2000);
+    }
+    setDropdownOpen(false);
+  };
+
+  const handleClickOutside = (event: MouseEvent) => {
+    if (
+      dropdownRef.current &&
+      !dropdownRef.current.contains(event.target as Node)
+    ) {
+      setDropdownOpen(false);
+    }
+  };
+
+  useEffect(() => {
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => {
+      document.removeEventListener("mousedown", handleClickOutside);
+    };
+  }, []);
+
+  return (
+    <div
+      style={{ position: "relative", display: "inline-block" }}
+      ref={dropdownRef}
+    >
+      <button
+        onClick={() => setDropdownOpen(!dropdownOpen)}
+        style={{
+          padding: "8px 12px",
+          borderRadius: "5px",
+          border: "1px solid #ccc",
+          backgroundColor: "#f0f0f0",
+          cursor: "pointer",
+        }}
+      >
+        Copy Page
+      </button>
+      {dropdownOpen && (
+        <div
+          style={{
+            position: "absolute",
+            top: "100%",
+            left: 0,
+            backgroundColor: "white",
+            border: "1px solid #ccc",
+            borderRadius: "5px",
+            boxShadow: "0px 8px 16px 0px rgba(0,0,0,0.2)",
+            zIndex: 1,
+            minWidth: "200px",
+          }}
+        >
+          <button
+            onClick={() => handleCopy("markdown")}
+            style={{
+              width: "100%",
+              padding: "10px",
+              border: "none",
+              backgroundColor: "transparent",
+              textAlign: "left",
+              cursor: "pointer",
+            }}
+          >
+            Copy page as Markdown for LLMs
+          </button>
+          <button
+            onClick={() => handleCopy("url")}
+            style={{
+              width: "100%",
+              padding: "10px",
+              border: "none",
+              backgroundColor: "transparent",
+              textAlign: "left",
+              cursor: "pointer",
+            }}
+          >
+            Copy page URL
+          </button>
+        </div>
+      )}
+      {copyStatus && (
+        <span style={{ marginLeft: "10px", color: "green" }}>{copyStatus}</span>
+      )}
+    </div>
+  );
+};
+
+export default CopyPageButton;

--- a/src/theme/DocItem/Content/index.tsx
+++ b/src/theme/DocItem/Content/index.tsx
@@ -1,0 +1,24 @@
+import React, { type ReactNode } from "react";
+import Content from "@theme-original/DocItem/Content";
+import type ContentType from "@theme/DocItem/Content";
+import type { WrapperProps } from "@docusaurus/types";
+import CopyPageButton from "../../../components/CopyPageButton"; // Import the new component
+
+type Props = WrapperProps<typeof ContentType>;
+
+export default function ContentWrapper(props: Props): ReactNode {
+  return (
+    <>
+      <div
+        style={{
+          display: "flex",
+          justifyContent: "flex-end",
+          marginBottom: "20px",
+        }}
+      >
+        <CopyPageButton />
+      </div>
+      <Content {...props} />
+    </>
+  );
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,8 +1,35 @@
 {
-  // This file is not used in compilation. It is here just for a nice editor experience.
-  "extends": "@docusaurus/tsconfig",
   "compilerOptions": {
-    "baseUrl": "."
+    "allowJs": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "isolatedModules": true,
+    "jsx": "react-jsx",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "moduleResolution": "node",
+    "noEmit": true,
+    "noFallthroughCasesInSwitch": true,
+    "resolveJsonModule": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "target": "esnext",
+    "allowSyntheticDefaultImports": true,
+    "module": "esnext",
+    "incremental": true,
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ],
+    "paths": {
+      "@/*": ["./*"],
+      "@theme/*": ["./src/theme/*"],
+      "@theme-original/*": [
+        "./.docusaurus/docusaurus-plugin-content-docs/default/theme/*"
+      ],
+      "@docusaurus/types": ["./node_modules/@docusaurus/types/src/index.d.ts"]
+    }
   },
-  "exclude": [".docusaurus", "build"]
+  "include": ["**/*.ts", "**/*.tsx", "**/*.js", "**/*.jsx"],
+  "exclude": ["node_modules", ".docusaurus", "build"]
 }


### PR DESCRIPTION
- __Created `docs/src/components/CopyPageButton.tsx`__:

  - This new React component implements a "Copy Page" button with a dropdown menu.
  - It includes functionality to copy the current page's URL.
  - It also attempts to fetch the raw Markdown content of the current page using `useDoc().metadata.source` and the `fetch` API, falling back to copying the URL if the Markdown content cannot be retrieved.
  - The component manages its dropdown state and handles clicks outside the dropdown to close it.

- __Modified `docs/tsconfig.json`__:

  - Updated the TypeScript compiler options to correctly support JSX (`"jsx": "react-jsx"`) and module resolution (`"moduleResolution": "node"`), along with other standard settings for a Docusaurus React project.
  - Added explicit `paths` mappings for Docusaurus-specific module aliases (`@theme/*`, `@theme-original/*`, `@docusaurus/types`) to resolve TypeScript errors.

- __Modified `docs/src/theme/DocItem/Content/index.tsx`__:

  - Imported the `CopyPageButton` component into this Docusaurus theme wrapper component.
  - Rendered the `CopyPageButton` at the top right of the documentation content area, using inline styles for positioning.
  - Corrected the relative import path for `CopyPageButton` to `../../../components/CopyPageButton` to ensure correct module resolution.
 /claim #191