### PR TITLE
feat: Implement Mintlify-like Copy Page button

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -9,10 +9,12 @@
         "@docusaurus/preset-classic": "3.8.1",
         "@docusaurus/theme-mermaid": "3.8.1",
         "@mdx-js/react": "^3.0.0",
+        "@types/turndown": "^5.0.5",
         "clsx": "^2.1.1",
         "prism-react-renderer": "^2.3.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
+        "turndown": "^7.2.1"
       },
       "devDependencies": {
         "@biomejs/biome": "^1.9.4",
@@ -508,6 +510,8 @@
 
     "@mermaid-js/parser": ["@mermaid-js/parser@0.6.2", "", { "dependencies": { "langium": "3.3.1" } }, "sha512-+PO02uGF6L6Cs0Bw8RpGhikVvMWEysfAyl27qTlroUB8jSWr1lL0Sf6zi78ZxlSnmgSY2AMMKVgghnN9jTtwkQ=="],
 
+    "@mixmark-io/domino": ["@mixmark-io/domino@2.2.0", "", {}, "sha512-Y28PR25bHXUg88kCV7nivXrP2Nj2RueZ3/l/jdx6J9f8J4nsEGcgX0Qe6lt7Pa+J79+kPiJU3LguR6O/6zrLOw=="],
+
     "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.18.2", "", { "dependencies": { "ajv": "^6.12.6", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.0.1", "express-rate-limit": "^7.5.0", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.23.8", "zod-to-json-schema": "^3.24.1" } }, "sha512-beedclIvFcCnPrYgHsylqiYJVJ/CI47Vyc4tY8no1/Li/O8U4BTlJfy6ZwxkYwx+Mx10nrgwSVrA7VBbhh4slg=="],
 
     "@napi-rs/nice": ["@napi-rs/nice@1.1.1", "", { "optionalDependencies": { "@napi-rs/nice-android-arm-eabi": "1.1.1", "@napi-rs/nice-android-arm64": "1.1.1", "@napi-rs/nice-darwin-arm64": "1.1.1", "@napi-rs/nice-darwin-x64": "1.1.1", "@napi-rs/nice-freebsd-x64": "1.1.1", "@napi-rs/nice-linux-arm-gnueabihf": "1.1.1", "@napi-rs/nice-linux-arm64-gnu": "1.1.1", "@napi-rs/nice-linux-arm64-musl": "1.1.1", "@napi-rs/nice-linux-ppc64-gnu": "1.1.1", "@napi-rs/nice-linux-riscv64-gnu": "1.1.1", "@napi-rs/nice-linux-s390x-gnu": "1.1.1", "@napi-rs/nice-linux-x64-gnu": "1.1.1", "@napi-rs/nice-linux-x64-musl": "1.1.1", "@napi-rs/nice-openharmony-arm64": "1.1.1", "@napi-rs/nice-win32-arm64-msvc": "1.1.1", "@napi-rs/nice-win32-ia32-msvc": "1.1.1", "@napi-rs/nice-win32-x64-msvc": "1.1.1" } }, "sha512-xJIPs+bYuc9ASBl+cvGsKbGrJmS6fAKaSZCnT0lhahT5rhA2VVy9/EcIgd2JhtEuFOJNx7UHNn/qiTPTY4nrQw=="],
@@ -773,6 +777,8 @@
     "@types/sockjs": ["@types/sockjs@0.3.36", "", { "dependencies": { "@types/node": "*" } }, "sha512-MK9V6NzAS1+Ud7JV9lJLFqW85VbC9dq3LmwZCuBe4wBDgKC0Kj/jd8Xl+nSviU+Qc3+m7umHHyHg//2KSa0a0Q=="],
 
     "@types/trusted-types": ["@types/trusted-types@2.0.7", "", {}, "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw=="],
+
+    "@types/turndown": ["@types/turndown@5.0.5", "", {}, "sha512-TL2IgGgc7B5j78rIccBtlYAnkuv8nUQqhQc+DSYV5j9Be9XOcm/SKOVRuA47xAVI3680Tk9B1d8flK2GWT2+4w=="],
 
     "@types/unist": ["@types/unist@3.0.3", "", {}, "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="],
 
