### PR TITLE
Fix laser prefab guide

### DIFF
--- a/docs/guides/tscircuit-essentials/biscuit-board-laser-ablation.mdx
+++ b/docs/guides/tscircuit-essentials/biscuit-board-laser-ablation.mdx
@@ -32,12 +32,12 @@ import { Fragment } from "react"
 
 export const BiscuitTemplate = () => (
   <Fragment>
-    <via name="B1" pcbX={-4} pcbY={6} fromLayer="top" toLayer="bottom" netIsAssignable />
-    <via name="B2" pcbX={0} pcbY={6} fromLayer="top" toLayer="bottom" netIsAssignable />
-    <via name="B3" pcbX={4} pcbY={6} fromLayer="top" toLayer="bottom" netIsAssignable />
-    <via name="B4" pcbX={-4} pcbY={0} fromLayer="top" toLayer="bottom" netIsAssignable />
-    <via name="B5" pcbX={0} pcbY={0} fromLayer="top" toLayer="bottom" netIsAssignable />
-    <via name="B6" pcbX={4} pcbY={0} fromLayer="top" toLayer="bottom" netIsAssignable />
+    <via name="B1" pcbX={-4} pcbY={6} fromLayer="top" toLayer="bottom" netIsAssignable outerDiameter={0.8} holeDiameter={0.4} />
+    <via name="B2" pcbX={0} pcbY={6} fromLayer="top" toLayer="bottom" netIsAssignable outerDiameter={0.8} holeDiameter={0.4} />
+    <via name="B3" pcbX={4} pcbY={6} fromLayer="top" toLayer="bottom" netIsAssignable outerDiameter={0.8} holeDiameter={0.4} />
+    <via name="B4" pcbX={-4} pcbY={0} fromLayer="top" toLayer="bottom" netIsAssignable outerDiameter={0.8} holeDiameter={0.4} />
+    <via name="B5" pcbX={0} pcbY={0} fromLayer="top" toLayer="bottom" netIsAssignable outerDiameter={0.8} holeDiameter={0.4} />
+    <via name="B6" pcbX={4} pcbY={0} fromLayer="top" toLayer="bottom" netIsAssignable outerDiameter={0.8} holeDiameter={0.4} />
   </Fragment>
 )
 ```
@@ -57,12 +57,12 @@ rotating the template in a way that misaligns the coordinates.
   code={`export default () => (
   <board width="20mm" height="20mm" autorouter="laser_prefab">
     <group name="biscuit" pcbX={0} pcbY={0}>
-      <via name="B1" pcbX={-4} pcbY={6} fromLayer="top" toLayer="bottom" netIsAssignable />
-      <via name="B2" pcbX={0} pcbY={6} fromLayer="top" toLayer="bottom" netIsAssignable />
-      <via name="B3" pcbX={4} pcbY={6} fromLayer="top" toLayer="bottom" netIsAssignable />
-      <via name="B4" pcbX={-4} pcbY={0} fromLayer="top" toLayer="bottom" netIsAssignable />
-      <via name="B5" pcbX={0} pcbY={0} fromLayer="top" toLayer="bottom" netIsAssignable />
-      <via name="B6" pcbX={4} pcbY={0} fromLayer="top" toLayer="bottom" netIsAssignable />
+      <via name="B1" pcbX={-4} pcbY={6} fromLayer="top" toLayer="bottom" netIsAssignable outerDiameter={0.8} holeDiameter={0.4} />
+      <via name="B2" pcbX={0} pcbY={6} fromLayer="top" toLayer="bottom" netIsAssignable outerDiameter={0.8} holeDiameter={0.4} />
+      <via name="B3" pcbX={4} pcbY={6} fromLayer="top" toLayer="bottom" netIsAssignable outerDiameter={0.8} holeDiameter={0.4} />
+      <via name="B4" pcbX={-4} pcbY={0} fromLayer="top" toLayer="bottom" netIsAssignable outerDiameter={0.8} holeDiameter={0.4} />
+      <via name="B5" pcbX={0} pcbY={0} fromLayer="top" toLayer="bottom" netIsAssignable outerDiameter={0.8} holeDiameter={0.4} />
+      <via name="B6" pcbX={4} pcbY={0} fromLayer="top" toLayer="bottom" netIsAssignable outerDiameter={0.8} holeDiameter={0.4} />
     </group>
 
     <testpoint name="TP_TOP" footprintVariant="pad" pcbX={0} pcbY={9} layer="top" />
@@ -79,21 +79,21 @@ board. The router treats assignable vias as neutral territory: any net can claim
 them provided both layers are available and no design rules are violated.
 
 ```tsx title="src/laser-prefab-example.tsx"
-<board width="20mm" height="20mm" autorouter="laser_prefab">
-  <BiscuitTemplate />
+  <board width="20mm" height="20mm" autorouter="laser_prefab">
+    <BiscuitTemplate />
 
-  <chip
-    name="U1"
-    footprint="soic8"
-    pcbX={-6}
-    pcbY={0}
-    connections={{ pin1: "R1.pin1", pin8: "B6.top" }}
-  />
-  <resistor name="R1" resistance="1k" footprint="0402" pcbX={6} pcbY={0} />
+    <chip
+      name="U1"
+      footprint="soic8"
+      pcbX={-6}
+      pcbY={0}
+      connections={{ pin1: "R1.pin1", pin8: "B6.top" }}
+    />
+    <resistor name="R1" resistance="1k" footprint="0402" pcbX={6} pcbY={0} />
 
   <trace from="TP_TOP.pin1" to="B2.top" />
   <trace from="B2.bottom" to="TP_BOTTOM.pin1" />
-</board>
+  </board>
 ```
 
 After generating manufacturing data (Gerber or ODB++ exports) or reviewing the
@@ -108,8 +108,8 @@ PCB preview, confirm that:
   code={`export default () => (
   <board width="20mm" height="20mm" autorouter="laser_prefab">
     <group name="biscuit">
-      <via name="B2" pcbX={0} pcbY={6} fromLayer="top" toLayer="bottom" netIsAssignable />
-      <via name="B5" pcbX={0} pcbY={0} fromLayer="top" toLayer="bottom" netIsAssignable />
+      <via name="B2" pcbX={0} pcbY={6} fromLayer="top" toLayer="bottom" netIsAssignable outerDiameter={0.8} holeDiameter={0.4} />
+      <via name="B5" pcbX={0} pcbY={0} fromLayer="top" toLayer="bottom" netIsAssignable outerDiameter={0.8} holeDiameter={0.4} />
     </group>
 
     <testpoint name="TP_TOP" footprintVariant="pad" pcbX={0} pcbY={9} layer="top" />


### PR DESCRIPTION
This pull request updates the via definitions in the Biscuit Board Laser Ablation guide to explicitly specify the `outerDiameter` and `holeDiameter` for all vias. This makes them render and the example autoroutes also this improves clarity and ensures consistent via sizing in both code examples and rendered previews.

**Documentation updates for via sizing:**

* All `via` components in the `BiscuitTemplate` React export now include `outerDiameter={0.8}` and `holeDiameter={0.4}` for explicit via sizing.

## Before:

<img width="880" height="520" alt="image" src="https://github.com/user-attachments/assets/25002d68-ee9f-4135-a8a8-4caa0c62a227" />

<img width="884" height="412" alt="image" src="https://github.com/user-attachments/assets/a466628f-b4b3-4972-8d4b-108b6048ad98" />

## After:
<img width="884" height="526" alt="image" src="https://github.com/user-attachments/assets/b3703aa4-c308-4645-b9c6-2f975cd1e77e" />

<img width="917" height="423" alt="image" src="https://github.com/user-attachments/assets/3e35d250-d90a-435d-84b8-267a0f3de7ef" />

/fix #311