### PR TITLE
Update JLCPCB guide example component usage properly requiring "name"

### DIFF
--- a/docs/guides/importing-modules-and-chips/importing-from-jlcpcb.mdx
+++ b/docs/guides/importing-modules-and-chips/importing-from-jlcpcb.mdx
@@ -46,7 +46,7 @@ import { ComponentName } from "@tsci/imported-component"
 
 export default () => (
   <board width="10mm" height="10mm">
-    <ComponentName />
+    <ComponentName name="U1" />
   </board>
 )
 ```


### PR DESCRIPTION
## Summary
- add the name attribute to the imported component in the JLCPCB guide example

## Testing
- bunx tsc --noEmit
- bun run format

------
https://chatgpt.com/codex/tasks/task_b_6903d44ea4f4832ea25083eb5ca8d296