### PR TITLE
Add custom thickness example to trace documentation

### DIFF
--- a/docs/elements/trace.mdx
+++ b/docs/elements/trace.mdx
@@ -39,6 +39,7 @@ Here's a simple example connecting two components:
 | `maxLength` | Maximum length the trace can be (optional) | `"10mm"` |
 | `minLength` | Minimum length the trace must be (optional) | `"5mm"` |
 | `width` | Width of the trace (optional) | `"0.2mm"` |
+| `thickness` | Same as `width`; sets the copper width for the trace (optional) | `"0.2mm"` |
 | `pcbPath` | Array of points defining a manual PCB path relative to an anchor port | `[{ x: 1, y: 0 }, { x: 1, y: 1 }]` |
 | `pcbPathRelativeTo` | Port selector that `pcbPath` coordinates are relative to (defaults to the `from` port) | `".R1 > .pin2"` |
 
@@ -152,3 +153,23 @@ When using net connections we use a Rats Nest on a PCB view or a net label on a
 schematic view. When you see a dotted line on a Rats Nest, you should think of
 it as a _possible_ connection point, but not necessarily the final place where
 the autorouter will connect to the net.
+
+## Creating a direct path with a custom thickness
+
+Use an empty `pcbPath` array to keep the autorouter's direct path between two
+ports while still overriding the copper width via the `thickness` property.
+
+<CircuitPreview leftView="code" rightView="pcb" code={`
+  export default () => (
+    <board width="20mm" height="10mm">
+      <resistor name="R1" resistance="1k" footprint="0402" pcbX={-3} />
+      <capacitor name="C1" capacitance="100nF" footprint="0402" pcbX={3} />
+      <trace
+        from="R1.pin1"
+        to="C1.pin1"
+        pcbPath={[]}
+        thickness="0.5mm"
+      />
+    </board>
+  )
+`} />

--- a/docs/elements/trace.mdx
+++ b/docs/elements/trace.mdx
@@ -157,7 +157,7 @@ the autorouter will connect to the net.
 ## Creating a direct path with a custom thickness
 
 Use an empty `pcbPath` array to keep the autorouter's direct path between two
-ports while still overriding the copper width via the `thickness` property.
+ports while overriding the trace width via the `thickness` property.
 
 <CircuitPreview leftView="code" rightView="pcb" code={`
   export default () => (
@@ -165,7 +165,7 @@ ports while still overriding the copper width via the `thickness` property.
       <resistor name="R1" resistance="1k" footprint="0402" pcbX={-3} />
       <capacitor name="C1" capacitance="100nF" footprint="0402" pcbX={3} />
       <trace
-        from="R1.pin1"
+        from="R1.pin2"
         to="C1.pin1"
         pcbPath={[]}
         thickness="0.5mm"


### PR DESCRIPTION
## Summary
- document the `thickness` trace property alongside `width`
- add a CircuitPreview example that shows using an empty pcbPath with a custom thickness for direct routing

## Testing
- bunx tsc --noEmit
- bun run format

------
https://chatgpt.com/codex/tasks/task_b_68faa7243680832e8ec2986d3c3d7380