### PR TITLE
feat: Enable infinite 3d grid for 3d docs images

### DIFF
--- a/src/components/CircuitPreview.tsx
+++ b/src/components/CircuitPreview.tsx
@@ -180,6 +180,7 @@ export default function CircuitPreview({
         format: "png",
         png_width: "800",
         png_height: "600",
+        show_infinite_grid: "true",
         fs_map: encodeURIComponent(encodedFsMap),
         main_component_path: mainComponentPath
           ? encodeURIComponent(mainComponentPath)
@@ -195,7 +196,7 @@ export default function CircuitPreview({
     const encodedCode = encodeURIComponent(
       getCompressedBase64SnippetString(code),
     )
-    return `https://svg.tscircuit.com/?svg_type=3d&format=png&png_width=800&png_height=600&code=${encodedCode}`
+    return `https://svg.tscircuit.com/?svg_type=3d&format=png&png_width=800&png_height=600&show_infinite_grid=true&code=${encodedCode}`
   }, [code, browser3dView, fsMap])
 
   const shouldSplitCode = _splitView && windowSize !== "mobile"


### PR DESCRIPTION
<img width="791" height="391" alt="image" src="https://github.com/user-attachments/assets/5296e278-6991-4a06-a171-3af5a9ea2b21" />
<img width="736" height="422" alt="image" src="https://github.com/user-attachments/assets/b3bde173-f8df-47d8-8d4c-21911f9997e4" />


Fix #319
