### PR TITLE
Remove memoization guidance from React context TypeScript guide

### DIFF
--- a/docs/guides/typescript-guide/using-react-context-to-avoid-prop-drilling.mdx
+++ b/docs/guides/typescript-guide/using-react-context-to-avoid-prop-drilling.mdx
@@ -12,7 +12,6 @@ Use context when multiple components need the same piece of state or configurati
 
 - Design-wide metadata such as board dimensions or authoring info
 - User preferences like measurement units or default footprints
-- Shared services (e.g., logger, analytics, or websocket clients)
 
 By colocating these values in a context provider, you avoid repetitive prop threading and keep your component interfaces focused on their primary responsibilities.
 

--- a/docs/guides/typescript-guide/using-react-context-to-avoid-prop-drilling.mdx
+++ b/docs/guides/typescript-guide/using-react-context-to-avoid-prop-drilling.mdx
@@ -21,7 +21,7 @@ By colocating these values in a context provider, you avoid repetitive prop thre
 The following example shares board-level configuration with any component that needs it. The `BoardSettings` interface ensures every consumer receives a strongly typed object.
 
 ```tsx
-import { ReactNode, createContext, useContext, useMemo } from "react"
+import { ReactNode, createContext, useContext } from "react"
 
 type BoardSettings = {
   boardName: string
@@ -40,15 +40,11 @@ export const BoardSettingsProvider = ({
 }: {
   children: ReactNode
   value: BoardSettings
-}) => {
-  const memoizedValue = useMemo(() => value, [value])
-
-  return (
-    <BoardSettingsContext.Provider value={memoizedValue}>
-      {children}
-    </BoardSettingsContext.Provider>
-  )
-}
+}) => (
+  <BoardSettingsContext.Provider value={value}>
+    {children}
+  </BoardSettingsContext.Provider>
+)
 
 export const useBoardSettings = () => {
   const context = useContext(BoardSettingsContext)
@@ -60,10 +56,6 @@ export const useBoardSettings = () => {
   return context
 }
 ```
-
-### Why memoize the value?
-
-Passing a memoized value prevents unnecessary re-renders of components consuming the context. This becomes important when the provider sits high in your component tree and wraps many children.
 
 ## Consuming the Context
 
@@ -127,7 +119,6 @@ Because every component inside the provider shares the same context, you can int
 
 - Define a context value type that captures the shared configuration.
 - Export both the provider and a custom hook that validates usage.
-- Memoize the context value to avoid unnecessary renders.
 - Wrap only the subtree that needs the shared data, keeping providers focused and intentional.
 
 With these patterns, React Context becomes a reliable way to manage shared state in your TypeScript tscircuit projects without the noise of prop drilling.
@@ -136,7 +127,7 @@ With these patterns, React Context becomes a reliable way to manage shared state
   hide3DTab
   hidePCBTab
   defaultView="schematic"
-  code={`import { ReactNode, createContext, useContext, useMemo } from "react"
+  code={`import { ReactNode, createContext, useContext } from "react"
 
 type BoardSettings = {
   boardName: string
@@ -155,15 +146,11 @@ const BoardSettingsProvider = ({
 }: {
   children: ReactNode
   value: BoardSettings
-}) => {
-  const memoizedValue = useMemo(() => value, [value])
-
-  return (
-    <BoardSettingsContext.Provider value={memoizedValue}>
-      {children}
-    </BoardSettingsContext.Provider>
-  )
-}
+}) => (
+  <BoardSettingsContext.Provider value={value}>
+    {children}
+  </BoardSettingsContext.Provider>
+)
 
 const useBoardSettings = () => {
   const context = useContext(BoardSettingsContext)


### PR DESCRIPTION
## Summary
- remove references to memoization from the React context guide
- simplify provider examples by passing the value directly without useMemo
- update the embedded CircuitPreview snippet to match the documentation changes

## Testing
- bunx tsc --noEmit
- bun run format

------
https://chatgpt.com/codex/tasks/task_b_68f7a4967c88832eba5d0712c7c07026