### PR TITLE
Clarify <symbol /> documentation language

### DIFF
--- a/docs/elements/symbol.mdx
+++ b/docs/elements/symbol.mdx
@@ -10,7 +10,7 @@ import CircuitPreview from "@site/src/components/CircuitPreview"
 
 The `<symbol />` element allows you to create custom schematic representations for your chips. Instead of using the default schematic box with pins, you can draw custom shapes using primitive components like `<schematicline />`, `<schematiccircle />`, `<schematicrect />`, and `<schematicarc />`.
 
-Symbols are used within the `symbol` prop of a **Normal Component** and can be combined with `<port />` elements to define connection points.
+Most components let you customize their schematic appearance through the `symbol` prop, where you can combine `<port />` elements with drawing primitives to define connection points.
 
 :::tip
 Use `<symbol />` when you want to create a custom schematic appearance for your component that differs from the standard rectangular box representation.


### PR DESCRIPTION
## Summary
- replace the reference to "Normal Component" with user-facing guidance about customizing symbols via the `symbol` prop

## Testing
- bunx tsc --noEmit
- bun run format

------
https://chatgpt.com/codex/tasks/task_b_68f132f2c87c832e9d8f27b70cfbecb1