### PR TITLE
Add tscircuit.com to dependency workflow diagram

### DIFF
--- a/docs/contributing/package-dependencies-and-auto-updates.mdx
+++ b/docs/contributing/package-dependencies-and-auto-updates.mdx
@@ -20,6 +20,9 @@ flowchart TD
     %% Eval to Runframe
     eval --> runframe[tscircuit/runframe]
 
+    %% Eval to tscircuit.com
+    eval --> tscircuitcom[tscircuit.com]
+
     %% 3D Viewer to Runframe
     viewer3d[tscircuit/3d-viewer] --> runframe
 


### PR DESCRIPTION
## Summary
- add tscircuit.com to the package dependency mermaid diagram as a downstream target of tscircuit/eval

## Testing
- bunx tsc --noEmit
- bun run format

------
https://chatgpt.com/codex/tasks/task_b_68f06b048adc832e9ac07b2473630ce0