### PR TITLE
Document `tsci build --transpile`

### DIFF
--- a/docs/command-line/tsci-build.md
+++ b/docs/command-line/tsci-build.md
@@ -31,13 +31,11 @@ Use this command before publishing or in CI to ensure your circuits evaluate cor
 
 ## Transpiling circuit entrypoints
 
-Pass the `--transpile` flag when you need browser-friendly or Node.js-friendly bundles of the same entry file you used to build `circuit.json`. The flag runs an extra Rollup pass that writes:
+Pass the `--transpile` flag when you want your codebase to be a reusable module that can be imported into other projects. Your "entrypoint", usually `lib/index.tsx` will be the source for the bundle. Export any circuits you'd like out of that file
 
 - `dist/<entry>/index.js` – an ESM bundle
 - `dist/<entry>.cjs` – a CommonJS bundle
 - `dist/<entry>.d.ts` – generated type declarations that reflect the JSX surface of your entry file
-
-This extra work is useful when you want to re-use the same TSCircuit entrypoint in a documentation site, demo, or other tooling without re-running the evaluator.
 
 ### Example project
 
@@ -52,7 +50,6 @@ tsci init
 Replace the generated `index.tsx` with a tiny RC circuit:
 
 ```tsx title="index.tsx"
-/// <reference types="tscircuit" />
 import React from "react"
 
 export default () => (
@@ -78,7 +75,6 @@ tsci build --transpile
 
 The build writes `dist/index/circuit.json` as usual, then finishes by bundling the entrypoint and printing the paths to the emitted ESM, CJS, and type declaration artifacts.
 
-You can inspect the generated files with `tree dist`:
 
 ```text
 dist

--- a/docs/command-line/tsci-build.md
+++ b/docs/command-line/tsci-build.md
@@ -21,7 +21,7 @@ Output files are placed in a `dist/` directory relative to your project. The mai
 - `--ignore-errors` – do not exit with code `1` on evaluation errors.
 - `--ignore-warnings` – suppress warning messages.
 - `--all-images` – emit every renderable image (PCB, schematic, 3D preview) for each built circuit into the matching `dist` subdirectory.
-- `--transpile` – emit bundler-friendly JavaScript alongside the generated `circuit.json`. See [Transpiling circuit entrypoints](#transpiling-circuit-entrypoints) for details.
+- `--transpile` – Package your project for use as a library
 
 ### Targeting specific sources
 - `tsci build path/to/file.circuit.tsx` – builds the given file, even if it does not match the `includeBoardFiles` glob in `tscircuit.config.json`.

--- a/docs/command-line/tsci-build.md
+++ b/docs/command-line/tsci-build.md
@@ -8,7 +8,7 @@ description: Generate circuit JSON from your source files
 ## Usage
 
 ```bash
-tsci build [path] [--ignore-errors] [--ignore-warnings] [--all-images]
+tsci build [path] [--ignore-errors] [--ignore-warnings] [--all-images] [--transpile]
 ```
 
 ### Arguments
@@ -21,9 +21,72 @@ Output files are placed in a `dist/` directory relative to your project. The mai
 - `--ignore-errors` – do not exit with code `1` on evaluation errors.
 - `--ignore-warnings` – suppress warning messages.
 - `--all-images` – emit every renderable image (PCB, schematic, 3D preview) for each built circuit into the matching `dist` subdirectory.
+- `--transpile` – emit bundler-friendly JavaScript alongside the generated `circuit.json`. See [Transpiling circuit entrypoints](#transpiling-circuit-entrypoints) for details.
 
 ### Targeting specific sources
 - `tsci build path/to/file.circuit.tsx` – builds the given file, even if it does not match the `includeBoardFiles` glob in `tscircuit.config.json`.
 - `tsci build path/to/directory` – scans only the files inside `path/to/directory` that both satisfy the `includeBoardFiles` glob and reside within the directory. Files outside the directory or filtered out by the glob are skipped.
 
 Use this command before publishing or in CI to ensure your circuits evaluate correctly.
+
+## Transpiling circuit entrypoints
+
+Pass the `--transpile` flag when you need browser-friendly or Node.js-friendly bundles of the same entry file you used to build `circuit.json`. The flag runs an extra Rollup pass that writes:
+
+- `dist/<entry>/index.js` – an ESM bundle
+- `dist/<entry>.cjs` – a CommonJS bundle
+- `dist/<entry>.d.ts` – generated type declarations that reflect the JSX surface of your entry file
+
+This extra work is useful when you want to re-use the same TSCircuit entrypoint in a documentation site, demo, or other tooling without re-running the evaluator.
+
+### Example project
+
+Spin up a scratch directory with `tsci init` to reproduce the transpile flow locally:
+
+```bash
+mkdir tsci-transpile-demo
+cd tsci-transpile-demo
+tsci init
+```
+
+Replace the generated `index.tsx` with a tiny RC circuit:
+
+```tsx title="index.tsx"
+/// <reference types="tscircuit" />
+import React from "react"
+
+export default () => (
+  <board>
+    <resistor resistance="1k" footprint="0402" name="R1" schX={3} pcbX={3} />
+    <capacitor
+      capacitance="1000pF"
+      footprint="0402"
+      name="C1"
+      schX={-3}
+      pcbX={-3}
+    />
+    <trace from=".R1 > .pin1" to=".C1 > .pin1" />
+  </board>
+)
+```
+
+Then run the transpile build:
+
+```bash
+tsci build --transpile
+```
+
+The build writes `dist/index/circuit.json` as usual, then finishes by bundling the entrypoint and printing the paths to the emitted ESM, CJS, and type declaration artifacts.
+
+You can inspect the generated files with `tree dist`:
+
+```text
+dist
+├── index
+│   └── circuit.json
+├── index.cjs
+├── index.d.ts
+└── index.js
+
+2 directories, 4 files
+```

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,5 +4,5 @@
   "compilerOptions": {
     "baseUrl": "."
   },
-  "exclude": [".docusaurus", "build", "static/examples"]
+  "exclude": [".docusaurus", "build"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,5 +4,5 @@
   "compilerOptions": {
     "baseUrl": "."
   },
-  "exclude": [".docusaurus", "build"]
+  "exclude": [".docusaurus", "build", "static/examples"]
 }


### PR DESCRIPTION
## Summary
- delete the `static/examples/tsci-transpile-demo` project so the repo no longer ships generated sample files
- update the `tsci build --transpile` docs to walk readers through creating their own scratch project before running the command

## Testing
- bunx tsc --noEmit
- bun run format

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_691bea281104832e89e641c523171fda)