### PR TITLE
Disable browser 3D preview by default in CircuitPreview

### DIFF
--- a/src/components/CircuitPreview.tsx
+++ b/src/components/CircuitPreview.tsx
@@ -80,7 +80,7 @@ export default function CircuitPreview({
   hidePCBTab = false,
   hide3DTab = false,
   showPinoutTab = false,
-  browser3dView = true,
+  browser3dView = false,
   fsMap,
   entrypoint = undefined,
   mainComponentPath = undefined,


### PR DESCRIPTION
## Summary
- default the CircuitPreview browser-driven 3D rendering to false to prevent unnecessary interactive previews

## Testing
- bunx tsc --noEmit *(fails: project lacks Docusaurus/React type configuration in this environment)*
- bun run format *(fails: biome command is not available in this environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69127e362ec8832e9161796a17f119c1)