@@ -2407,6 +2413,8 @@
     "ts-dedent": ["ts-dedent@2.2.0", "", {}, "sha512-q5W7tVM71e2xjHZTlgfTDoPF/SmqKG5hddq9SzR49CH2hayqRKJtQ4mtRlSxKaJlR/+9rEM+mnBHf7I2/BQcpQ=="],
 
     "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
+
+    "turndown": ["turndown@7.2.1", "", { "dependencies": { "@mixmark-io/domino": "^2.2.0" } }, "sha512-7YiPJw6rLClQL3oUKN3KgMaXeJJ2lAyZItclgKDurqnH61so4k4IH/qwmMva0zpuJc/FhRExBBnk7EbeFANlgQ=="],
 
     "twind": ["twind@0.16.19", "", { "dependencies": { "csstype": "^3.0.5", "htmlparser2": "^6.0.0", "style-vendorizer": "^2.0.0" }, "peerDependencies": { "typescript": "^4.1.0" }, "optionalPeers": ["typescript"] }, "sha512-/9H7I/Xzji6UZ+x1V8/llcQSAI0bINqpZtvAqqTzuU/qAdzRCnrpaME8x57k8tUu2KbosjSQE85sSwcLBGD1DQ=="],
 

--- a/package.json
+++ b/package.json
@@ -23,10 +23,12 @@
     "@docusaurus/preset-classic": "3.8.1",
     "@docusaurus/theme-mermaid": "3.8.1",
     "@mdx-js/react": "^3.0.0",
+    "@types/turndown": "^5.0.5",
     "clsx": "^2.1.1",
     "prism-react-renderer": "^2.3.0",
     "react": "^19.0.0",
