### PR TITLE
feat(docs): add half-wave rectifier SPICE example

### DIFF
--- a/docs/guides/spice-simulation/Diodes/_category_.json
+++ b/docs/guides/spice-simulation/Diodes/_category_.json
@@ -1,0 +1,6 @@
+{
+  "label": "Diodes",
+  "position": 2,
+  "collapsible": true,
+  "collapsed": true
+}

--- a/docs/guides/spice-simulation/Diodes/half-wave-rectifier.mdx
+++ b/docs/guides/spice-simulation/Diodes/half-wave-rectifier.mdx
@@ -1,0 +1,55 @@
+---
+title: Half-Wave Rectifier Example
+sidebar_label: Half-Wave Rectifier
+sidebar_position: 1
+description: An example of a half-wave rectifier circuit for SPICE simulation.
+---
+import CircuitPreview from "@site/src/components/CircuitPreview"
+
+<p>
+  This example demonstrates a half-wave rectifier. The diode allows current to
+  flow in only one direction, effectively cutting off the negative portion of
+  the AC input sine wave. The two voltage probes allow for a comparison of
+  the input and output waveforms.
+</p>
+<CircuitPreview
+  defaultView="schematic"
+  hidePCBTab={true}
+  hide3DTab={true}
+  verticalStack={true}
+  showSimulationGraph={true}
+  code={`
+export default () => (
+      <board schMaxTraceDistance={10} routingDisabled>
+        <voltagesource
+          name="V1"
+          voltage="5V"
+          frequency="40Hz"
+          waveShape="sinewave"
+        />
+        <diode name="D1" />
+        <resistor name="R1" resistance="640ohm" />
+
+        <trace from=".V1 > .pin1" to=".D1 > .anode" />
+        <trace from=".D1 > .cathode" to=".R1 > .pin1" />
+
+        <trace from=".V1 > .pin2" to=".R1 > .pin2" />
+
+        <voltageprobe name="VP_IN" connectsTo=".V1 > .pin1" />
+        <voltageprobe name="VP_OUT" connectsTo=".R1 > .pin1" />
+
+        <analogsimulation
+          duration="50ms"
+          timePerStep="0.1ms"
+          spiceEngine="ngspice"
+        />
+      </board>
+)
+`}
+/>
+<p>
+  The simulation graph shows the input sine wave and the rectified output.
+  The output voltage follows the positive half of the input sine wave and is
+  approximately 0V during the negative half, demonstrating the rectifying
+  action of the diode.
+</p>

--- a/docs/guides/spice-simulation/boost-converter.mdx
+++ b/docs/guides/spice-simulation/boost-converter.mdx
@@ -1,7 +1,7 @@
 ---
 title: Boost Converter Example
 sidebar_label: Boost Converter
-sidebar_position: 2
+sidebar_position: 3
 description: An example of a boost converter circuit configured for SPICE simulation.
 ---
 import CircuitPreview from "@site/src/components/CircuitPreview"

--- a/docs/guides/spice-simulation/rc-charging-circuit.mdx
+++ b/docs/guides/spice-simulation/rc-charging-circuit.mdx
@@ -1,7 +1,7 @@
 ---
 title: RC Charging Circuit Example
 sidebar_label: RC Charging Circuit
-sidebar_position: 3
+sidebar_position: 4
 description: An example of an RC charging circuit configured for SPICE simulation.
 ---
 import CircuitPreview from "@site/src/components/CircuitPreview"

--- a/docs/guides/spice-simulation/switch-example.mdx
+++ b/docs/guides/spice-simulation/switch-example.mdx
@@ -1,7 +1,7 @@
 ---
 title: Switch Example
 sidebar_label: Switch
-sidebar_position: 4
+sidebar_position: 5
 description: An example of using a switch in a SPICE simulation.
 ---
 import CircuitPreview from "@site/src/components/CircuitPreview"


### PR DESCRIPTION
This pull request introduces a new SPICE simulation example for a half-wave rectifier circuit.                    

A new "Diodes" category has been added under the SPICE Simulation section to house relevant examples. The new     
half-wave rectifier example is the first to be included. To accommodate this change, the sidebar_position for     
other SPICE examples has been updated.

<img width="465" height="241" alt="Screenshot 2025-11-14 at 5 36 48 PM" src="https://github.com/user-attachments/assets/f1478c31-6b46-4b0c-8952-2b6bcbcfe7f5" />

<img width="1299" height="756" alt="Screenshot 2025-11-14 at 5 36 35 PM" src="https://github.com/user-attachments/assets/7a3b5ea9-5cce-407c-9f9b-f24fa6e6ee93" />
