### PR TITLE
Fix the `Copy page` markdown generation by filtering out unnecessary text and fix the appearing on mobile view

### DIFF
--- a/src/components/CopyPageButton.tsx
+++ b/src/components/CopyPageButton.tsx
@@ -32,15 +32,40 @@ export default function CopyPageButton() {
     const article = document.querySelector("article")
     if (!article) return ""
 
+    // Clone the article to avoid modifying the actual DOM
+    const articleClone = article.cloneNode(true) as HTMLElement
+
+    // Remove unwanted elements
+    const selectorsToRemove = [
+      ".copy-page-button-container",
+      ".theme-edit-this-page",
+      ".theme-last-updated",
+      ".pagination-nav",
+      'nav[aria-label="Docs pages"]',
+      ".theme-doc-version-badge",
+      ".theme-doc-version-banner",
+      ".tocCollapsible_node_modules-\\@docusaurus-theme-classic-lib-theme-TOC-styles-module",
+      ".theme-doc-breadcrumbs",
+    ]
+
+    selectorsToRemove.forEach((selector) => {
+      const elements = articleClone.querySelectorAll(selector)
+      elements.forEach((el) => el.remove())
+    })
+
     // Get title
     const title =
       document.querySelector("h1")?.textContent || document.title || ""
 
     // Get the content as text
-    let content = article.innerText || article.textContent || ""
+    let content = articleClone.innerText || articleClone.textContent || ""
 
-    // Clean up the content
-    content = content.trim()
+    // Clean up the content - remove extra whitespace
+    content = content
+      .split("\n")
+      .map((line) => line.trim())
+      .filter((line) => line.length > 0)
+      .join("\n\n")
 
     return `# ${title}\n\n${content}`
   }

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -857,6 +857,15 @@ article,
   box-sizing: border-box;
 }
 
+@media (max-width: 768px) {
+  .copy-page-dropdown {
+    left: 0;
+    right: auto;
+    width: calc(100vw - 2rem);
+    max-width: 20rem;
+  }
+}
+
 .copy-page-dropdown.light {
   background: #ffffff;
   border-color: #e5e7eb;

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -857,12 +857,10 @@ article,
   box-sizing: border-box;
 }
 
-@media (max-width: 768px) {
+@media (max-width: 500px) {
   .copy-page-dropdown {
     left: 0;
     right: auto;
-    width: calc(100vw - 2rem);
-    max-width: 20rem;
   }
 }
 

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -726,7 +726,7 @@ article,
   flex-shrink: 0;
 }
 
-@media (max-width: 768px) {
+@media (max-width: 500px) {
   .copy-page-button-container {
     margin-right: 0;
     margin-left: 0.9rem;

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -721,8 +721,16 @@ article,
 /* Copy Page Button Styles - Mintlify Design */
 .copy-page-button-container {
   position: relative;
-  display: inline-block;
+  display: inline-flex;
   margin-right: 2rem;
+  flex-shrink: 0;
+}
+
+@media (max-width: 768px) {
+  .copy-page-button-container {
+    margin-right: 0;
+    margin-left: 0.9rem;
+  }
 }
 
 .copy-page-button-wrapper {
@@ -1002,11 +1010,11 @@ article,
 /* Responsive adjustments */
 @media (max-width: 768px) {
   .copy-page-button-text {
-    display: none;
+    display: inline-block;
   }
 
   .copy-page-button-main {
-    padding: 0.375rem;
+    padding: 0.375rem 0.625rem;
   }
 }
 

--- a/src/theme/DocItem/Layout/styles.module.css
+++ b/src/theme/DocItem/Layout/styles.module.css
@@ -38,7 +38,7 @@
   padding-right: 180px;
 }
 
-@media (max-width: 768px) {
+@media (max-width: 500px) {
   .docItemWithButton {
     display: flex;
     flex-direction: column;

--- a/src/theme/DocItem/Layout/styles.module.css
+++ b/src/theme/DocItem/Layout/styles.module.css
@@ -39,8 +39,20 @@
 }
 
 @media (max-width: 768px) {
+  .docItemWithButton {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 1rem;
+  }
+
+  .docItemWithButton :global(.copy-page-button-container) {
+    position: static;
+    align-self: flex-start;
+  }
+
   .docItemWithButton :global(.markdown) > :global(h1):first-child {
-    padding-right: 60px;
+    padding-right: 0;
   }
 }
 

--- a/src/theme/DocItem/Layout/styles.module.css
+++ b/src/theme/DocItem/Layout/styles.module.css
@@ -43,16 +43,17 @@
     display: flex;
     flex-direction: column;
     align-items: flex-start;
-    gap: 1rem;
+    gap: 0.5rem;
   }
 
   .docItemWithButton :global(.copy-page-button-container) {
-    position: static;
+    position: relative;
     align-self: flex-start;
   }
 
   .docItemWithButton :global(.markdown) > :global(h1):first-child {
     padding-right: 0;
+    margin-bottom: 0;
   }
 }
 


### PR DESCRIPTION
<img width="618" height="417" alt="image" src="https://github.com/user-attachments/assets/1706f599-c975-4b32-84e1-45bbf02101db" />



<img width="432" height="535" alt="image" src="https://github.com/user-attachments/assets/f951d067-2cff-4f36-a613-c0fab9738838" />



<img width="441" height="465" alt="image" src="https://github.com/user-attachments/assets/0413d221-03a7-45f6-b444-7b4373b0ee0a" />
