### PR TITLE
docs: improve UI consistency in Quickstart CLI section

### DIFF
--- a/docs/intro/quickstart-cli.md
+++ b/docs/intro/quickstart-cli.md
@@ -45,11 +45,12 @@ To use the CLI offline, you need to disable the "Force Latest @tscircuit/eval" o
 
 ## Pushing to the tscircuit Registry
 
-<!-- TODO -->
 Next, you push your project by running `tsci push`. This will push your project to your registry.
+
 ![tsci push result](../../static/img/tsci-push.png)
 
 Go to your tscircuit account. You can now see PCB, Schematic and 3D views of your circuit in you registry. 
+
 ![browser](../../static/img/registry-snippet.png)
 
 ## Exporting to SVGs, PDF, or Fabrication Files


### PR DESCRIPTION
Adjusted image styling and spacing in the "Pushing to the tscircuit Registry" section for better visual consistency with other Quickstart docs.

Before and after screenshots attached for reference.

### Before
<img width="655" height="595" alt="Screenshot 2025-10-24 at 8 59 01 AM" src="https://github.com/user-attachments/assets/3280333f-ba01-4b81-9cfb-8e95905148fd" />

### After
<img width="655" height="604" alt="Screenshot 2025-10-24 at 8 58 40 AM" src="https://github.com/user-attachments/assets/ed0f45cf-f9b3-4939-9ef0-91a531dba028" />
