### PR TITLE
Clarify RunFrame import for JLCPCB components

### DIFF
--- a/docs/guides/importing-modules-and-chips/importing-from-jlcpcb.mdx
+++ b/docs/guides/importing-modules-and-chips/importing-from-jlcpcb.mdx
@@ -10,6 +10,30 @@ import YouTubeEmbed from '../../../src/components/YouTubeEmbed';
 
 JLCPCB has a massive component catalog of 3d models and footprints.
 
+## RunFrame Import (Recommended)
+
+The recommended way to import JLCPCB components is by using RunFrame. RunFrame is a tscircuit component that allows you to preview and run tscircuit code directly in your browser.
+
+You can use RunFrame to import JLCPCB components by providing the JLCPCB part number to the `RunFrame` component.
+
+```tsx
+import { RunFrame } from "@tscircuit/runframe"
+
+export default () => (
+  <RunFrame
+    initialJlcpcbId="C133726"
+    packageName="my-jlcpcb-component"
+  />
+)
+```
+
+This will display the component in the RunFrame, and you can then use it in your tscircuit projects.
+
+<figure>
+  <img src="/img/runframe-example.png" />
+  <figcaption>An example of a JLCPCB component imported with RunFrame</figcaption>
+</figure>
+
 ## Web Import
 
 You can import JLCPCB components on [tscircuit.com](https://tscircuit.com). After

--- a/docs/guides/importing-modules-and-chips/importing-from-jlcpcb.mdx
+++ b/docs/guides/importing-modules-and-chips/importing-from-jlcpcb.mdx
@@ -27,7 +27,21 @@ export default () => (
 )
 ```
 
-This will display the component in the RunFrame, and you can then use it in your tscircuit projects.
+This will display the component in the RunFrame. After the component has been imported, it will be available on the tscircuit registry under the package name you provided.
+
+### Using the Imported Component
+
+To use the component in your own tscircuit projects, you can import it from the tscircuit registry using the package name you provided in the `RunFrame` component.
+
+```tsx
+import { MyJlcpcbComponent } from "@tsci/my-jlcpcb-component"
+
+export default () => (
+  <board width="10mm" height="10mm">
+    <MyJlcpcbComponent />
+  </board>
+)
+```
 
 <figure>
   <img src="/img/runframe-example.png" />


### PR DESCRIPTION
This PR improves the documentation for importing JLCPCB components using RunFrame. The previous version was not helpful to users as it didn't explain how to use the imported component.

- Clarifies that the imported component is available on the tscircuit registry.
- Adds a "Using the Imported Component" section with a code snippet showing how to import and use the component in a project.

This should make the documentation more helpful and actionable for users.

Addresses the feedback on the previous PR.
<img width="1366" height="768" alt="Screenshot 2025-10-25 044356" src="https://github.com/user-attachments/assets/bf1231e7-1394-4345-8650-82f693f42add" />

