### PR TITLE
Fix table sizing on mobile and desktop for better readability

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -181,15 +181,55 @@ figure img {
   height: auto !important;
 }
 
-/* Make markdown table content slightly smaller for better fit */
+/* Responsive table styling for better mobile and desktop readability */
 .markdown table {
-  font-size: 0.9rem;
+  font-size: 0.875rem;
+  display: block;
+  width: 100%;
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
 }
 
 .markdown table th,
 .markdown table td {
   font-size: inherit;
-  line-height: 1.4;
+  line-height: 1.5;
+  padding: 0.5rem 0.75rem;
+  vertical-align: top;
+}
+
+.markdown table th {
+  font-weight: 600;
+  white-space: nowrap;
+}
+
+.markdown table td {
+  word-break: break-word;
+}
+
+/* Reduce table font size on mobile for better fit */
+@media (max-width: 768px) {
+  .markdown table {
+    font-size: 0.75rem;
+  }
+
+  .markdown table th,
+  .markdown table td {
+    padding: 0.4rem 0.5rem;
+    line-height: 1.4;
+  }
+}
+
+/* Very small screens - extra compact */
+@media (max-width: 480px) {
+  .markdown table {
+    font-size: 0.7rem;
+  }
+
+  .markdown table th,
+  .markdown table td {
+    padding: 0.35rem 0.4rem;
+  }
 }
 
 .youtube-embed__container {


### PR DESCRIPTION
Improved responsive table styling to ensure tables are readable on all screen sizes:

- Desktop: 0.875rem font size with proper padding (0.5rem 0.75rem)
- Tablet/Mobile (≤768px): 0.75rem font size with compact padding
- Small screens (≤480px): 0.7rem font size for very tight spaces
- Added horizontal scroll support for wide tables
- Better text wrapping with word-break in cells
- Improved line heights for readability across devices

Fixes #250
/claim #250 