### PR TITLE
fix(docs): correct SVG generation when importing local .glb models

### DIFF
--- a/src/components/CircuitPreview.tsx
+++ b/src/components/CircuitPreview.tsx
@@ -155,30 +155,28 @@ export default function CircuitPreview({
       return createPngUrl(fsMapOrCode, "3d")
     }
 
+    function detectEntrypoint(fsMap: Record<string, string>): string {
+      if (fsMap["index.tsx"]) return "index.tsx"
+      if (fsMap["main.tsx"]) return "main.tsx"
+      // prefer a top-level .tsx file
+      const tsxRoot = Object.keys(fsMap).find(
+        (k) => k.endsWith(".tsx") && !k.includes("/"),
+      )
+      if (tsxRoot) return tsxRoot
+      return Object.keys(fsMap)[0]
+    }
+
     // If fsMap is provided, use fs_map parameter instead of code
     if (fsMap) {
-      const fsMapJson = JSON.stringify(fsMap)
-      // Use browser-compatible base64 encoding
-      const encodedFsMap = btoa(
-        encodeURIComponent(fsMapJson).replace(/%([0-9A-F]{2})/g, (_match, p1) =>
-          String.fromCharCode(Number.parseInt(p1, 16)),
-        ),
-      )
+      const entrypoint = detectEntrypoint(fsMap)
 
-      // Construct the URL step by step for clarity
-      const baseUrl = "https://svg.tscircuit.com/"
-      const params: Record<string, string> = {
-        svg_type: "3d",
+      return createSvgUrl(fsMap, "3d", {
         format: "png",
-        png_width: "800",
-        png_height: "600",
-        fs_map: encodeURIComponent(encodedFsMap),
-        project_base_url: encodeURIComponent(projectBaseUrl),
-      }
-      const queryString = Object.entries(params)
-        .map(([key, value]) => `${key}=${value}`)
-        .join("&")
-      return `${baseUrl}?${queryString}`
+        pngWidth: 800,
+        pngHeight: 600,
+        entrypoint,
+        // projectBaseUrl
+      })
     }
 
     const encodedCode = encodeURIComponent(


### PR DESCRIPTION
## **Summary**

This PR fixes **invalid SVG generation** introduced after the refactor in #213 , where the renderer began **manually constructing the SVG URL** instead of using the official `createSvgUrl` utility from `@tscircuit/create-snippet-url`.

The manual URL generation introduced three problems:

* Used a **custom Base64 encoding** for `fsMap` instead of the proper encoding already handled by the SVG API.
* Added an unsupported `projectBaseUrl` query parameter, which the API does not recognize.
* Omitted the `entrypoint` parameter in generated url's, causing incorrect or failed render output for multi-file (`fsMap`) examples.

---

## **Changes**

* Reverted manual URL creation and reinstated use of `createSvgUrl(fsMap, ...)` for SVG generation.
* Added a `detectEntrypoint(fsMap)` helper to automatically determine the correct entry file (`index.tsx`, `main.tsx`, or first `.tsx` file).
* commented out the not yet unsupported `projectBaseUrl` query parameter from SVG requests.

---

## **Result**

* SVG  previews now render correctly using the proper `fsMap` encoding expected by the `svg.tscircuit.com` API.
* Eliminates invalid Base64 data and unsupported query parameters from generated URLs.
* Ensures `entrypoint` is always explicitly provided when rendering multi-file examples.

---

## **Note**

> A follow-up PR to finally add support for the `projectBaseUrl` parameter in the relevant snippet and SVG libraries, as it was observed to be needed.
>
> This fix restores parity with the behavior prior to the refactor in #213, aligning the documentation renderer with the official snippet URL utilities.

---

/closes #234
/claim #234
