### PR TITLE
fix add board tag to silkscreenrect for rendering 3d view

### DIFF
--- a/docs/footprints/silkscreenrect.mdx
+++ b/docs/footprints/silkscreenrect.mdx
@@ -12,11 +12,13 @@ import CircuitPreview from "@site/src/components/CircuitPreview"
 
 <CircuitPreview code={`
   export default () => (
+  <board width="5mm" height="5mm">
     <group>
       <footprint>
         <silkscreenrect pcbX={0} pcbY={0} width={1} height={1} />
       </footprint>
     </group>
+      </board>
   )
 `} />
 
@@ -26,6 +28,7 @@ Enable the `filled` prop to create solid silkscreen blocks—useful for alignmen
 
 <CircuitPreview code={`
   export default () => (
+  <board width="5mm" height="5mm">
     <group>
       <footprint name="U1">
         <silkscreenrect pcbX={-1.2} pcbY={0} width={1} height={1} />
@@ -38,5 +41,6 @@ Enable the `filled` prop to create solid silkscreen blocks—useful for alignmen
         />
       </footprint>
     </group>
+  </board>
   )
 `} />

--- a/docs/footprints/silkscreenrect.mdx
+++ b/docs/footprints/silkscreenrect.mdx
@@ -18,7 +18,7 @@ import CircuitPreview from "@site/src/components/CircuitPreview"
         <silkscreenrect pcbX={0} pcbY={0} width={1} height={1} />
       </footprint>
     </group>
-      </board>
+  </board>
   )
 `} />
 


### PR DESCRIPTION
fix #309 

## Before
<img width="1124" height="907" alt="Screenshot_2025-11-04_13-36-45" src="https://github.com/user-attachments/assets/6de7e1e8-a694-48e5-aa6c-5ba990375a22" />


## After
<img width="975" height="879" alt="Screenshot_2025-11-04_13-55-20" src="https://github.com/user-attachments/assets/34eda699-6112-4d92-b606-8ee01b4f9304" />
