### PR TITLE
Fix markdown format , Add missing or incomplete description, Add spacing before first para.

### DIFF
--- a/docs/advanced/units.md
+++ b/docs/advanced/units.md
@@ -1,5 +1,6 @@
 ---
 title: tscircuit Units
+description: Understanding default units in tscircuit for length, electrical properties, and other measurements.
 ---
 
 In tscircuit you can specify a unit explicitly with a string e.g. "0.1mm", but

--- a/docs/command-line/tsci-export.md
+++ b/docs/command-line/tsci-export.md
@@ -1,5 +1,6 @@
 ---
 title: tsci export
+description: Export tscircuit files to various formats including SVG schematics, PCB layouts, and fabrication files.
 ---
 
 import ImageWithCaption from "../../src/components/ImageWithCaption"

--- a/docs/contributing/overview-of-projects.md
+++ b/docs/contributing/overview-of-projects.md
@@ -1,6 +1,7 @@
 ---
 title: Overview of Projects
 sidebar_position: 2
+description: Explore the key tscircuit repositories including core libraries, tools, and web components that power the ecosystem.
 ---
 
 | Repo                                                                          | Description                                                                                    | Open Issues                                                                                                                                 |

--- a/docs/contributing/the-contributor-handbook.md
+++ b/docs/contributing/the-contributor-handbook.md
@@ -1,5 +1,6 @@
 ---
 title: The Contributor Handbook
+description: Essential patterns and guidelines for contributing to tscircuit, including development tools and coding standards.
 ---
 
 We have some important patterns that make contributing to

--- a/docs/footprints/silkscreencircle.mdx
+++ b/docs/footprints/silkscreencircle.mdx
@@ -1,5 +1,6 @@
 ---
 title: <silkscreencircle />
+description: Silkscreen circles are often used to indicate "pin1" on a chip.
 ---
 
 ## Overview

--- a/docs/footprints/silkscreenrect.mdx
+++ b/docs/footprints/silkscreenrect.mdx
@@ -1,5 +1,6 @@
 ---
 title: <silkscreenrect />
+description: Silkscreen rectangles can be used to encapsulate a rectangular area around a chip.
 ---
 
 ## Overview

--- a/docs/guides/running-tscircuit/building-static-sites-with-tsci.mdx
+++ b/docs/guides/running-tscircuit/building-static-sites-with-tsci.mdx
@@ -1,5 +1,6 @@
 ---
 title: Building a Static Site
+description: "`tsci build --site` packages your tscircuit project into a static website that anyone can browse without running a server."
 ---
 
 `tsci build --site` packages your tscircuit project into a static website that anyone can browse without running a server. The command evaluates your circuits, exports the generated assets into a `dist` folder, and wires them up to the tscircuit RunFrame viewer so visitors can flip between PCB, schematic, and 3D previews right in the browser.

--- a/docs/intro/installation.md
+++ b/docs/intro/installation.md
@@ -1,6 +1,7 @@
 ---
 title: Installation
 sidebar_position: 2
+description: Install tscircuit CLI globally or per-project to start building electronic circuits with TypeScript.
 ---
 
 ## Dependencies

--- a/docs/tutorials/building-a-simple-usb-flashlight.mdx
+++ b/docs/tutorials/building-a-simple-usb-flashlight.mdx
@@ -1,5 +1,6 @@
 ---
 title: Building a Simple USB Flashlight
+description: Learn how to build a simple USB-powered flashlight circuit using tscircuit with a push button, LED, and USB-C connector.
 ---
 
 ## Overview
@@ -34,4 +35,4 @@ export default () => {
     </board>
   )
 }
-`} />
+`} />

--- a/docs/web-apis/datasheet-sdk.md
+++ b/docs/web-apis/datasheet-sdk.md
@@ -1,6 +1,7 @@
 ---
 title: Retrieve datasheets with the SDK
 sidebar_position: 5
