### PR TITLE
docs: make schematic view default and disable PCB/3D view for symbols

### DIFF
--- a/docs/elements/symbol.mdx
+++ b/docs/elements/symbol.mdx
@@ -20,7 +20,11 @@ Use `<symbol />` when you want to create a custom schematic appearance for your 
 
 Here's an example combining multiple primitive components to create a custom symbol:
 
-<CircuitPreview defaultView="schematic" code={`
+<CircuitPreview 
+  hide3DTab
+  hidePCBTab
+  defaultView="schematic"
+  code={`
 export default () => (
   <board width="10mm" height="10mm">
     <chip
@@ -53,7 +57,11 @@ export default () => (
 
 You can create multiple chips with custom symbols and connect them via traces:
 
-<CircuitPreview defaultView="schematic" code={`
+<CircuitPreview 
+  hide3DTab
+  hidePCBTab
+  defaultView="schematic"
+  code={`
 export default () => (
   <board width="10mm" height="10mm">
     <chip


### PR DESCRIPTION
Updated CircuitPreview examples to include additional attributes.