### PR TITLE
Maintain level-3 sidebar indentation on hover

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -492,6 +492,14 @@ figure img {
   padding-right: 16px !important;
 }
 
+/* Preserve level-3 indentation on hover/active */
+.menu__link--level-3,
+.menu__link--level-3:hover,
+.menu__link--level-3.menu__link--active {
+  padding-left: 28px !important;
+  padding-right: 16px !important;
+}
+
 @media (max-width: 768px) {
   iframe {
     max-width: 90vw;

--- a/src/theme/Root.tsx
+++ b/src/theme/Root.tsx
@@ -1,0 +1,50 @@
+import React, { useEffect, type ReactElement } from "react"
+import type { Props } from "@theme/Root"
+import { useLocation } from "@docusaurus/router"
+
+const LEVEL_3_LINK_SELECTOR =
+  ".theme-doc-sidebar-item-link-level-3 > .menu__link"
+const LEVEL_3_PADDING_CLASS = "menu__link--level-3"
+const SIDEBAR_MENU_SELECTOR = ".theme-doc-sidebar-menu"
+
+function applyLevel3PaddingClass() {
+  if (typeof document === "undefined") {
+    return
+  }
+
+  const links = document.querySelectorAll<HTMLAnchorElement>(
+    LEVEL_3_LINK_SELECTOR,
+  )
+  links.forEach((link) => {
+    link.classList.add(LEVEL_3_PADDING_CLASS)
+  })
+}
+
+export default function Root({ children }: Props): ReactElement {
+  const location = useLocation()
+
+  useEffect(() => {
+    if (typeof document === "undefined") {
+      return undefined
+    }
+
+    applyLevel3PaddingClass()
+
+    const sidebarMenu = document.querySelector(SIDEBAR_MENU_SELECTOR)
+    if (!sidebarMenu) {
+      return undefined
+    }
+
+    const observer = new MutationObserver(() => {
+      applyLevel3PaddingClass()
+    })
+
+    observer.observe(sidebarMenu, { childList: true, subtree: true })
+
+    return () => {
+      observer.disconnect()
+    }
+  }, [location])
+
+  return <>{children}</>
+}


### PR DESCRIPTION
## Summary
- add a Docusaurus Root wrapper that tags level-3 sidebar links with a padding class
- update custom CSS so level-3 links keep their indentation on hover and active states

## Testing
- bunx tsc --noEmit
- bun run format

------
https://chatgpt.com/codex/tasks/task_b_68e9c4a2e45c832e920de85560871f42