### PR TITLE
Add tscircuit.com as upstream dependency for eval

### DIFF
--- a/docs/contributing/package-dependencies-and-auto-updates.mdx
+++ b/docs/contributing/package-dependencies-and-auto-updates.mdx
@@ -17,6 +17,9 @@ flowchart TD
     %% Core to Eval
     core[tscircuit/core] --> eval[tscircuit/eval]
 
+    %% Website to Eval
+    website[tscircuit.com] --> eval
+
     %% Eval to Runframe
     eval --> runframe[tscircuit/runframe]
 


### PR DESCRIPTION
## Summary
- add the tscircuit.com upstream relationship to the package dependency graph documentation

## Testing
- bunx tsc --noEmit
- bun run format

------
https://chatgpt.com/codex/tasks/task_b_68f037475a7c832ea203d89ec7f8d772