### PR TITLE
Add switch example for SPICE simulation

### DIFF
--- a/docs/guides/spice-simulation/introduction.mdx
+++ b/docs/guides/spice-simulation/introduction.mdx
@@ -61,3 +61,12 @@ Example:
 | `amplitude` | string or number | Amplitude of the AC signal. For square waves, this is the peak voltage. |
 | `offset` | string or number | DC offset of the waveform. |
 | `dutyCycle` | number | For square waves, the fraction of the period the signal is high (0 to 1). |
+
+### {"<switch />"}
+<p>
+  For simulations, a {"<switch />"} can be configured to toggle at a
+  specific frequency.
+</p>
+| Property | Type | Description |
+| :--- | :--- | :--- |
+| `simSwitchFrequency` | string or number | Frequency at which the switch toggles (e.g., `"1kHz"` or `1000`). |

--- a/docs/guides/spice-simulation/switch-example.mdx
+++ b/docs/guides/spice-simulation/switch-example.mdx
@@ -1,0 +1,44 @@
+---
+title: Switch Example
+sidebar_label: Switch
+sidebar_position: 4
+description: An example of using a switch in a SPICE simulation.
+---
+import CircuitPreview from "@site/src/components/CircuitPreview"
+
+<p>
+  This example demonstrates how to use a switch in a SPICE simulation. When
+  the <code>simSwitchFrequency</code> property is set, an ideal switch will
+  toggle at the specified frequency. A voltage probe is placed after the switch
+  to observe the output.
+</p>
+<CircuitPreview
+  defaultView="schematic"
+  showSimulationGraph={true}
+  code={`
+export default () => (
+      <board schMaxTraceDistance={10} routingDisabled>
+        <voltagesource name="V1" voltage="5V" />
+        <switch name="SW1" spst simSwitchFrequency="1kHz" />
+        <trace from=".V1 > .terminal1" to=".SW1 > .pin1" />
+        <resistor
+          name="R1"
+          resistance="1k"
+          footprint="0402"
+          connections={{ pin1: ".SW1 > .pin2", pin2: ".V1 > .terminal2" }}
+        />
+        <voltageprobe connectsTo={".R1 > .pin1"} />
+        <analogsimulation
+          duration="4ms"
+          timePerStep="10us"
+          spiceEngine="ngspice"
+        />
+      </board>
+)
+`}
+/>
+<p>
+  The simulation shows the voltage at the node after the switch. Since the
+  switch is toggling at 1kHz, the voltage probe will show a 1kHz square
+  wave going between approximately 0V and 5V.
+</p>


### PR DESCRIPTION
This pull request introduces a new documentation page with an example of using a <switch /> component in a SPICE  
simulation. It also updates the SPICE simulation introduction to include details on the <switch /> component's    
simulation-specific properties.
<img width="1317" height="723" alt="Screenshot 2025-11-13 at 7 06 49 PM" src="https://github.com/user-attachments/assets/06286de7-0dd0-4369-a047-b00331d20220" />
