### PR TITLE
feat(docs): Add SPICE simulation documentation

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -21,7 +21,7 @@
         "@docusaurus/module-type-aliases": "3.8.1",
         "@docusaurus/tsconfig": "3.8.1",
         "@docusaurus/types": "3.8.1",
-        "@tscircuit/create-snippet-url": "^0.0.10",
+        "@tscircuit/create-snippet-url": "^0.0.12",
         "@tscircuit/footprinter": "^0.0.135",
         "@tscircuit/math-utils": "^0.0.18",
         "@twind/core": "^1.1.3",
@@ -619,7 +619,7 @@
 
     "@trysound/sax": ["@trysound/sax@0.2.0", "", {}, "sha512-L7z9BgrNEcYyUYtF+HaEfiS5ebkh9jXqbszz7pC0hRBPaatV0XjSD3+eHrpqFemQfgwiFF0QPIarnIihIDn7OA=="],
 
-    "@tscircuit/create-snippet-url": ["@tscircuit/create-snippet-url@0.0.10", "", { "dependencies": { "fflate": "^0.8.2" }, "peerDependencies": { "typescript": "^5.0.0" } }, "sha512-5sFzUsrRIPisnRWjGFvVORGRJTrxLB4FXp1ZFSrr/5RXz/OJTL900YA34IRYulVypR5rU7krEnTs9ed5gpIBWA=="],
+    "@tscircuit/create-snippet-url": ["@tscircuit/create-snippet-url@0.0.12", "", { "dependencies": { "fflate": "^0.8.2" }, "peerDependencies": { "typescript": "^5.0.0" } }, "sha512-dOBs/rv53Gz2y6swurLKbF25kUmz9KPzDAndjBh+lmmWSs6QRs63OubIk7HYBagsdgwKvOhHDceSl4ByTmTAZQ=="],
 
     "@tscircuit/footprinter": ["@tscircuit/footprinter@0.0.135", "", { "dependencies": { "@tscircuit/mm": "^0.0.8", "zod": "^3.23.8" }, "peerDependencies": { "circuit-json": "*" } }, "sha512-+8MasMGTNQL/NINnlWk2v6zw/NDerfdIBG3uqhrTr0r7VOHh4lK1ymTkQR7IeoypkxTIHYGB9wHbOt39XAF3mg=="],
 

--- a/docs/advanced/spice-simulation.mdx
+++ b/docs/advanced/spice-simulation.mdx
@@ -1,0 +1,155 @@
+---
+title: SPICE Simulation
+sidebar_position: 4
+description: >-
+  Run SPICE simulations on your circuits to analyze their analog behavior.
+---
+
+import CircuitPreview from "@site/src/components/CircuitPreview"
+
+## Overview
+
+tscircuit supports SPICE simulation to analyze the analog behavior of your circuits. You can define voltage sources with various waveforms, place probes to measure voltages, and configure the simulation parameters. The results can be visualized to understand how your circuit performs over time.
+
+## Simulation Components
+
+### `<analogsimulation />`
+
+This component configures and enables the analog simulation for the board.
+
+| Property      | Type   | Description                                           |
+| ------------- | ------ | ----------------------------------------------------- |
+| `duration`    | number | The total duration of the simulation (e.g., in seconds).    |
+| `timePerStep` | number | The time interval between simulation steps (e.g., in seconds). |
+| `spiceEngine` | string | The SPICE engine to use (e.g., `"ngspice"`).            |
+
+Example:
+
+```tsx
+<analogsimulation
+  duration={0.01}
+  timePerStep={1e-6}
+  spiceEngine="ngspice"
+/>
+```
+
+### Probes
+
+Probes are used to specify which parts of the circuit you want to measure. These do not have a physical representation on the PCB.
+
+#### `<voltageprobe />`
+
+Measures the voltage at a specific point in the circuit.
+
+| Property     | Type   | Description                                                                                             |
+| ------------ | ------ | ------------------------------------------------------------------------------------------------------- |
+| `connectsTo` | string | A [port selector](../guides/tscircuit-essentials/port-and-net-selectors.md) indicating where to place the probe. |
+
+Example:
+
+```tsx
+<voltageprobe connectsTo=".R1 > .pin1" />
+```
+
+### `<voltagesource />`
+
+For simulations, `<voltagesource />` can be configured to produce various waveforms beyond a simple DC voltage.
+
+| Property    | Type             | Description                                                                    |
+| ----------- | ---------------- | ------------------------------------------------------------------------------ |
+| `waveShape` | string           | Shape of the voltage wave. Can be `"dc"`, `"sine"`, `"square"`, `"triangle"`.  |
+| `frequency` | string or number | Frequency of the waveform (e.g., `"1kHz"` or `1000`).                           |
+| `amplitude` | string or number | Amplitude of the AC signal. For square waves, this is the peak voltage.        |
+| `offset`    | string or number | DC offset of the waveform.                                                     |
+| `dutyCycle` | number           | For square waves, the fraction of the period the signal is high (0 to 1). |
+
+## Example: Boost Converter
+
+Here is an example of a boost converter circuit configured for SPICE simulation. It uses one voltage source (`V2`) with a square wave to drive a MOSFET, boosting the voltage from a 5V DC source (`V1`) to a higher level. Voltage probes are placed at the input and output to observe the results.
+
+<CircuitPreview
+  defaultView="schematic"
+  showSimulationGraph={true}
+  code={`
+export default () => (
+      <board width={30} height={30} schMaxTraceDistance={5}>
+        <voltagesource
+          name="V1"
+          voltage={"5V"}
+          schY={2}
+          schX={-5}
+          schRotation={270}
+        />
+        <trace from={".V1 > .pin1"} to={".L1 > .pin1"} />
+        <trace from={".L1 > .pin2"} to={".D1 > .anode"} />
+        <trace from={".D1 > .cathode"} to={".C1 > .pin1"} />
+        <trace from={".D1 > .cathode"} to={".R1 > .pin1"} />
+        <trace from={".C1 > .pin2"} to={".R1 > .pin2"} />
+        <trace from={".R1 > .pin2"} to={".V1 > .pin2"} />
+        <trace from={".L1 > .pin2"} to={".M1 > .drain"} />
+        <trace from={".M1 > .source"} to={".V1 > .pin2"} />
+        <trace from={".M1 > .source"} to={"net.GND"} />
+        <trace from={".M1 > .gate"} to={".V2 > .pin1"} />
+        <trace from={".V2 > .pin2"} to={".V1 > .pin2"} />
+        <inductor 
+          footprint={"0603"} 
+          name="L1" 
+          inductance={"1mH"} 
+          schY={3} 
+          schX={-1} 
+          pcbY={3} 
+        />
+        <diode
+          name="D1"
+          footprint={"0603"}
+          schY={3}
+          schX={2.1}
+          pcbY={6}
+          pcbX={3}
+        />
+        <capacitor
+          polarized
+          schRotation={270}
+          name="C1"
+          capacitance={"10uF"}
+          footprint={"0603"}
+          schX={3}
+          pcbX={3}
+        />
+        <resistor
+          schRotation={270}
+          name="R1"
+          resistance={"1k"}
+          footprint={"0603"}
+          schX={6}
+          pcbX={9}
+        />
+        <voltagesource
+          name="V2"
+          voltage={"10V"}
+          waveShape="square"
+          dutyCycle={0.68}
+          frequency={"1kHz"}
+          schX={-3}
+          schRotation={270}
+        />
+        <mosfet
+          channelType="n"
+          footprint={"sot23"}
+          name="M1"
+          mosfetMode="enhancement"
+          pcbX={-4}
+        />
+        <voltageprobe connectsTo={".V1 > .pin1"} />
+        <voltageprobe connectsTo={".R1 > .pin1"} />
+
+        <analogsimulation
+          duration={100}
+          timePerStep={1}
+          spiceEngine="ngspice"
+        />
+      </board>
+)
+`} />
+
+The simulation results would show the output voltage across `R1` successfully "boosted" compared to the 5V input from `V1`. The specific output voltage depends on the duty cycle of the MOSFET driver `V2` and the component values.

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "@docusaurus/module-type-aliases": "3.8.1",
     "@docusaurus/tsconfig": "3.8.1",
     "@docusaurus/types": "3.8.1",
