### PR TITLE
Refine pinrow rows parameter description

### DIFF
--- a/docs/footprints/footprinter-strings.mdx
+++ b/docs/footprints/footprinter-strings.mdx
@@ -361,5 +361,6 @@ Parameters:
 | `p` | `"2.3mm"` | Pin pitch |
 | `id` | `"1mm"` | Inner diameter |
 | `od` | `"1.5mm"` | Outer diameter |
+| `rows` | `1` | Number of rows (single- or double-row headers) |
 | `male` | `true` | Male header |
 | `female` | `false` | Female header |


### PR DESCRIPTION
## Summary
- simplify the pinrow `rows` parameter description to omit unsupported pin distribution note

## Testing
- bunx tsc --noEmit *(fails: missing Docusaurus/React configs and dependencies for JSX typing)*
- bun run format *(fails: biome formatter command not available in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_692bc91c125c832e99159dea86419932)