### PR TITLE
Adjust level 3 sidebar link padding

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -481,6 +481,10 @@ figure img {
   padding-right: 16px !important;
 }
 
+.theme-doc-sidebar-item-link-level-3 .menu__link {
+  padding-left: 28px !important;
+}
+
 /* Ensure hover and active states maintain padding */
 .menu__link:hover,
 .menu__link--active {


### PR DESCRIPTION
fixes #210 fixes #206

## Summary
- increase indentation for level 3 sidebar links to improve hierarchy clarity

## Testing
- bunx tsc --noEmit
- bun run format

------
https://chatgpt.com/codex/tasks/task_b_68e9c2303a94832e9d23fd228ea01933