### PR TITLE
Fix 'tscircuit Essentials' category descriptions

### DIFF
--- a/docs/guides/tscircuit-essentials/automatic-pcb-layout.mdx
+++ b/docs/guides/tscircuit-essentials/automatic-pcb-layout.mdx
@@ -1,5 +1,9 @@
 ---
 title: Automatic PCB Layout
+description: >-
+  Explore tscircuit's automatic PCB layout engines: pcbFlex, pcbGrid, and
+  pcbPack, and learn how to choose the right approach for arranging components
+  quickly.
 ---
 
 :::warning

--- a/docs/guides/tscircuit-essentials/automatic-schematic-layout.mdx
+++ b/docs/guides/tscircuit-essentials/automatic-schematic-layout.mdx
@@ -1,5 +1,8 @@
 ---
 title: Automatic Schematic Layout
+description: >-
+  Understand how the default schematic autolayout arranges components and
+  discover options for nudging results with manual edits and layout helpers.
 ---
 
 :::warning

--- a/docs/guides/tscircuit-essentials/configuring-chips.mdx
+++ b/docs/guides/tscircuit-essentials/configuring-chips.mdx
@@ -1,6 +1,9 @@
 ---
 title: Configuring Chips
 sidebar_position: 1.5
+description: >-
+  Walk through configuring `<chip />` components, from defining pin labels and
+  footprints to wiring reusable chip abstractions.
 ---
 
 import ChipPage from "../../elements/chip.mdx"

--- a/docs/guides/tscircuit-essentials/manual-edits.mdx
+++ b/docs/guides/tscircuit-essentials/manual-edits.mdx
@@ -1,5 +1,9 @@
 ---
 title: Manual Edits
+description: >-
+  Learn how to capture drag-and-drop adjustments in `manual-edits.json`, use
+  the schematic and PCB editors to create them, and troubleshoot when changes
+  don't apply.
 ---
 import YouTubeEmbed from "../../../src/components/YouTubeEmbed"
 

--- a/docs/guides/tscircuit-essentials/pinout-svg.mdx
+++ b/docs/guides/tscircuit-essentials/pinout-svg.mdx
@@ -1,5 +1,8 @@
 ---
 title: Pinout SVG
+description: >-
+  Generate shareable pinout diagrams by annotating components with
+  `pinAttributes` and exporting the interactive SVG view.
 ---
 
 import CircuitPreview from "@site/src/components/CircuitPreview"

--- a/docs/guides/tscircuit-essentials/port-and-net-selectors.md
+++ b/docs/guides/tscircuit-essentials/port-and-net-selectors.md
@@ -1,5 +1,8 @@
 ---
 title: Port and Net Selectors
+description: >-
+  Learn how to target ports, nets, and components with selector strings, and
+  see practical examples for traces and component props.
 ---
 
 Selectors are a string used to reference a port, net or any component. They're most

--- a/docs/guides/tscircuit-essentials/using-expressions.mdx
+++ b/docs/guides/tscircuit-essentials/using-expressions.mdx
@@ -1,5 +1,8 @@
 ---
 title: Using Expressions for Component Values
+description: >-
+  Use JavaScript expressions inside circuits to derive component values that
+  react to other parameters, like voltage dividers or tuned filters.
 ---
 
 import CircuitPreview from "@site/src/components/CircuitPreview"
@@ -71,4 +74,3 @@ export default () => {
 `} />
 
 These examples show how expressions make it easy to drive component values from formulas so designs can adapt when requirements change.
-

--- a/docs/guides/tscircuit-essentials/using-sel-references.mdx
+++ b/docs/guides/tscircuit-essentials/using-sel-references.mdx
@@ -1,5 +1,8 @@
 ---
 title: Using "sel" References
+description: >-
+  Reference components, pins, and modules with the type-safe `sel` helper and
+  learn when to use conventional selectors or component-aware lookups.
 ---
 
 The `sel` object is a special import that allows you to easily reference


### PR DESCRIPTION
closes https://github.com/tscircuit/docs/issues/277

<img width="2634" height="1904" alt="image" src="https://github.com/user-attachments/assets/15476bb1-ca1a-4a81-8073-bddccea556ad" />
