### PR TITLE
Add circuit-json-to-gerber link to dependency diagram

### DIFF
--- a/docs/contributing/package-dependencies-and-auto-updates.mdx
+++ b/docs/contributing/package-dependencies-and-auto-updates.mdx
@@ -29,6 +29,9 @@ flowchart TD
     %% Schematic Viewer to Runframe
     schemaviewer[tscircuit/schematic-viewer] --> runframe
 
+    %% Circuit JSON to Gerber to Runframe
+    circuitjsontogerber[circuit-json-to-gerber] --> runframe
+
     %% Runframe to CLI
     runframe --> cli[tscircuit/cli]
 


### PR DESCRIPTION
## Summary
- add circuit-json-to-gerber package node linking to runframe in the package dependencies diagram

## Testing
- bunx tsc --noEmit
- bun run format

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_692cff605394832e985c9911faf5059d)