### PR TITLE
docs: document chip obstructsWithinBounds behavior

### DIFF
--- a/docs/elements/chip.mdx
+++ b/docs/elements/chip.mdx
@@ -298,14 +298,20 @@ places a second chip inside its body. Because the outer chip has
 `obstructsWithinBounds` prop remains `true`—can safely occupy the same PCB
 area.
 
-<CircuitPreview splitView defaultView="pcb" code={`
+<CircuitPreview
+  splitView
+  defaultView="3d"
+  hideSchematicTab
+  browser3d={false}
+  browser3dView={false}
+  code={`
 
 export default () => (
   <board width="50mm" height="30mm">
     <chip
       name="Module"
-      pcbX="25mm"
-      pcbY="15mm"
+      pcbX={0}
+      pcbY={0}
       obstructsWithinBounds={false}
       footprint={
         <footprint>
@@ -355,8 +361,8 @@ export default () => (
     />
     <chip
       name="Sensor"
-      pcbX="25mm"
-      pcbY="15mm"
+      pcbX={0}
+      pcbY={0}
       obstructsWithinBounds={true}
       footprint="0402"
     />

--- a/docs/elements/chip.mdx
+++ b/docs/elements/chip.mdx
@@ -284,6 +284,87 @@ export default () => (
 
 For more information about custom footprints, check out the [<footprint /> element](./footprint.mdx)
 
+### `obstructsWithinBounds`
+
+By default, `<chip />` components occupy all of the PCB area inside their
+footprint's bounding box, which prevents other components from being placed
+inside that region. Set `obstructsWithinBounds={false}` to indicate that the
+component leaves usable room within its outline (for example, when you are
+representing a tall module that allows other chips to sit underneath).
+
+The example below manually constructs a footprint for a module-style chip and
+places a second chip inside its body. Because the outer chip has
+`obstructsWithinBounds={false}`, the inner chip—whose own
+`obstructsWithinBounds` prop remains `true`—can safely occupy the same PCB
+area.
+
+<CircuitPreview splitView defaultView="pcb" code={`
+
+export default () => (
+  <board width="50mm" height="30mm">
+    <chip
+      name="Module"
+      pcbX="25mm"
+      pcbY="15mm"
+      obstructsWithinBounds={false}
+      footprint={
+        <footprint>
+          <smtpad
+            portHints={["VIN"]}
+            pcbX="-8mm"
+            pcbY="4mm"
+            width="2mm"
+            height="2mm"
+            shape="rect"
+          />
+          <smtpad
+            portHints={["GND"]}
+            pcbX="8mm"
+            pcbY="4mm"
+            width="2mm"
+            height="2mm"
+            shape="rect"
+          />
+          <smtpad
+            portHints={["SCL"]}
+            pcbX="-8mm"
+            pcbY="-4mm"
+            width="2mm"
+            height="2mm"
+            shape="rect"
+          />
+          <smtpad
+            portHints={["SDA"]}
+            pcbX="8mm"
+            pcbY="-4mm"
+            width="2mm"
+            height="2mm"
+            shape="rect"
+          />
+          <silkscreenpath
+            route={[
+              { x: -12, y: -6 },
+              { x: 12, y: -6 },
+              { x: 12, y: 6 },
+              { x: -12, y: 6 },
+              { x: -12, y: -6 },
+            ]}
+          />
+        </footprint>
+      }
+    />
+    <chip
+      name="Sensor"
+      pcbX="25mm"
+      pcbY="15mm"
+      obstructsWithinBounds={true}
+      footprint="0402"
+    />
+  </board>
+)
+`}
+/>
+
 ### Internally Connected Pins
 
 Some chips, such as a standard 4 pin pushbutton, have pins that are internally


### PR DESCRIPTION
## Summary
- explain how the obstructsWithinBounds prop affects chip placement and when to disable it
- add a CircuitPreview example that manually defines a footprint and nests a chip inside another body

## Testing
- bunx tsc --noEmit
- bun run format

------
https://chatgpt.com/codex/tasks/task_b_68f01ef972f0832eb5c05a22f2ec1331