### PR TITLE
Add color usage example for LED element

### DIFF
--- a/docs/elements/led.mdx
+++ b/docs/elements/led.mdx
@@ -36,7 +36,7 @@ Here's an example showing how to use different LED colors in a board layout:
 
 <CircuitPreview
   browser3d={false}
-  defaultView="pcb"
+  defaultView="3d"
   code={`
   export default () => (
     <board width="10mm" height="10mm">

--- a/docs/elements/led.mdx
+++ b/docs/elements/led.mdx
@@ -40,9 +40,9 @@ Here's an example showing how to use different LED colors in a board layout:
   code={`
   export default () => (
     <board width="10mm" height="10mm">
-      <led name="D1" footprint="0402" color="red" pcbY={2} />
+      <led name="D1" footprint="0402" color="blue" pcbY={2} />
       <led name="D2" footprint="0603" color="green"/>
-      <led name="D3" footprint="0805" color="blue" pcbY={-2}/>
+      <led name="D3" footprint="0805" color="red" pcbY={-2}/>
     </board>
   )
 `}

--- a/docs/elements/led.mdx
+++ b/docs/elements/led.mdx
@@ -30,6 +30,24 @@ import CircuitPreview from "@site/src/components/CircuitPreview"
 | `color`          | `red`         | The color of the LED. `red` LEDs are most common.                |
 | `forwardVoltage` | `1.6V`        | The voltage drop across the LED when forward current is applied. |
 
+### Color Example
+
+Here's an example showing how to use different LED colors in a board layout:
+
+<CircuitPreview
+  browser3d={false}
+  defaultView="pcb"
+  code={`
+  export default () => (
+    <board width="10mm" height="10mm">
+      <led name="D1" footprint="0402" color="red" pcbY={2} />
+      <led name="D2" footprint="0603" color="green"/>
+      <led name="D3" footprint="0805" color="blue" pcbY={-2}/>
+    </board>
+  )
+`}
+/>
+
 ### Common LED Footprints
 
 The following represent the most common footprints for LEDs based on [jlcsearch](https://jlcsearch.tscircuit.com),

--- a/docs/elements/led.mdx
+++ b/docs/elements/led.mdx
@@ -35,13 +35,13 @@ import CircuitPreview from "@site/src/components/CircuitPreview"
 Here's an example showing how to use different LED colors in a board layout:
 
 <CircuitPreview
-  browser3d={false}
+  browser3dView={false}
   defaultView="3d"
   code={`
   export default () => (
     <board width="10mm" height="10mm">
-      <led name="D1" footprint="0402" color="blue" pcbY={2} />
-      <led name="D2" footprint="0603" color="green"/>
+      <led name="D1" footprint="0805" color="blue" pcbY={2} />
+      <led name="D2" footprint="0805" color="green"/>
       <led name="D3" footprint="0805" color="red" pcbY={-2}/>
     </board>
   )


### PR DESCRIPTION
Added a new section to docs/elements/led.mdx demonstrating how to specify different LED colors in a board layout with a CircuitPreview example.
This helps users understand the color prop and visualize multiple LED colors directly in docs.


/claim https://github.com/tscircuit/tscircuit/issues/971
/close https://github.com/tscircuit/tscircuit/issues/971