### PR TITLE
Reduce markdown table font size

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -181,6 +181,17 @@ figure img {
   height: auto !important;
 }
 
+/* Make markdown table content slightly smaller for better fit */
+.markdown table {
+  font-size: 0.9rem;
+}
+
+.markdown table th,
+.markdown table td {
+  font-size: inherit;
+  line-height: 1.4;
+}
+
 .youtube-embed__container {
   background: var(--media-container-bg);
   border: 1px solid var(--media-container-border);


### PR DESCRIPTION
## Summary
- decrease markdown table font sizing to improve fit within content areas

## Testing
- bunx tsc --noEmit
- bun run format

------
https://chatgpt.com/codex/tasks/task_b_68efba2ef4d8832e93d88687f8642dbc