+description: Use the @tscircuit/api SDK to programmatically retrieve and process component datasheets with pin information.
 ---
 
 The [`@tscircuit/api`](https://github.com/tscircuit/api) package provides a

--- a/docs/web-apis/jlcsearch-api.md
+++ b/docs/web-apis/jlcsearch-api.md
@@ -1,6 +1,7 @@
 ---
 title: jlcsearch API
 sidebar_position: 6
+description: Search and query JLCPCB in-stock components with the jlcsearch JSON API for scripting and integration.
 ---
 
 # jlcsearch.tscircuit.com

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -601,7 +601,7 @@ article h4 {
 }
 
 .markdown > p:first-of-type {
-  margin-bottom: 2rem !important;
+  margin-top: 2rem !important;
 }
 
 .skeleton-container {

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -732,6 +732,16 @@ article h4 {
   font-size: 1rem !important;
 }
 
+/* Allow inline code styling in overview pages */
+[class*="generatedIndexPage"] p code {
+  all: revert !important;
+  background: var(--ifm-code-background) !important;
+  border-radius: 3px !important;
+  font-family: var(--ifm-font-family-monospace) !important;
+  padding: var(--ifm-code-padding-vertical) var(--ifm-code-padding-horizontal) !important;
+  font-size: 0.9em !important;
+}
+
 /* Add colon separator between heading and description */
 [class*="generatedIndexPage"] h2::after {
   content: ": " !important;

--- a/src/theme/DocCard/index.tsx
+++ b/src/theme/DocCard/index.tsx
@@ -79,11 +79,22 @@ function CardLayout({
           className={clsx("text--truncate", styles.cardDescription)}
           title={description}
         >
-          {description}
+          {parseInlineMarkdown(description)}
         </p>
       )}
     </CardContainer>
   )
+}
+
+function parseInlineMarkdown(text: string): ReactNode[] {
+  // Convert inline code (backticks) to <code> elements
+  const parts = text.split(/(`[^`]+`)/g)
+  return parts.map((part, i) => {
+    if (part.startsWith("`") && part.endsWith("`")) {
+      return <code key={i}>{part.slice(1, -1)}</code>
+    }
+    return <React.Fragment key={i}>{part}</React.Fragment>
+  })
 }
 
 function NestedItem({
@@ -95,11 +106,15 @@ function NestedItem({
     return (
       <li>
         <Link to={item.href} className={styles.nestedLink}>
-          <span className={styles.nestedTitle}>{item.label}</span>
+          <span className={styles.nestedTitle}>
+            {parseInlineMarkdown(item.label)}
+          </span>
           {description && (
             <>
               <span className={styles.nestedColon}>: </span>
-              <span className={styles.nestedDescription}>{description}</span>
+              <span className={styles.nestedDescription}>
+                {parseInlineMarkdown(description)}
+              </span>
             </>
           )}
         </Link>
@@ -110,12 +125,14 @@ function NestedItem({
     return subHref ? (
       <li>
         <Link to={subHref} className={styles.nestedLink}>
-          <span className={styles.nestedTitle}>{item.label}</span>
+          <span className={styles.nestedTitle}>
+            {parseInlineMarkdown(item.label)}
+          </span>
           {item.description && (
             <>
               <span className={styles.nestedColon}>: </span>
               <span className={styles.nestedDescription}>
-                {item.description}
+                {parseInlineMarkdown(item.description)}
               </span>
             </>
           )}
@@ -148,7 +165,7 @@ function CardCategory({ item }: { item: PropSidebarItemCategory }): ReactNode {
           className={clsx("text--truncate", styles.cardDescription)}
           title={item.description}
         >
-          {item.description}
+          {parseInlineMarkdown(item.description)}
         </p>
       )}
       {item.items.length > 0 && (


### PR DESCRIPTION
- Fix the markdown format:
<img width="1364" height="546" alt="image" src="https://github.com/user-attachments/assets/66dedd13-eb74-40a2-b7ee-e6f84d647e39" />
<img width="1365" height="601" alt="image" src="https://github.com/user-attachments/assets/c392e876-498b-45e1-9415-95d3f571d437" />
<img width="1365" height="601" alt="image" src="https://github.com/user-attachments/assets/5704fcc6-7af7-4f8d-b07e-fbfa8de7d6e7" />


- Fix the missing descriptions:
<img width="1347" height="480" alt="image" src="https://github.com/user-attachments/assets/8c0ddc87-7f4c-48bc-b6fd-68b49edb1a61" />
<img width="1365" height="570" alt="image" src="https://github.com/user-attachments/assets/0b697608-4862-4e6f-a18c-048a7e62e034" />

- Add spacing before first para:
<img width="1365" height="599" alt="image" src="https://github.com/user-attachments/assets/fe8cdef8-fbf7-4595-877e-e4defa9faac0" />

