### PR TITLE
Fix indentation for CircuitPreview code snippets

### DIFF
--- a/src/components/CircuitPreview.tsx
+++ b/src/components/CircuitPreview.tsx
@@ -53,10 +53,6 @@ const formatCodeForDisplay = (rawCode?: string) => {
       continue
     }
 
-    if (/^[\t ]/.test(lines[i])) {
-      continue
-    }
-
     lines[i] = `${indentation}${lines[i]}`
   }
 


### PR DESCRIPTION
## Summary
- add a formatter that restores indentation to code strings following `export default` before displaying them
- reuse the formatted output for all CircuitPreview code blocks so previews maintain consistent spacing

## Testing
- bunx tsc --noEmit
- bun run format

------
https://chatgpt.com/codex/tasks/task_b_68ebeb99ec30832eb2d146ca6c5574af