### PR TITLE
fix: wrap CircuitPreview components in board tags for proper rendering

### DIFF
--- a/docs/building-electronics/what-are-electronics-made-of.mdx
+++ b/docs/building-electronics/what-are-electronics-made-of.mdx
@@ -86,15 +86,17 @@ pins are called "surface-mount" chips.
 <CircuitPreview defaultView="pcb" code={`
 
 export default () => (
-  <footprint>
-    <platedhole
-      shape="circle"
-      x="5mm"
-      y="2.4mm"
-      holeDiameter="0.25mm"
-      outerDiameter="0.35mm"
-    />
-  </footprint>
+  <board width="2mm" height="2mm">
+    <footprint>
+      <platedhole
+        shape="circle"
+        x="5mm"
+        y="2.4mm"
+        holeDiameter="0.25mm"
+        outerDiameter="0.35mm"
+      />
+    </footprint>
+  </board>
 )
 
 `} />
@@ -108,9 +110,11 @@ can be very helpful for mounting the printed circuit board.
 <CircuitPreview defaultView="pcb" code={`
 
 export default () => (
-  <footprint>
-    <hole diameter="1mm" />
-  </footprint>
+  <board width="2mm" height="2mm">
+    <footprint>
+      <hole diameter="1mm" />
+    </footprint>
+  </board>
 )
 
 `} />


### PR DESCRIPTION
/fix #307 

Wrapping the component with the board does fix it but adds a border in PCB view, i think that is acceptable (maybe).

# Before:

3D
<img width="1920" height="1080" alt="Screenshot_20251104_030434" src="https://github.com/user-attachments/assets/ee8cdd2c-845d-4d8f-9e53-12f3b8bed910" />

PCB
<img width="1920" height="1080" alt="Screenshot_20251104_030353" src="https://github.com/user-attachments/assets/5a560e23-270f-4659-9331-a50f5727b242" />

# After:

3D
<img width="1920" height="1080" alt="Screenshot_20251104_030536" src="https://github.com/user-attachments/assets/1be0061b-7b0a-4415-ad94-a0ee9651b22e" />


PCB
<img width="1920" height="1080" alt="Screenshot_20251104_030511" src="https://github.com/user-attachments/assets/77a0fd49-0e25-4afe-bde3-65c888230d7c" />
