### PR TITLE
fix add board tag to Inductor for rendering 3d view

### DIFF
--- a/docs/elements/inductor.mdx
+++ b/docs/elements/inductor.mdx
@@ -23,11 +23,13 @@ import CircuitPreview from "@site/src/components/CircuitPreview"
   code={`
 
   export default () => (
+   <board width="10mm" height="10mm">
     <inductor
       name="L1"
       footprint="0603"
       inductance="10μH"
     />
+   </board>
   )
 
   `}


### PR DESCRIPTION
![Screenshot_2025-11-18-14-15-11-16_40deb401b9ffe8e1df2f1cc5ba480b12](https://github.com/user-attachments/assets/cc630da3-c1f8-4556-ae97-158ef6df09bc)
