### PR TITLE
Add Resistor Footprint Attribute to Subcircuits for PCB and 3D Rendering

### DIFF
--- a/docs/elements/subcircuit.mdx
+++ b/docs/elements/subcircuit.mdx
@@ -24,10 +24,10 @@ import CircuitPreview from "@site/src/components/CircuitPreview"
   export default () => (
     <board width="10mm" height="10mm">
       <subcircuit name="subcircuit1" schX={-2}>
-        <resistor name="R1" resistance="1k" />
+        <resistor name="R1" resistance="1k" footprint="0402" />
       </subcircuit>
       <subcircuit name="subcircuit2" schX={2}>
-        <resistor name="R2" resistance="1k"  />
+        <resistor name="R2" resistance="1k" footprint="0402"  />
       </subcircuit>
       <trace from=".subcircuit1 .R1 .pin1" to=".subcircuit2 .R2 .pin1" />
     </board>
@@ -55,10 +55,10 @@ e.g. `.somesubcircuit .R1`
   export default () => (
     <board width="10mm" height="10mm">
       <subcircuit name="subcircuit1" schX={-2}>
-        <resistor name="R1" resistance="1k" />
+        <resistor name="R1" resistance="1k" footprint="0402" />
       </subcircuit>
       <subcircuit name="subcircuit2" schX={2}>
-        <resistor name="R1" resistance="1k" />
+        <resistor name="R1" resistance="1k" footprint="0402" />
       </subcircuit>
       <trace from=".subcircuit1 .R1 .pin1" to=".subcircuit2 .R1 .pin1" />
     </board>


### PR DESCRIPTION
## Before
<img width="969" height="538" alt="Screenshot_2025-12-07_21-35-34" src="https://github.com/user-attachments/assets/8772ab82-7a89-4c83-8cc3-7cd1ec7625ac" />
 <img width="938" height="584" alt="Screenshot_2025-12-07_21-35-45" src="https://github.com/user-attachments/assets/31c78623-570a-4645-8ab3-5d0f48fed883" />

## After
<img width="966" height="671" alt="Screenshot_2025-12-07_21-40-07" src="https://github.com/user-attachments/assets/d27f440d-87f2-4fbf-a3ff-9a69b41a30b6" />
<img width="903" height="588" alt="Screenshot_2025-12-07_21-39-56" src="https://github.com/user-attachments/assets/97f35166-cbad-42b9-b281-11307fc19abd" />