### PR TITLE
Update pcbnotedimension docs for auto measurements

### DIFF
--- a/docs/elements/pcbnotedimension.mdx
+++ b/docs/elements/pcbnotedimension.mdx
@@ -7,7 +7,7 @@ import CircuitPreview from "@site/src/components/CircuitPreview"
 
 ## Overview
 
-`<pcbnotedimension />` lets you add dimensional annotations to your PCB design. These annotations display the distance between two points with arrows and text labels, making it easy to communicate critical measurements for manufacturing, assembly, or design review. Dimension annotations are visible in PCB previews and can be exported with fabrication outputs.
+`<pcbnotedimension />` lets you add dimensional annotations to your PCB design. These annotations display the distance between two points with arrows and an automatically generated measurement label, making it easy to communicate critical measurements for manufacturing, assembly, or design review. Dimension annotations are visible in PCB previews and can be exported with fabrication outputs.
 
 ## Basic Usage
 
@@ -25,7 +25,6 @@ Below is a simple board with a dimension annotation showing the distance between
       <pcbnotedimension
         from={{ x: -3, y: 2 }}
         to={{ x: 3, y: 2 }}
-        text="6mm"
         arrowSize={0.8}
         fontSize={1.5}
         color="#ffffff"
@@ -51,7 +50,6 @@ Instead of specifying exact coordinates, you can use selectors to reference comp
       <pcbnotedimension
         from="R1"
         to="R2"
-        text="10mm spacing"
         fontSize={1.2}
         color="#00ff00"
       />
@@ -66,7 +64,7 @@ Instead of specifying exact coordinates, you can use selectors to reference comp
 |---------|------|-------------|
 | `from` | string \| Point | **Required.** Starting point of the dimension. Can be a selector string (e.g., `"R1"`) or a Point object with `x` and `y` coordinates. |
 | `to` | string \| Point | **Required.** Ending point of the dimension. Can be a selector string (e.g., `"R2"`) or a Point object with `x` and `y` coordinates. |
-| `text` | string | Label text to display on the dimension line (e.g., `"5mm"`, `"Critical spacing"`). |
+| `text` | string | Optional custom label text to override the auto-generated measurement (e.g., `"Critical spacing"`). |
 | `arrowSize` | length | Size of the arrows at each end of the dimension line. Defaults to `1mm`. |
 | `fontSize` | length | Height of the label text. Defaults to `1mm`. |
 | `color` | string | Hex color code for the dimension line, arrows, and text (e.g., `"#ffffff"`, `"#00ff00"`). |


### PR DESCRIPTION
## Summary
- stop hardcoding measurement strings in `<pcbnotedimension />` examples so they rely on the auto-generated label
- clarify the `text` property documentation to explain it overrides the automatic measurement text

## Testing
- bunx tsc --noEmit
- bun run format

------
https://chatgpt.com/codex/tasks/task_b_68fa86028464832eb6dca21497ef0a1f