### PR TITLE
 fix add board tag to Pinheader for rendering 3d view

### DIFF
--- a/docs/elements/pinheader.mdx
+++ b/docs/elements/pinheader.mdx
@@ -15,7 +15,7 @@ import CircuitPreview from "@site/src/components/CircuitPreview"
 <CircuitPreview
   defaultView="schematic"
   code={`export default () => (
-   <board width="20mm" height="20mm">
+   <board width="30mm" height="10mm">
     <pinheader
       name="J1"
       pinCount={8}

--- a/docs/elements/pinheader.mdx
+++ b/docs/elements/pinheader.mdx
@@ -15,6 +15,7 @@ import CircuitPreview from "@site/src/components/CircuitPreview"
 <CircuitPreview
   defaultView="schematic"
   code={`export default () => (
+   <board width="10mm" height="10mm">
     <pinheader
       name="J1"
       pinCount={8}
@@ -26,6 +27,7 @@ import CircuitPreview from "@site/src/components/CircuitPreview"
       x={10}
       y={10}
     />
+   </board>
   )
 `}
 />

--- a/docs/elements/pinheader.mdx
+++ b/docs/elements/pinheader.mdx
@@ -15,7 +15,7 @@ import CircuitPreview from "@site/src/components/CircuitPreview"
 <CircuitPreview
   defaultView="schematic"
   code={`export default () => (
-   <board width="10mm" height="10mm">
+   <board width="20mm" height="20mm">
     <pinheader
       name="J1"
       pinCount={8}


### PR DESCRIPTION
## Before 
<img width="1016" height="517" alt="Screenshot_2025-12-07_22-20-35" src="https://github.com/user-attachments/assets/bd814b0f-9ce7-4209-a2cf-378bf8457a45" />
<img width="1007" height="528" alt="Screenshot_2025-12-07_22-20-25" src="https://github.com/user-attachments/assets/e942c7b3-24c3-44ae-ae0d-31d9dbc56012" />