-    "@tscircuit/create-snippet-url": "^0.0.10",
+    "@tscircuit/create-snippet-url": "^0.0.12",
     "@tscircuit/footprinter": "^0.0.135",
     "@tscircuit/math-utils": "^0.0.18",
     "@twind/core": "^1.1.3",

--- a/src/components/CircuitPreview.tsx
+++ b/src/components/CircuitPreview.tsx
@@ -88,6 +88,7 @@ export default function CircuitPreview({
   projectBaseUrl = "https://docs.tscircuit.com/",
   leftView,
   rightView,
+  showSimulationGraph = false,
 }: {
   code?: string
   showTabs?: boolean
@@ -106,6 +107,7 @@ export default function CircuitPreview({
   leftView?: "code" | "pcb" | "schematic" | "3d" | "runframe" | "pinout"
   rightView?: "code" | "pcb" | "schematic" | "3d" | "runframe" | "pinout"
   projectBaseUrl?: string
+  showSimulationGraph?: boolean
 }) {
   const { isDarkTheme } = useColorMode()
   const windowSize = useWindowSize()
@@ -141,11 +143,17 @@ export default function CircuitPreview({
   const fsMapOrCode = hasMultipleFiles
     ? fsMap || code
     : code || Object.values(fsMap ?? {})[0]
+
   const pcbUrl = useMemo(() => createSvgUrl(fsMapOrCode, "pcb"), [fsMapOrCode])
+  console.log(fsMapOrCode)
   const schUrl = useMemo(
-    () => createSvgUrl(fsMapOrCode, "schematic"),
-    [fsMapOrCode],
+    () =>
+      createSvgUrl(fsMapOrCode, showSimulationGraph ? "schsim" : "schematic", {
+        simulationExperimentId: "simulation_experiment_0",
+      }),
+    [fsMapOrCode, showSimulationGraph],
   )
+  console.log(schUrl)
   const pinoutUrl = useMemo(
     () => createSvgUrl(fsMapOrCode, "pinout"),
     [fsMapOrCode],


### PR DESCRIPTION
This PR introduces documentation for `tscircuit`'s SPICE simulation capabilities and improves the `CircuitPreview` component to display simulation results.

### Key Changes:

-   **New Documentation Page**: Added `docs/advanced/spice-simulation.mdx` to explain how to use simulation components like `<analogsimulation>`, `<voltageprobe>`, and waveform options in `<voltagesource>`. The page includes a boost converter example.
-   **`CircuitPreview` Improvement**: The component now accepts a `showSimulationGraph` prop. When `true`, it requests a schematic view with the simulation graph overlaid (`schsim`).
-   **Dependency Update**: Bumped `@tscircuit/create-snippet-url` to support the new simulation view type.
<img width="1346" height="525" alt="Screenshot 2025-11-10 at 9 09 31 PM" src="https://github.com/user-attachments/assets/178a61ec-2db9-4d5d-a151-43d659e2bb7f" />
