### PR TITLE
Fix hole example PCB coordinates in documentation

### DIFF
--- a/docs/elements/hole.mdx
+++ b/docs/elements/hole.mdx
@@ -32,7 +32,7 @@ A circular hole is the most common type used for mounting:
   browser3dView={false}
   code={`export default () => (
     <board width="30mm" height="20mm">
-      <hole diameter="3mm" pcbX={10} pcbY={10} />
+      <hole diameter="3mm" pcbX={0} pcbY={0} />
     </board>
   )`}
 />


### PR DESCRIPTION
This pull request updates the example code in the documentation for the `hole` element. The change modifies the position of the hole in the example to better illustrate its default placement.

Documentation update:

* In `docs/elements/hole.mdx`, the example code for the `hole` element now places the hole at coordinates `(0, 0)` instead of `(10, 10)`.

## Before

<img width="908" height="677" alt="image" src="https://github.com/user-attachments/assets/b64f18c9-e2f0-4c50-a7a7-367a1fe0352a" />

## After

<img width="908" height="683" alt="Screenshot_20251111_231550" src="https://github.com/user-attachments/assets/28478b9a-d07f-4704-ad3d-5d5ced3c4373" />
