### PR TITLE
Fix: Improve sidebar indentation for nested documentation groups

### DIFF
--- a/docs/guides/running-tscircuit/scripting/_category_.json
+++ b/docs/guides/running-tscircuit/scripting/_category_.json
@@ -1,0 +1,10 @@
+{
+  "label": "Scripting",
+  "position": 10,
+  "link": {
+    "type": "generated-index",
+    "description": "Learn how to use tscircuit programmatically with scripts."
+  },
+  "collapsible": true,
+  "collapsed": false
+}

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -624,27 +624,30 @@ figure img {
   padding-right: 16px !important;
 }
 
-.sidebar-item-level-1 .menu__link {
-  padding-left: 16px !important;
-}
-
-.sidebar-item-level-2 .menu__link {
-  padding-left: 16px !important;
-}
-
-.sidebar-item-level-3 .menu__link {
+.theme-doc-sidebar-item-category[class*="level-3"]
+  > .menu__list-item-collapsible
+  > .menu__link {
   padding-left: 28px !important;
 }
 
-.sidebar-item-level-4 .menu__link {
+.theme-doc-sidebar-item-link[class*="level-4"] .menu__link,
+.theme-doc-sidebar-item-category[class*="level-4"]
+  > .menu__list-item-collapsible
+  > .menu__link {
   padding-left: 40px !important;
 }
 
-.sidebar-item-level-5 .menu__link {
+.theme-doc-sidebar-item-link[class*="level-5"] .menu__link,
+.theme-doc-sidebar-item-category[class*="level-5"]
+  > .menu__list-item-collapsible
+  > .menu__link {
   padding-left: 52px !important;
 }
 
-.sidebar-item-level-6 .menu__link {
+.theme-doc-sidebar-item-link[class*="level-6"] .menu__link,
+.theme-doc-sidebar-item-category[class*="level-6"]
+  > .menu__list-item-collapsible
+  > .menu__link {
   padding-left: 64px !important;
 }
 

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -624,6 +624,30 @@ figure img {
   padding-right: 16px !important;
 }
 
+.sidebar-item-level-1 .menu__link {
+  padding-left: 16px !important;
+}
+
+.sidebar-item-level-2 .menu__link {
+  padding-left: 16px !important;
+}
+
+.sidebar-item-level-3 .menu__link {
+  padding-left: 28px !important;
+}
+
+.sidebar-item-level-4 .menu__link {
+  padding-left: 40px !important;
+}
+
+.sidebar-item-level-5 .menu__link {
+  padding-left: 52px !important;
+}
+
+.sidebar-item-level-6 .menu__link {
+  padding-left: 64px !important;
+}
+
 @media (max-width: 768px) {
   iframe {
     max-width: 90vw;

--- a/src/theme/DocSidebarItem/index.tsx
+++ b/src/theme/DocSidebarItem/index.tsx
@@ -6,11 +6,5 @@ import type { WrapperProps } from "@docusaurus/types"
 type Props = WrapperProps<typeof DocSidebarItemType>
 
 export default function DocSidebarItemWrapper(props: Props): ReactNode {
-  const depth = props.level || 1
-
-  return (
-    <div className={`sidebar-item-level-${depth}`}>
-      <DocSidebarItem {...props} />
-    </div>
-  )
+  return <DocSidebarItem {...props} />
 }

--- a/src/theme/DocSidebarItem/index.tsx
+++ b/src/theme/DocSidebarItem/index.tsx
@@ -1,0 +1,16 @@
+import React, { type ReactNode } from "react"
+import DocSidebarItem from "@theme-original/DocSidebarItem"
+import type DocSidebarItemType from "@theme/DocSidebarItem"
+import type { WrapperProps } from "@docusaurus/types"
+
+type Props = WrapperProps<typeof DocSidebarItemType>
+
+export default function DocSidebarItemWrapper(props: Props): ReactNode {
+  const depth = props.level || 1
+
+  return (
+    <div className={`sidebar-item-level-${depth}`}>
+      <DocSidebarItem {...props} />
+    </div>
+  )
+}


### PR DESCRIPTION
Before:
<img width="223" height="335" alt="image" src="https://github.com/user-attachments/assets/1c99e21d-5489-4d03-9230-bda13a6c08b2" />


After:
<img width="288" height="380" alt="image" src="https://github.com/user-attachments/assets/2903df85-822d-479a-989a-f1acdd191cc3" />
