### PR TITLE
docs: Recommend RunFrame for JLCPCB imports

### DIFF
--- a/docs/guides/importing-modules-and-chips/importing-from-jlcpcb.mdx
+++ b/docs/guides/importing-modules-and-chips/importing-from-jlcpcb.mdx
@@ -10,6 +10,30 @@ import YouTubeEmbed from '../../../src/components/YouTubeEmbed';
 
 JLCPCB has a massive component catalog of 3d models and footprints.
 
+## RunFrame Import (Recommended)
+
+The recommended way to import JLCPCB components is by using RunFrame. RunFrame is a tscircuit component that allows you to preview and run tscircuit code directly in your browser.
+
+You can use RunFrame to import JLCPCB components by providing the JLCPCB part number to the `RunFrame` component.
+
+```tsx
+import { RunFrame } from "@tscircuit/runframe"
+
+export default () => (
+  <RunFrame
+    initialJlcpcbId="C133726"
+    packageName="my-jlcpcb-component"
+  />
+)
+```
+
+This will display the component in the RunFrame, and you can then use it in your tscircuit projects.
+
+<figure>
+  <img src="/img/runframe-example.png" />
+  <figcaption>An example of a JLCPCB component imported with RunFrame</figcaption>
+</figure>
+
 ## Web Import
 
 You can import JLCPCB components on [tscircuit.com](https://tscircuit.com). After


### PR DESCRIPTION
/claim #288 
/fixes #288 

This PR updates the documentation to recommend using RunFrame for importing JLCPCB components, as it is the easiest and most straightforward method.

- Adds a new "RunFrame Import (Recommended)" section to the `importing-from-jlcpcb.mdx` page.
- Includes a code example and an image to illustrate the process.

sreenshots:
<img width="1366" height="768" alt="Screenshot 2025-10-25 035950" src="https://github.com/user-attachments/assets/d72a2a0b-258c-48ce-af42-b5d5742fafec" />
<img width="1366" height="768" alt="Screenshot 2025-10-25 040006" src="https://github.com/user-attachments/assets/92dc2226-772a-4183-a098-c76b3b209af7" />