-    "react-dom": "^19.0.0"
+    "react-dom": "^19.0.0",
+    "turndown": "^7.2.1"
   },
   "devDependencies": {
     "@biomejs/biome": "^1.9.4",

--- a/src/components/CopyPageButton/CopyPageButton.css
+++ b/src/components/CopyPageButton/CopyPageButton.css
@@ -1,0 +1,199 @@
+:root {
+  --background-light: #ffffff;
+  --background-dark: #1e1e1e;
+  --text-primary-light: #27272a;
+  --text-primary-dark: #e4e4e7;
+  --text-secondary-light: #6b7280;
+  --text-secondary-dark: #5e5e61ff;
+  --border-light: #e5e7eb;
+  --border-dark: rgba(255, 255, 255, 0.07);
+  --hover-light: rgba(100, 116, 139, 0.05);
+  --hover-dark: rgba(203, 213, 225, 0.05);
+  --shadow: 0 10px 15px -3px rgb(0 0 0 / 0.1), 0 4px 6px -4px rgb(0 0 0 / 0.1);
+}
+
+.copy-page-container {
+  position: relative;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen,
+    Ubuntu, Cantarell, "Open Sans", "Helvetica Neue", sans-serif;
+  color: var(--text-primary-light);
+  margin-bottom: 4px;
+}
+
+html[data-theme="dark"] .copy-page-container {
+  color: var(--text-primary-dark);
+}
+
+.button-group {
+  display: flex;
+  align-items: center;
+}
+
+.copy-page-base-button {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  border: 1px solid var(--border-light);
+  background-color: var(--background-light);
+  cursor: pointer;
+  transition: background-color 0.2s ease-in-out;
+  font-size: 14px;
+  font-weight: 500;
+  height: 38px;
+}
+
+.copy-page-base-button:hover {
+  background-color: var(--hover-light);
+}
+
+html[data-theme="dark"] .copy-page-base-button {
+  border-color: var(--border-dark);
+  background-color: var(--background-dark);
+}
+html[data-theme="dark"] .copy-page-base-button:hover {
+  background-color: var(--hover-dark);
+}
+
+.copy-button {
+  border-right: none;
+  border-radius: 12px 0 0 12px;
+  padding: 0 12px;
+  min-width: 110px;
+}
+
+.copy-button .icon {
+  width: 16px;
+  height: 16px;
+}
+
+.menu-trigger-button {
+  border-radius: 0 12px 12px 0;
+  padding: 0 12px;
+}
+
+.menu-trigger-button .icon {
+  width: 8px;
+  height: 24px;
+  color: var(--text-secondary-light);
+  transition: transform 0.2s ease-in-out, color 0.2s ease-in-out;
+}
+
+.menu-trigger-button:hover .icon {
+  color: var(--text-primary-light);
+}
+
+.menu-trigger-button.open .icon {
+  transform: rotate(90deg);
+}
+
+html[data-theme="dark"] .menu-trigger-button .icon {
+  color: var(--text-secondary-dark);
+}
+html[data-theme="dark"] .menu-trigger-button:hover .icon {
+  color: var(--text-primary-dark);
+}
+
+@keyframes fadeInUp {
+  from {
+    opacity: 0;
+    transform: translateY(10px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.dropdown-menu {
+  position: absolute;
+  top: calc(100% + 8px);
+  left: 0;
+  z-index: 10;
+  width: max-content;
+  min-width: 260px;
+  padding: 6px;
+  background-color: var(--background-light);
+  border: 1px solid var(--border-light);
+  border-radius: 12px;
+  box-shadow: var(--shadow);
+  animation: fadeInUp 0.2s ease-out;
+}
+
+html[data-theme="dark"] .dropdown-menu {
+  background-color: var(--background-dark);
+  border-color: var(--border-dark);
+}
+
+.menu-item {
+  border: none;
+  background: none;
+  display: block;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 10px;
+  border-radius: 12px;
+  text-decoration: none;
+  color: inherit;
+  cursor: pointer;
+  transition: background-color 0.15s ease-in-out;
+}
+
+.menu-item-wrapper {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: 8px;
+}
+
+.menu-item:hover {
+  background-color: var(--hover-light);
+}
+
+html[data-theme="dark"] .menu-item:hover {
+  background-color: var(--hover-dark);
+}
+
+.menu-item-icon-container {
+  display: flex;
+  border: 1px solid var(--border-light);
+  border-radius: 8px;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+}
+
+.menu-item .icon {
+  border: 1px solid var(--border-light);
+  border-radius: 4px;
+  width: 12px;
+  height: 12px;
+  color: var(--text-secondary-light);
+}
+
+html[data-theme="dark"] .menu-item .icon {
+  color: var(--text-secondary-dark);
+}
+
+.menu-item-text-container {
+  display: flex;
+  flex-direction: column;
+  line-height: 1.2;
+}
+
+.menu-item-text {
+  flex-grow: 1;
+  font-size: 16px;
+  font-weight: 400;
+}
+
+.menu-item-description {
+  font-size: 14px;
+  color: var(--text-secondary-dark);
+}
+
+html[data-theme="dark"] .menu-item .external-link-icon {
+  color: var(--text-secondary-dark);
+}

--- a/src/components/CopyPageButton/CopyPageButton.tsx
+++ b/src/components/CopyPageButton/CopyPageButton.tsx
@@ -1,0 +1,179 @@
+import { useState, useRef, useEffect } from "react"
+import TurndownService from "turndown"
+import "./CopyPageButton.css"
+import {
+  CopyIcon,
+  ChevronIcon,
+  ExternalLinkIcon,
+  ChatGPTIcon,
+  ClaudeIcon,
+} from "./icons"
+
+interface MenuItem {
+  id: number
+  label: string
+  description: string
+  icon: React.ElementType
+  action: () => void
+  isExternal?: boolean
+}
+
+export const CopyPageButton: React.FC = () => {
+  const [isMenuOpen, setIsMenuOpen] = useState(false)
+  const [copyButtonText, setCopyButtonText] = useState("Copy page")
+  const containerRef = useRef<HTMLDivElement>(null)
+
+  const handleCopyPage = async () => {
+    const articleElement = document.querySelector("article")
+
+    if (!articleElement) {
+      console.error("Couldn't find the main <article> element to copy.")
+      setCopyButtonText("Error!")
+      setTimeout(() => setCopyButtonText("Copy page"), 2000)
+      return
+    }
+
+    try {
+      // Initialize the HTML-to-Markdown converter
+      const turndownService = new TurndownService({
+        headingStyle: "atx",
+        codeBlockStyle: "fenced",
+      })
+
+      // Convert the article's HTML to Markdown
+      const markdown = turndownService.turndown(articleElement)
+
+      // Copy the Markdown to the clipboard
+      await navigator.clipboard.writeText(markdown)
+
+      setCopyButtonText("Copied!")
+      setTimeout(() => setCopyButtonText("Copy page"), 2000)
+    } catch (err) {
+      console.error("Failed to copy page as Markdown: ", err)
+      setCopyButtonText("Copy failed")
+      setTimeout(() => setCopyButtonText("Copy page"), 2000)
+    }
+    setIsMenuOpen(false) // Close menu after action
+  }
+
+  const handleOpenInAI = (platform: "chatgpt" | "claude") => () => {
+    if (typeof window === "undefined") return
+    const currentPageUrl = window.location.href
+    const promptText = `Read from ${currentPageUrl} so I can ask questions about it.`
+    const encodedPrompt = encodeURIComponent(promptText)
+
+    let finalUrl = ""
+    if (platform === "chatgpt") {
+      finalUrl = `https://chat.openai.com/?hints=search&q=${encodedPrompt}`
+    } else if (platform === "claude") {
+      finalUrl = `https://claude.ai/new?q=${encodedPrompt}`
+    }
+
+    if (finalUrl) {
+      window.open(finalUrl, "_blank", "noopener,noreferrer")
+    }
+    setIsMenuOpen(false)
+  }
+
+  const openLink = (url: string) => () => {
+    window.open(url, "_blank", "noopener,noreferrer")
+    setIsMenuOpen(false)
+  }
+
+  const menuItems: MenuItem[] = [
+    {
+      id: 1,
+      label: "Copy page",
+      description: "Copy page as Markdown for LLMs",
+      icon: CopyIcon,
+      action: handleCopyPage,
+    },
+    {
+      id: 2,
+      label: "Open in ChatGPT",
+      description: "Ask questions about this page",
+      icon: ChatGPTIcon,
+      action: handleOpenInAI("chatgpt"),
+      isExternal: true,
+    },
+    {
+      id: 3,
+      label: "Open in Claude",
+      description: "Ask questions about this page",
+      icon: ClaudeIcon,
+      action: handleOpenInAI("claude"),
+      isExternal: true,
+    },
+  ]
+
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (
+        containerRef.current &&
+        !containerRef.current.contains(event.target as Node)
+      ) {
+        setIsMenuOpen(false)
+      }
+    }
+    document.addEventListener("mousedown", handleClickOutside)
+    return () => {
+      document.removeEventListener("mousedown", handleClickOutside)
+    }
+  }, [])
+
+  return (
+    <div className="copy-page-container" ref={containerRef}>
+      <div className="button-group">
+        <button
+          type="button"
+          className="copy-page-base-button copy-button"
+          onClick={handleCopyPage}
+        >
+          <CopyIcon className="icon" />
+          <span>{copyButtonText}</span>
+        </button>
+        <button
+          type="button"
+          className={`copy-page-base-button menu-trigger-button ${isMenuOpen ? "open" : ""}`}
+          onClick={() => setIsMenuOpen((prev) => !prev)}
+          aria-haspopup="true"
+          aria-expanded={isMenuOpen}
+        >
+          <ChevronIcon className="icon" />
+        </button>
+      </div>
+
+      {isMenuOpen && (
+        <div className="dropdown-menu" role="menu">
+          {menuItems.map((item) => (
+            <button
+              key={item.id}
+              onClick={item.action}
+              className="menu-item"
+              role="menuitem"
+              type="button"
+            >
+              <div className="menu-item-wrapper">
+                <div className="menu-item-icon-container">
+                  <item.icon className="icon" />
+                </div>
+
+                <div className="menu-item-text-container">
+                  <div className="menu-item-label">
+                    <span className="menu-item-text">{item.label}</span>
+                    {item.isExternal && <ExternalLinkIcon />}
+                  </div>
+                  <span className="menu-item-description">
+                    {item.description}
+                  </span>
+                </div>
+              </div>
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}
+
+export default CopyPageButton

--- a/src/components/CopyPageButton/icons.tsx
+++ b/src/components/CopyPageButton/icons.tsx
@@ -1,0 +1,94 @@
+import React from "react"
+
+type IconProps = {
+  className?: string
+}
+
+export const CopyIcon = ({ className }: IconProps) => (
+  <svg
+    width="18"
+    height="18"
+    viewBox="0 0 18 18"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+    className="w-4 h-4 shrink-0"
+  >
+    <title>Copy</title>
+    <path
+      d="M14.25 5.25H7.25C6.14543 5.25 5.25 6.14543 5.25 7.25V14.25C5.25 15.3546 6.14543 16.25 7.25 16.25H14.25C15.3546 16.25 16.25 15.3546 16.25 14.25V7.25C16.25 6.14543 15.3546 5.25 14.25 5.25Z"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    <path
+      d="M2.80103 11.998L1.77203 5.07397C1.61003 3.98097 2.36403 2.96397 3.45603 2.80197L10.38 1.77297C11.313 1.63397 12.19 2.16297 12.528 3.00097"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+  </svg>
+)
+
+export const ChevronIcon = ({ className }: IconProps) => (
+  <svg width="18" height="24" viewBox="0 -9 3 24" className="w-4 h-4 shrink-0">
+    <title>Chevron</title>
+    <path
+      d="M0 0L3 3L0 6"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+    />
+  </svg>
+)
+
+export const ExternalLinkIcon = ({ className }: IconProps) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    width="12"
+    height="12"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    stroke-width="2"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+    className="w-2 h-2 shrink-0"
+  >
+    <title>External Link</title>
+    <path d="M7 7h10v10" />
+    <path d="M7 17 17 7" />
+  </svg>
+)
+
+export const ChatGPTIcon = ({ className }: IconProps) => (
+  <svg
+    fill="currentColor"
+    fill-rule="evenodd"
+    height="1em"
+    viewBox="0 0 24 24"
+    width="1em"
+    xmlns="http://www.w3.org/2000/svg"
+    className="w-4 h-4 shrink-0"
+  >
+    <title>OpenAI</title>
+    <path d="M21.55 10.004a5.416 5.416 0 00-.478-4.501c-1.217-2.09-3.662-3.166-6.05-2.66A5.59 5.59 0 0010.831 1C8.39.995 6.224 2.546 5.473 4.838A5.553 5.553 0 001.76 7.496a5.487 5.487 0 00.691 6.5 5.416 5.416 0 00.477 4.502c1.217 2.09 3.662 3.165 6.05 2.66A5.586 5.586 0 0013.168 23c2.443.006 4.61-1.546 5.361-3.84a5.553 5.553 0 003.715-2.66 5.488 5.488 0 00-.693-6.497v.001zm-8.381 11.558a4.199 4.199 0 01-2.675-.954c.034-.018.093-.05.132-.074l4.44-2.53a.71.71 0 00.364-.623v-6.176l1.877 1.069c.02.01.033.029.036.05v5.115c-.003 2.274-1.87 4.118-4.174 4.123zM4.192 17.78a4.059 4.059 0 01-.498-2.763c.032.02.09.055.131.078l4.44 2.53c.225.13.504.13.73 0l5.42-3.088v2.138a.068.068 0 01-.027.057L9.9 19.288c-1.999 1.136-4.552.46-5.707-1.51h-.001zM3.023 8.216A4.15 4.15 0 015.198 6.41l-.002.151v5.06a.711.711 0 00.364.624l5.42 3.087-1.876 1.07a.067.067 0 01-.063.005l-4.489-2.559c-1.995-1.14-2.679-3.658-1.53-5.63h.001zm15.417 3.54l-5.42-3.088L14.896 7.6a.067.067 0 01.063-.006l4.489 2.557c1.998 1.14 2.683 3.662 1.529 5.633a4.163 4.163 0 01-2.174 1.807V12.38a.71.71 0 00-.363-.623zm1.867-2.773a6.04 6.04 0 00-.132-.078l-4.44-2.53a.731.731 0 00-.729 0l-5.42 3.088V7.325a.068.068 0 01.027-.057L14.1 4.713c2-1.137 4.555-.46 5.707 1.513.487.833.664 1.809.499 2.757h.001zm-11.741 3.81l-1.877-1.068a.065.065 0 01-.036-.051V6.559c.001-2.277 1.873-4.122 4.181-4.12.976 0 1.92.338 2.671.954-.034.018-.092.05-.131.073l-4.44 2.53a.71.71 0 00-.365.623l-.003 6.173v.002zm1.02-2.168L12 9.25l2.414 1.375v2.75L12 14.75l-2.415-1.375v-2.75z" />
+  </svg>
+)
+
+export const ClaudeIcon = ({ className }: IconProps) => (
+  <svg
+    fill="currentColor"
+    fill-rule="evenodd"
+    height="1em"
+    viewBox="0 0 24 24"
+    width="1em"
+    xmlns="http://www.w3.org/2000/svg"
+    className="w-4 h-4 shrink-0"
+  >
+    <title>Anthropic</title>
+    <path d="M13.827 3.52h3.603L24 20h-3.603l-6.57-16.48zm-7.258 0h3.767L16.906 20h-3.674l-1.343-3.461H5.017l-1.344 3.46H0L6.57 3.522zm4.132 9.959L8.453 7.687 6.205 13.48H10.7z" />
+  </svg>
+)

--- a/src/theme/DocItem/Layout/index.tsx
+++ b/src/theme/DocItem/Layout/index.tsx
@@ -55,15 +55,6 @@ export default function DocItemLayout({ children }: Props): ReactNode {
           <article>
             <DocBreadcrumbs />
             <DocVersionBadge />
-            {/* We render our own custom header with the title and the button.
-            We'll hide the one inside DocItemContent with CSS. */}
-
-            {/* {!hideTitle && ( */}
-            {/* // <header className="doc-page-header"> */}
-            {/* <h1 className={styles.docTitle}>{title}</h1> */}
-            {/* </header> */}
-            {/* )} */}
-
             {docTOC.mobile}
             <DocItemContent>
               <CopyPageButton />

--- a/src/theme/DocItem/Layout/index.tsx
+++ b/src/theme/DocItem/Layout/index.tsx
@@ -1,0 +1,80 @@
+import React, { type ReactNode } from "react"
+import clsx from "clsx"
+import { useWindowSize } from "@docusaurus/theme-common"
+import { useDoc } from "@docusaurus/plugin-content-docs/client"
+import DocItemPaginator from "@theme/DocItem/Paginator"
+import DocVersionBanner from "@theme/DocVersionBanner"
+import DocVersionBadge from "@theme/DocVersionBadge"
+import DocItemFooter from "@theme/DocItem/Footer"
+import DocItemTOCMobile from "@theme/DocItem/TOC/Mobile"
+import DocItemTOCDesktop from "@theme/DocItem/TOC/Desktop"
+import DocItemContent from "@theme/DocItem/Content"
+import DocBreadcrumbs from "@theme/DocBreadcrumbs"
+import ContentVisibility from "@theme/ContentVisibility"
+import type { Props } from "@theme/DocItem/Layout"
+
+import styles from "./styles.module.css"
+
+import { CopyPageButton } from "@site/src/components/CopyPageButton/CopyPageButton"
+import "@site/src/components/CopyPageButton/CopyPageButton.css"
+
+/**
+ * Decide if the toc should be rendered, on mobile or desktop viewports
+ */
+function useDocTOC() {
+  const { frontMatter, toc, metadata } = useDoc()
+  const windowSize = useWindowSize()
+
+  const hidden = frontMatter.hide_table_of_contents
+  const canRender = !hidden && toc.length > 0
+
+  const mobile = canRender ? <DocItemTOCMobile /> : undefined
+
+  const desktop =
+    canRender && (windowSize === "desktop" || windowSize === "ssr") ? (
+      <DocItemTOCDesktop />
+    ) : undefined
+
+  return {
+    hidden,
+    mobile,
+    desktop,
+  }
+}
+
+export default function DocItemLayout({ children }: Props): ReactNode {
+  const docTOC = useDocTOC()
+  const { metadata } = useDoc()
+
+  return (
+    <div className="row">
+      <div className={clsx("col", !docTOC.hidden && styles.docItemCol)}>
+        <ContentVisibility metadata={metadata} />
+        <DocVersionBanner />
+        <div className={styles.docItemContainer}>
+          <article>
+            <DocBreadcrumbs />
+            <DocVersionBadge />
+            {/* We render our own custom header with the title and the button.
+            We'll hide the one inside DocItemContent with CSS. */}
+
+            {/* {!hideTitle && ( */}
+            {/* // <header className="doc-page-header"> */}
+            {/* <h1 className={styles.docTitle}>{title}</h1> */}
+            {/* </header> */}
+            {/* )} */}
+
+            {docTOC.mobile}
+            <DocItemContent>
+              <CopyPageButton />
+              {children}
+            </DocItemContent>
+            <DocItemFooter />
+          </article>
+          <DocItemPaginator />
+        </div>
+      </div>
+      {docTOC.desktop && <div className="col col--3">{docTOC.desktop}</div>}
+    </div>
+  )
+}

--- a/src/theme/DocItem/Layout/styles.module.css
+++ b/src/theme/DocItem/Layout/styles.module.css
@@ -1,0 +1,10 @@
+.docItemContainer header + *,
+.docItemContainer article > *:first-child {
+  margin-top: 0;
+}
+
+@media (min-width: 997px) {
+  .docItemCol {
+    max-width: 75% !important;
+  }
+}


### PR DESCRIPTION
## Summary

This PR introduces a **Mintlify-style "Copy Page" button** and context menu to all documentation pages.
Previously, there was no built-in functionality for users to quickly copy page content or access related actions like opening the page context in an AI assistant.

* Created a new standalone `CopyPageButton` React component with a dropdown menu for actions like "Open in ChatGPT."
* Swizzled the Docusaurus `DocItem/Layout` theme component to integrate the button directly next to the page title.
* Added responsive CSS to ensure the button is correctly positioned on both desktop (inline) and mobile (stacked) views.
* Makes use of `Turndown` to accurately convert page content to markdown format.

---

## **Changes**

* **`src/components/CopyPageButton/`** – Added the new `CopyPageButton.tsx`, `CopyPageButton.css`, and `icons.tsx` files, creating a fully encapsulated component.
* **`src/theme/DocItem/Layout/index.tsx`** – Created via swizzle. This file is modified to render a custom header containing both the page title and the new `CopyPageButton` component.
* **`src/css/custom.css`** – Appended CSS rules to create a responsive layout for the new header and to hide the duplicate title automatically rendered by Docusaurus from the page's markdown.

---

## **Result**

* Every documentation page now features a "Copy Page" button with a context menu, improving user experience and providing quick access to page-related actions.
* The button and title are displayed inline on desktop and stack vertically on mobile, providing a clean, responsive layout.
* The "Copy page" action now correctly converts the content of the `<article>` tag into Markdown for the user's clipboard.

<img width="1214" height="499" alt="image" src="https://github.com/user-attachments/assets/7c67c1e9-e872-456a-a065-32b44778b584" />


---

## **Note**

>The Markdown conversion has a known limitation with images. Images of code are not converted into text, and locally hosted images may appear broken when pasted into external Markdown viewers.

---
/closes #191 
/claim #191 