### PR TITLE
Add fabricationnoterect docs and show silkscreen fill usage

### DIFF
--- a/docs/footprints/fabricationnoterect.mdx
+++ b/docs/footprints/fabricationnoterect.mdx
@@ -1,0 +1,99 @@
+---
+title: <fabricationnoterect />
+description: Highlight fabrication callouts and assembly regions with rectangular annotations on the fabrication layer.
+---
+
+import CircuitPreview from "@site/src/components/CircuitPreview"
+
+## Overview
+
+The `<fabricationnoterect />` element draws rectangular callouts on the fabrication layer. Use it to flag assembly keep-out zones, highlight areas that need manual inspection, or surround notes that should only appear on fabrication outputs. Fabrication rectangles will not appear on the silkscreen or schematic exports.
+
+## Basic Usage
+
+The example below adds a fabrication note rectangle around a cluster of passives to highlight an assembly instruction. Because the element renders on the fabrication layer, it appears alongside `<fabricationnotetext />` callouts in fabrication plots but stays off the silkscreen.
+
+<CircuitPreview
+  defaultView="pcb"
+  hide3DTab
+  hideSchematicTab
+  code={`
+export default () => (
+  <board width="28mm" height="20mm">
+    <resistor name="R1" resistance="1k" footprint="0603" pcbX={-6} pcbY={-2} />
+    <capacitor name="C1" capacitance="1uF" footprint="0603" pcbX={-2} pcbY={2} />
+    <fabricationnotetext
+      text="Install last"
+      pcbX={8}
+      pcbY={0}
+      anchorAlignment="left"
+      fontSize="1.4mm"
+    />
+    <fabricationnoterect
+      pcbX={2}
+      pcbY={0}
+      width={18}
+      height={12}
+      strokeWidth={0.3}
+      color="#2563eb"
+    />
+  </board>
+)
+`}
+/>
+
+## Filled Callouts
+
+Set `isFilled` to tint the region. Pair it with `hasStroke={false}` when you only want a filled highlight without an outline.
+
+<CircuitPreview
+  defaultView="pcb"
+  hide3DTab
+  hideSchematicTab
+  code={`
+export default () => (
+  <board width="28mm" height="20mm">
+    <fabricationnoterect
+      pcbX={-6}
+      pcbY={0}
+      width={8}
+      height={6}
+      color="#f97316"
+      isFilled
+    />
+    <fabricationnoterect
+      pcbX={6}
+      pcbY={0}
+      width={8}
+      height={6}
+      color="#16a34a"
+      isFilled
+      hasStroke={false}
+    />
+  </board>
+)
+`}
+/>
+
+## Properties
+
+| Property | Type | Required | Default | Description |
+|----------|------|----------|---------|-------------|
+| `pcbX` | length | Yes | – | X coordinate of the rectangle center on the PCB fabrication layer. |
+| `pcbY` | length | Yes | – | Y coordinate of the rectangle center on the PCB fabrication layer. |
+| `width` | length | Yes | – | Width of the rectangle. |
+| `height` | length | Yes | – | Height of the rectangle. |
+| `strokeWidth` | length | No | `0.2mm` | Outline thickness for the rectangle border. |
+| `color` | string | No | `"#000"` | Hex color used when previewing the fabrication rectangle. |
+| `isFilled` | boolean | No | `false` | When `true`, fills the rectangle with `color`. |
+| `hasStroke` | boolean | No | `true` | Toggles the rectangle border. |
+| `isStrokeDashed` | boolean | No | `false` | Renders the border with a dashed pattern. |
+| `layer` | string | No | `"fabrication"` | Fabrication layer name to place the rectangle on. |
+| `pcbRelative` | boolean | No | `false` | Interpret `pcbX`/`pcbY` relative to the parent group instead of the board origin. |
+| `relative` | boolean | No | `false` | Applies relative positioning rules to both PCB and schematic coordinates within groups. |
+
+## Tips
+
+- Combine `<fabricationnoterect />` with [`<fabricationnotetext />`](./fabricationnotetext.mdx) to connect visual highlights with explicit instructions.
+- Use `isStrokeDashed` to outline areas that require optional or future assembly steps.
+- Keep fabrication rectangles off critical copper features—they are only for documentation and do not affect manufacturing clearances.

--- a/docs/footprints/silkscreenrect.mdx
+++ b/docs/footprints/silkscreenrect.mdx
@@ -19,3 +19,24 @@ import CircuitPreview from "@site/src/components/CircuitPreview"
     </group>
   )
 `} />
+
+## Filled Silkscreen Rectangles
+
+Enable the `isFilled` prop to create solid silkscreen blocks—useful for alignment targets or bold markings. You can mix filled and outlined rectangles within the same footprint.
+
+<CircuitPreview code={`
+  export default () => (
+    <group>
+      <footprint name="U1">
+        <silkscreenrect pcbX={-1.2} pcbY={0} width={1} height={1} />
+        <silkscreenrect
+          pcbX={1.2}
+          pcbY={0}
+          width={1}
+          height={1}
+          isFilled
+        />
+      </footprint>
+    </group>
+  )
+`} />


### PR DESCRIPTION
## Summary
- add a documentation page for `<fabricationnoterect />` covering usage examples, filled callouts, and available props
- extend the `<silkscreenrect />` docs with a CircuitPreview demonstrating the `isFilled` prop

## Testing
- bunx tsc --noEmit

------
https://chatgpt.com/codex/tasks/task_b_68f7d9138670832eaa28c5c061223959