### PR TITLE
Update CircuitPreview example to include board wrapper for via component

### DIFF
--- a/docs/elements/via.mdx
+++ b/docs/elements/via.mdx
@@ -20,14 +20,16 @@ import CircuitPreview from "@site/src/components/CircuitPreview"
 <CircuitPreview
   defaultView="pcb"
   code={`export default () => (
-    <via
-      fromLayer="top"
-      toLayer="bottom"
-      outerDiameter="0.8mm"
-      holeDiameter="0.4mm"
-      pcbX={10}
-      pcbY={10}
-    />
+    <board width={5} height={5}>
+      <via
+        fromLayer="top"
+        toLayer="bottom"
+        outerDiameter="0.8mm"
+        holeDiameter="0.4mm"
+        pcbX={0}
+        pcbY={0}
+      />
+    </board>
   )`}
 />
 


### PR DESCRIPTION
This pull request makes a minor update to the example code in the `CircuitPreview` component for the `via.mdx` documentation. The example now wraps the `via` element in a `board` component and adjusts the `pcbX` and `pcbY` coordinates to (0, 0) for clarity and consistency.

- Documentation improvement:
  * Updated the `CircuitPreview` example to wrap the `via` in a `board` with defined dimensions and set its position to the origin (`pcbX={0}`, `pcbY={0}`) for a clearer demonstration.

## Before 
<img width="860" height="730" alt="image" src="https://github.com/user-attachments/assets/ff3ebb00-a6e5-48ac-90f1-4cbbe683b541" />

## After
<img width="860" height="730" alt="image" src="https://github.com/user-attachments/assets/03462559-9213-41c7-822c-0ac242bbe931" />
