### PR TITLE
Document gltf and glb tsci export formats

### DIFF
--- a/docs/command-line/tsci-export.md
+++ b/docs/command-line/tsci-export.md
@@ -40,6 +40,8 @@ The following export formats are supported:
 | `pcb-svg` | PCB layout as SVG |
 | `readable-netlist` | Human-readable netlist |
 | `specctra-dsn` | Specctra DSN format for autorouting |
+| `gltf` | Text-based 3D scene (glTF 2.0) that references board meshes and textures |
+| `glb` | Binary glTF bundle that packs geometry, materials, and textures into a single file |
 
 ## Examples
 
@@ -62,6 +64,28 @@ Export to Specctra DSN format:
 ```bash
 tsci export circuit.tsx -f specctra-dsn
 ```
+
+## Exporting 3D models
+
+Use the `gltf` or `glb` formats when you want a 3D representation of your board for use in CAD tools, AR viewers, or when embedding on the web.
+
+### Export as glTF
+
+```bash
+tsci export circuit.tsx --format gltf
+```
+
+This produces a `.gltf` file (plus any referenced texture files) that follows the [glTF 2.0](https://www.khronos.org/gltf/) spec. Because the assets stay separate, glTF exports are easier to diff in git and you can selectively optimize textures.
+
+### Export as GLB
+
+```bash
+tsci export circuit.tsx --format glb
+```
+
+The `glb` format wraps the same data into a single binary so you can upload one file to a web viewer (for example, https://gltf.report/ or `model-viewer`). This is handy for sharing previews or attaching a lightweight CAD model to a manufacturing request.
+
+Both commands work with `.tsx` source files as well as `.circuit.json` files, so you can export whichever representation you already have. Each command writes the 3D model next to the input file unless you override the location with `--output <path>`.
 
 ## Output Files
 


### PR DESCRIPTION
## Summary
- describe the new `gltf` and `glb` entries in the `tsci export` format table and explain when to choose each one
- add a dedicated "Exporting 3D models" section that walks through the commands and common viewer workflows

## Testing
- `tsci export /tmp/tsci-export-demo.tsx --format gltf`
- `tsci export /tmp/tsci-export-demo.tsx --format glb`
- `bunx tsc --noEmit`
- `bun run format`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_691ba7326530832e952f92fef308694d)