### PR TITLE
Add biscuit board laser ablation essentials guide

### DIFF
--- a/docs/elements/board.mdx
+++ b/docs/elements/board.mdx
@@ -87,7 +87,7 @@ Usually you'll want to use an autorouter preset:
 - `autorouter="sequential-trace"` - Iterate over each trace and use tscircuit's fast built-in autorouter. This method is fast and deterministic but often fails with over 50 traces.
 - `autorouter="auto-local"` - Use the platform configuration, but only route locally (do not make API calls)
 - `autorouter="auto-cloud"` - Use the platform configuration for
-- `autorouter="laser_prefab"` - Reserve [prefabricated vias](./via.mdx#prefabricated-vias-for-laser-routing) that can be reassigned during routing. Ideal for rapid-turn PCBs produced with laser ablation and mechanical drilling templates. See the [Biscuit Board Laser Ablation guide](../guides/tscircuit-essentials/biscuit-board-laser-ablation.mdx) for a complete walkthrough.
+- `autorouter="laser_prefab"` - Reserve prefabricated vias that can be reassigned during routing. Ideal for rapid-turn PCBs produced with laser ablation and mechanical drilling templates. See the [Biscuit Board Laser Ablation guide](../guides/tscircuit-essentials/biscuit-board-laser-ablation.mdx) for a complete walkthrough.
 
 For complex boards with over 50 traces, you should use `autorouter="auto-cloud"`
 to take advantage of tscircuit's cloud autorouters, which internally use the popular

--- a/docs/elements/board.mdx
+++ b/docs/elements/board.mdx
@@ -86,7 +86,8 @@ Usually you'll want to use an autorouter preset:
 - `autorouter="auto"` - Uses the [platform configuration](../guides/running-tscircuit/platform-configuration.md). For tscircuit.com this defaults to `sequential-trace`.
 - `autorouter="sequential-trace"` - Iterate over each trace and use tscircuit's fast built-in autorouter. This method is fast and deterministic but often fails with over 50 traces.
 - `autorouter="auto-local"` - Use the platform configuration, but only route locally (do not make API calls)
-- `autorouter="auto-cloud"` - Use the platform configuration for 
+- `autorouter="auto-cloud"` - Use the platform configuration for
+- `autorouter="laser_prefab"` - Reserve [prefabricated vias](./via.mdx#prefabricated-vias-for-laser-routing) that can be reassigned during routing. Ideal for rapid-turn PCBs produced with laser ablation and mechanical drilling templates. See the [Biscuit Board Laser Ablation guide](../guides/tscircuit-essentials/biscuit-board-laser-ablation.mdx) for a complete walkthrough.
 
 For complex boards with over 50 traces, you should use `autorouter="auto-cloud"`
 to take advantage of tscircuit's cloud autorouters, which internally use the popular

--- a/docs/elements/via.mdx
+++ b/docs/elements/via.mdx
@@ -42,37 +42,4 @@ import CircuitPreview from "@site/src/components/CircuitPreview"
 | outerDiameter | number \| string | "0.8mm" | Outer diameter of the copper annular ring |
 | pcbX | number | 0 | PCB X position of the via |
 | pcbY | number | 0 | PCB Y position of the via |
-| netIsAssignable | boolean | `false` | Marks the via as prefabricated so autorouters like `laser_prefab` can claim it for any compatible net |
-
-### Prefabricated vias for laser routing
-
-The [`laser_prefab` autorouter](./board.mdx#setting-the-autorouter) pairs with
-prefabricated ("biscuit") via templates used in laser ablation workflows.
-Setting `netIsAssignable` on a via marks it as reusable so the autorouter can
-repurpose the hole for whichever net needs to switch layers during routing.
-
-<CircuitPreview
-  defaultView="pcb"
-  code={`export default () => (
-    <board width="10mm" height="10mm" autorouter="laser_prefab">
-      <testpoint name="TP_TOP" footprintVariant="pad" pcbX={0} pcbY={4} layer="top" />
-      <testpoint name="TP_BOTTOM" footprintVariant="pad" pcbX={0} pcbY={-4} layer="bottom" />
-      <via
-        name="V_ASSIGNABLE"
-        pcbX={0}
-        pcbY={0}
-        fromLayer="top"
-        toLayer="bottom"
-        holeDiameter="0.3mm"
-        outerDiameter="0.6mm"
-        netIsAssignable
-      />
-      <trace from="TP_TOP.pin1" to="V_ASSIGNABLE.top" />
-      <trace from="V_ASSIGNABLE.bottom" to="TP_BOTTOM.pin1" />
-    </board>
-  )`}
-/>
-
-Unused assignable vias keep their original net, while claimed vias are updated
-to match the completed connection. For a full walkthrough, see the
-[Biscuit Board Laser Ablation guide](../guides/tscircuit-essentials/biscuit-board-laser-ablation.mdx).
+| netIsAssignable | boolean | `false` | Marks the via as prefabricated so autorouters like `laser_prefab` can claim it for any compatible net. For a full workflow, see the [Biscuit Board Laser Ablation guide](../guides/tscircuit-essentials/biscuit-board-laser-ablation.mdx). |

--- a/docs/elements/via.mdx
+++ b/docs/elements/via.mdx
@@ -48,9 +48,8 @@ import CircuitPreview from "@site/src/components/CircuitPreview"
 
 The [`laser_prefab` autorouter](./board.mdx#setting-the-autorouter) pairs with
 prefabricated ("biscuit") via templates used in laser ablation workflows.
-Setting `netIsAssignable` on a via exports it as an **assignable obstacle**,
-allowing the autorouter to repurpose the hole for whichever net needs to switch
-layers during routing.
+Setting `netIsAssignable` on a via marks it as reusable so the autorouter can
+repurpose the hole for whichever net needs to switch layers during routing.
 
 <CircuitPreview
   defaultView="pcb"

--- a/docs/elements/via.mdx
+++ b/docs/elements/via.mdx
@@ -46,26 +46,11 @@ import CircuitPreview from "@site/src/components/CircuitPreview"
 
 ### Prefabricated vias for laser routing
 
-The [`laser_prefab` autorouter](./board.mdx#setting-the-autorouter) is designed
-for fabrication flows that combine laser ablation with pre-drilled or templated
-vias. These workflows start with a "biscuit" carrier board that already contains
-a precise matrix of holes. Copper is laminated onto the carrier and a laser
-ablates the top copper to define traces before the template's vias are filled or
-re-plated.
-
-When you mark a via with `netIsAssignable`, the autorouter exports an
-**assignable obstacle** so the router can reuse the via for whichever net needs
-to cross layers during routing. This lets you place a library of vias ahead of
-time while still giving the autorouter flexibility to finish the layout. You can
-still pre-assign a net to the via in your design; the autorouter only replaces
-that assignment if a different trace claims the via.
-
-:::tip
-Group all of the prefabricated vias together—usually in a separate subcircuit or
-component library—so you can reuse the same biscuit template across multiple
-projects. The `netIsAssignable` flag prevents unused vias from shorting random
-nets while remaining available to complete new connections.
-:::
+The [`laser_prefab` autorouter](./board.mdx#setting-the-autorouter) pairs with
+prefabricated ("biscuit") via templates used in laser ablation workflows.
+Setting `netIsAssignable` on a via exports it as an **assignable obstacle**,
+allowing the autorouter to repurpose the hole for whichever net needs to switch
+layers during routing.
 
 <CircuitPreview
   defaultView="pcb"
@@ -89,7 +74,6 @@ nets while remaining available to complete new connections.
   )`}
 />
 
-When the board renders, any assignable via that remains unused keeps its
-original net assignment. Otherwise, the autorouter replaces its net with the one
-required for the completed connection. For an end-to-end workflow, read the
+Unused assignable vias keep their original net, while claimed vias are updated
+to match the completed connection. For a full walkthrough, see the
 [Biscuit Board Laser Ablation guide](../guides/tscircuit-essentials/biscuit-board-laser-ablation.mdx).

--- a/docs/elements/via.mdx
+++ b/docs/elements/via.mdx
@@ -42,3 +42,54 @@ import CircuitPreview from "@site/src/components/CircuitPreview"
 | outerDiameter | number \| string | "0.8mm" | Outer diameter of the copper annular ring |
 | pcbX | number | 0 | PCB X position of the via |
 | pcbY | number | 0 | PCB Y position of the via |
+| netIsAssignable | boolean | `false` | Marks the via as prefabricated so autorouters like `laser_prefab` can claim it for any compatible net |
+
+### Prefabricated vias for laser routing
+
+The [`laser_prefab` autorouter](./board.mdx#setting-the-autorouter) is designed
+for fabrication flows that combine laser ablation with pre-drilled or templated
+vias. These workflows start with a "biscuit" carrier board that already contains
+a precise matrix of holes. Copper is laminated onto the carrier and a laser
+ablates the top copper to define traces before the template's vias are filled or
+re-plated.
+
+When you mark a via with `netIsAssignable`, the autorouter exports an
+**assignable obstacle** so the router can reuse the via for whichever net needs
+to cross layers during routing. This lets you place a library of vias ahead of
+time while still giving the autorouter flexibility to finish the layout. You can
+still pre-assign a net to the via in your design; the autorouter only replaces
+that assignment if a different trace claims the via.
+
+:::tip
+Group all of the prefabricated vias together—usually in a separate subcircuit or
+component library—so you can reuse the same biscuit template across multiple
+projects. The `netIsAssignable` flag prevents unused vias from shorting random
+nets while remaining available to complete new connections.
+:::
+
+<CircuitPreview
+  defaultView="pcb"
+  code={`export default () => (
+    <board width="10mm" height="10mm" autorouter="laser_prefab">
+      <testpoint name="TP_TOP" footprintVariant="pad" pcbX={0} pcbY={4} layer="top" />
+      <testpoint name="TP_BOTTOM" footprintVariant="pad" pcbX={0} pcbY={-4} layer="bottom" />
+      <via
+        name="V_ASSIGNABLE"
+        pcbX={0}
+        pcbY={0}
+        fromLayer="top"
+        toLayer="bottom"
+        holeDiameter="0.3mm"
+        outerDiameter="0.6mm"
+        netIsAssignable
+      />
+      <trace from="TP_TOP.pin1" to="V_ASSIGNABLE.top" />
+      <trace from="V_ASSIGNABLE.bottom" to="TP_BOTTOM.pin1" />
+    </board>
+  )`}
+/>
+
+When the board renders, any assignable via that remains unused keeps its
+original net assignment. Otherwise, the autorouter replaces its net with the one
+required for the completed connection. For an end-to-end workflow, read the
+[Biscuit Board Laser Ablation guide](../guides/tscircuit-essentials/biscuit-board-laser-ablation.mdx).

--- a/docs/guides/tscircuit-essentials/biscuit-board-laser-ablation.mdx
+++ b/docs/guides/tscircuit-essentials/biscuit-board-laser-ablation.mdx
@@ -1,0 +1,164 @@
+---
+title: Biscuit Board Laser Ablation
+description: Learn how to route PCBs against a prefabricated via template using the laser_prefab autorouter and the netIsAssignable via property.
+---
+
+import CircuitPreview from "@site/src/components/CircuitPreview"
+
+# Biscuit Board Laser Ablation
+
+The **laser_prefab** autorouter pairs tscircuit with a fabrication process that
+combines laser ablation and a "biscuit" carrier board. Fabricators pre-drill a
+matrix of vias into an inexpensive substrate—the biscuit—then laminate thin
+copper to the top and bottom. A UV or IR laser ablates the copper, defining the
+traces while leaving the via barrels intact. Because the vias are prefabricated,
+you route against a known template instead of drilling new holes for every
+board.
+
+This guide walks through designing for that workflow. You'll learn how to:
+
+1. Prepare a via template that can be reused across designs.
+2. Configure your board to route with `autorouter="laser_prefab"`.
+3. Mark vias as assignable so the autorouter can claim them dynamically.
+4. Validate that the generated routing honors the biscuit's geometry.
+
+## 1. Build a reusable via template
+
+Create a library subcircuit that contains every via location available on the
+biscuit board. Mark each via with `netIsAssignable` so it becomes an assignable
+obstacle when the router runs. The vias can optionally include default net names
+to serve as documentation for repeated layouts.
+
+```tsx title="src/biscuit-template.tsx"
+import { Fragment } from "react"
+
+export const BiscuitTemplate = () => (
+  <Fragment>
+    <via name="B1" pcbX={-4} pcbY={6} fromLayer="top" toLayer="bottom" netIsAssignable />
+    <via name="B2" pcbX={0} pcbY={6} fromLayer="top" toLayer="bottom" netIsAssignable />
+    <via name="B3" pcbX={4} pcbY={6} fromLayer="top" toLayer="bottom" netIsAssignable />
+    <via name="B4" pcbX={-4} pcbY={0} fromLayer="top" toLayer="bottom" netIsAssignable />
+    <via name="B5" pcbX={0} pcbY={0} fromLayer="top" toLayer="bottom" netIsAssignable />
+    <via name="B6" pcbX={4} pcbY={0} fromLayer="top" toLayer="bottom" netIsAssignable />
+  </Fragment>
+)
+```
+
+Keep the template focused on the vias themselves. Copper features such as fiducials or
+alignment marks should live in their own subcircuits so you can swap templates
+without affecting the mechanical stackup.
+
+## 2. Place the biscuit template on your board
+
+Include the template inside your `<board />` before adding components. Because
+the vias are already drilled in the physical biscuit, avoid translating or
+rotating the template in a way that misaligns the coordinates.
+
+<CircuitPreview
+  defaultView="pcb"
+  code={`export default () => (
+  <board width="20mm" height="20mm" autorouter="laser_prefab">
+    <group name="biscuit" pcbX={0} pcbY={0}>
+      <via name="B1" pcbX={-4} pcbY={6} fromLayer="top" toLayer="bottom" netIsAssignable />
+      <via name="B2" pcbX={0} pcbY={6} fromLayer="top" toLayer="bottom" netIsAssignable />
+      <via name="B3" pcbX={4} pcbY={6} fromLayer="top" toLayer="bottom" netIsAssignable />
+      <via name="B4" pcbX={-4} pcbY={0} fromLayer="top" toLayer="bottom" netIsAssignable />
+      <via name="B5" pcbX={0} pcbY={0} fromLayer="top" toLayer="bottom" netIsAssignable />
+      <via name="B6" pcbX={4} pcbY={0} fromLayer="top" toLayer="bottom" netIsAssignable />
+    </group>
+
+    <testpoint name="TP_TOP" footprintVariant="pad" pcbX={0} pcbY={9} layer="top" />
+    <testpoint name="TP_BOTTOM" footprintVariant="pad" pcbX={0} pcbY={-9} layer="bottom" />
+  </board>
+)`}
+/>
+
+If your biscuit provides fiducials or tooling holes, align them with your CAD
+origin so the panelization step can easily merge your routed copper with the
+prefabricated template. Keep the board outline slightly inside the biscuit's
+usable area so the laser can clear debris without hitting the rails.
+
+## 3. Route with `autorouter="laser_prefab"`
+
+Once the template is in place, add traces exactly as you would for a conventional
+board. The router treats assignable vias as neutral territory: any net can claim
+them provided both layers are available and no design rules are violated.
+
+```tsx title="src/laser-prefab-example.tsx"
+<board width="20mm" height="20mm" autorouter="laser_prefab">
+  <BiscuitTemplate />
+
+  <chip
+    name="U1"
+    footprint="soic8"
+    pcbX={-6}
+    pcbY={0}
+    connections={{ pin1: "R1.pin1", pin8: "B6.top" }}
+  />
+  <resistor name="R1" resistance="1k" footprint="0402" pcbX={6} pcbY={0} />
+
+  <trace from="TP_TOP.pin1" to="B2.top" />
+  <trace from="B2.bottom" to="TP_BOTTOM.pin1" />
+</board>
+```
+
+During routing, tscircuit emits a **simple route JSON** that marks each
+`netIsAssignable` via as an obstacle with the `netIsAssignable` flag. The
+`laser_prefab` preset looks for that flag, allowing it to reserve a via for any
+trace that needs to change layers. The [integration test in the core
+library](https://github.com/tscircuit/core/blob/main/tests/autorouting/laser-prefab.test.tsx)
+verifies the behavior end to end.
+
+### Reserving specific vias
+
+Sometimes you know that certain vias must stay tied to a particular net—perhaps
+they connect to ground pour or stitching features. In that case, omit the
+`netIsAssignable` flag on those vias and route them manually. The router will
+leave them untouched while still consuming the rest of the biscuit template as
+needed.
+
+## 4. Validate the routed output
+
+After calling `circuit.renderUntilSettled()`, inspect the PCB view or export the
+Gerber/ODB++ data to confirm that:
+
+- Every claimed via matches a real location on the biscuit template.
+- Unused vias remain isolated and keep their original net names.
+- Trace clearances respect your fabrication limits.
+
+<CircuitPreview
+  defaultView="pcb"
+  code={`export default () => (
+  <board width="20mm" height="20mm" autorouter="laser_prefab">
+    <group name="biscuit">
+      <via name="B2" pcbX={0} pcbY={6} fromLayer="top" toLayer="bottom" netIsAssignable />
+      <via name="B5" pcbX={0} pcbY={0} fromLayer="top" toLayer="bottom" netIsAssignable />
+    </group>
+
+    <testpoint name="TP_TOP" footprintVariant="pad" pcbX={0} pcbY={9} layer="top" />
+    <testpoint name="TP_BOTTOM" footprintVariant="pad" pcbX={0} pcbY={-9} layer="bottom" />
+
+    <trace from="TP_TOP.pin1" to="B2.top" />
+    <trace from="B2.bottom" to="B5.top" />
+    <trace from="B5.bottom" to="TP_BOTTOM.pin1" />
+  </board>
+)`}
+/>
+
+If you need to adjust routing priorities, you can provide a custom autorouter
+object instead of the preset. Just make sure the implementation understands the
+`netIsAssignable` obstacles that tscircuit produces.
+
+## Additional tips
+
+- **Version your templates.** Include a `templateVersion` prop or layer marker so
+  your fabrication team can confirm they are loading the correct biscuit.
+- **Simulate thermal load.** Prefabricated vias sometimes have smaller annular
+  rings. Run a design-rule check (DRC) to ensure high-current nets can handle the
+  reduced copper area.
+- **Document drill tolerances.** Share the biscuit's drill chart with your team so
+  component footprints can account for any off-center holes.
+
+With these practices, you can create a repeatable laser ablation workflow that
+leverages tscircuit's autorouting while taking full advantage of prefabricated
+via templates.

--- a/docs/guides/tscircuit-essentials/biscuit-board-laser-ablation.mdx
+++ b/docs/guides/tscircuit-essentials/biscuit-board-laser-ablation.mdx
@@ -24,10 +24,10 @@ This guide walks through designing for that workflow. You'll learn how to:
 
 ## 1. Build a reusable via template
 
-Create a library subcircuit that contains every via location available on the
-biscuit board. Mark each via with `netIsAssignable` so it becomes an assignable
-obstacle when the router runs. The vias can optionally include default net names
-to serve as documentation for repeated layouts.
+Create a component for your biscuit template that contains every via location
+available on the board. Mark each via with `netIsAssignable` so it is treated as
+an assignable via when the router runs. The vias can optionally include default
+net names to serve as documentation for repeated layouts.
 
 ```tsx title="src/biscuit-template.tsx"
 import { Fragment } from "react"
@@ -44,9 +44,9 @@ export const BiscuitTemplate = () => (
 )
 ```
 
-Keep the template focused on the vias themselves. Copper features such as fiducials or
-alignment marks should live in their own subcircuits so you can swap templates
-without affecting the mechanical stackup.
+Keep the template focused on the vias themselves. Copper features such as
+fiducials or alignment marks should live in their own components so you can swap
+templates without affecting the mechanical stackup.
 
 ## 2. Place the biscuit template on your board
 
@@ -73,10 +73,8 @@ rotating the template in a way that misaligns the coordinates.
 )`}
 />
 
-If your biscuit provides fiducials or tooling holes, align them with your CAD
-origin so the panelization step can easily merge your routed copper with the
-prefabricated template. Keep the board outline slightly inside the biscuit's
-usable area so the laser can clear debris without hitting the rails.
+Keep the board outline slightly inside the biscuit's usable area so the laser
+can clear debris without hitting the rails.
 
 ## 3. Route with `autorouter="laser_prefab"`
 
@@ -103,9 +101,9 @@ them provided both layers are available and no design rules are violated.
 ```
 
 During routing, tscircuit emits a **simple route JSON** that marks each
-`netIsAssignable` via as an obstacle with the `netIsAssignable` flag. The
-`laser_prefab` preset looks for that flag, allowing it to reserve a via for any
-trace that needs to change layers. The [integration test in the core
+`netIsAssignable` via with the `netIsAssignable` flag. The `laser_prefab` preset
+looks for that flag, allowing it to reserve a via for any trace that needs to
+change layers. The [integration test in the core
 library](https://github.com/tscircuit/core/blob/main/tests/autorouting/laser-prefab.test.tsx)
 verifies the behavior end to end.
 
@@ -147,7 +145,7 @@ Gerber/ODB++ data to confirm that:
 
 If you need to adjust routing priorities, you can provide a custom autorouter
 object instead of the preset. Just make sure the implementation understands the
-`netIsAssignable` obstacles that tscircuit produces.
+`netIsAssignable` vias that tscircuit produces.
 
 ## Additional tips
 

--- a/docs/guides/tscircuit-essentials/biscuit-board-laser-ablation.mdx
+++ b/docs/guides/tscircuit-essentials/biscuit-board-laser-ablation.mdx
@@ -17,12 +17,10 @@ board.
 
 This guide walks through designing for that workflow. You'll learn how to:
 
-1. Prepare a via template that can be reused across designs.
-2. Configure your board to route with `autorouter="laser_prefab"`.
-3. Mark vias as assignable so the autorouter can claim them dynamically.
-4. Validate that the generated routing honors the biscuit's geometry.
+1. Build a reusable via template (the biscuit board).
+2. Place that template, route with `autorouter="laser_prefab"`, and confirm the results match the prefabricated geometry.
 
-## 1. Build a reusable via template
+## 1. Build a reusable via template (a biscuit board)
 
 Create a component for your biscuit template that contains every via location
 available on the board. Mark each via with `netIsAssignable` so it is treated as
@@ -48,7 +46,7 @@ Keep the template focused on the vias themselves. Copper features such as
 fiducials or alignment marks should live in their own components so you can swap
 templates without affecting the mechanical stackup.
 
-## 2. Place the biscuit template on your board
+## 2. Place the biscuit template, route, and validate
 
 Include the template inside your `<board />` before adding components. Because
 the vias are already drilled in the physical biscuit, avoid translating or
@@ -76,8 +74,6 @@ rotating the template in a way that misaligns the coordinates.
 Keep the board outline slightly inside the biscuit's usable area so the laser
 can clear debris without hitting the rails.
 
-## 3. Route with `autorouter="laser_prefab"`
-
 Once the template is in place, add traces exactly as you would for a conventional
 board. The router treats assignable vias as neutral territory: any net can claim
 them provided both layers are available and no design rules are violated.
@@ -100,25 +96,8 @@ them provided both layers are available and no design rules are violated.
 </board>
 ```
 
-During routing, tscircuit emits a **simple route JSON** that marks each
-`netIsAssignable` via with the `netIsAssignable` flag. The `laser_prefab` preset
-looks for that flag, allowing it to reserve a via for any trace that needs to
-change layers. The [integration test in the core
-library](https://github.com/tscircuit/core/blob/main/tests/autorouting/laser-prefab.test.tsx)
-verifies the behavior end to end.
-
-### Reserving specific vias
-
-Sometimes you know that certain vias must stay tied to a particular net—perhaps
-they connect to ground pour or stitching features. In that case, omit the
-`netIsAssignable` flag on those vias and route them manually. The router will
-leave them untouched while still consuming the rest of the biscuit template as
-needed.
-
-## 4. Validate the routed output
-
-After calling `circuit.renderUntilSettled()`, inspect the PCB view or export the
-Gerber/ODB++ data to confirm that:
+After generating manufacturing data (Gerber or ODB++ exports) or reviewing the
+PCB preview, confirm that:
 
 - Every claimed via matches a real location on the biscuit template.
 - Unused vias remain isolated and keep their original net names.
@@ -142,21 +121,3 @@ Gerber/ODB++ data to confirm that:
   </board>
 )`}
 />
-
-If you need to adjust routing priorities, you can provide a custom autorouter
-object instead of the preset. Just make sure the implementation understands the
-`netIsAssignable` vias that tscircuit produces.
-
-## Additional tips
-
-- **Version your templates.** Include a `templateVersion` prop or layer marker so
-  your fabrication team can confirm they are loading the correct biscuit.
-- **Simulate thermal load.** Prefabricated vias sometimes have smaller annular
-  rings. Run a design-rule check (DRC) to ensure high-current nets can handle the
-  reduced copper area.
-- **Document drill tolerances.** Share the biscuit's drill chart with your team so
-  component footprints can account for any off-center holes.
-
-With these practices, you can create a repeatable laser ablation workflow that
-leverages tscircuit's autorouting while taking full advantage of prefabricated
-via templates.


### PR DESCRIPTION
## Summary
- add a Biscuit Board Laser Ablation guide to tscircuit Essentials covering the laser_prefab workflow
- expand the via documentation with biscuit template context and guidance on managing assignable vias
- reference the new guide from the board autorouter section

## Testing
- bunx tsc --noEmit
- bun run format

------
https://chatgpt.com/codex/tasks/task_b_69063531cfb4832ebca3e6c858c2a7cf