### PR TITLE
Document color options for <pcbnoterect>

### DIFF
--- a/docs/elements/pcbnoterect.mdx
+++ b/docs/elements/pcbnoterect.mdx
@@ -108,6 +108,29 @@ export default () => (
 `}
 />
 
+### Using Color Names
+
+Any web-compatible color name or hex code can be used for the `color` property.
+
+<CircuitPreview
+  defaultView="pcb"
+  hide3DTab
+  hideSchematicTab
+  code={`
+export default () => (
+  <board width="30mm" height="20mm">
+    <pcbnoterect
+      pcbX={0}
+      pcbY={0}
+      width={12}
+      height={8}
+      strokeWidth={0.4}
+      color="yellow"
+    />
+  </board>
+)
+`}
+/>
 
 | Property | Type | Required | Default | Description |
 |----------|------|----------|---------|-------------|
@@ -116,7 +139,7 @@ export default () => (
 | width | distance | Yes | - | Width of the rectangle in mm |
 | height | distance | Yes | - | Height of the rectangle in mm |
 | strokeWidth | distance | No | 0.1 | Width of the rectangle border in mm |
-| color | string | No | - | Rectangle color as hex string (e.g., "#ff0000") |
+| color | string | No | - | Rectangle color as a web-compatible color name or hex string (e.g., "yellow", "#ff0000") |
 | isFilled | boolean | No | false | Whether the rectangle is filled with color |
 | hasStroke | boolean | No | true | Whether the rectangle has a border |
 | isStrokeDashed | boolean | No | false | Whether the border is drawn with dashes |


### PR DESCRIPTION
Adds documentation for using web-compatible color names with the `color` prop on `<pcbnoterect />`. Includes a new section with a preview example demonstrating a yellow rectangle.

<img width="1349" height="612" alt="Screenshot 2025-10-25 at 4 06 26 PM" src="https://github.com/user-attachments/assets/1b56c678-40df-474e-9c95-d68a18a30fdd" />

/claim https://github.com/tscircuit/tscircuit/issues/1151
/closes https://github.com/tscircuit/tscircuit/issues/1151