### PR TITLE
Move SPICE simulation doc into Guides section

### DIFF
--- a/docs/guides/spice-simulation.mdx
+++ b/docs/guides/spice-simulation.mdx
@@ -1,6 +1,5 @@
 ---
 title: SPICE Simulation
-sidebar_position: 4
 description: >-
   Run SPICE simulations on your circuits to analyze their analog behavior.
 ---
@@ -43,7 +42,7 @@ Measures the voltage at a specific point in the circuit.
 
 | Property     | Type   | Description                                                                                             |
 | ------------ | ------ | ------------------------------------------------------------------------------------------------------- |
-| `connectsTo` | string | A [port selector](../guides/tscircuit-essentials/port-and-net-selectors.md) indicating where to place the probe. |
+| `connectsTo` | string | A [port selector](./tscircuit-essentials/port-and-net-selectors.md) indicating where to place the probe. |
 
 Example:
 


### PR DESCRIPTION
## Summary
- move the SPICE Simulation documentation page from the Advanced section into Guides
- update the document frontmatter and internal link so it fits the Guides hierarchy

## Testing
- bunx tsc --noEmit *(fails: requires Docusaurus/React type dependencies in this environment)*
- bun run format *(fails: biome CLI is not available in this environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_691415fe80d4832ea51f06904ff8cc54)