### PR TITLE
fix add board tag to Led for rendering 3d view

### DIFF
--- a/docs/elements/led.mdx
+++ b/docs/elements/led.mdx
@@ -18,7 +18,9 @@ import CircuitPreview from "@site/src/components/CircuitPreview"
   defaultView="schematic"
   code={`
   export default () => (
+   <board width="10mm" height="10mm">
     <led name="LED1" footprint="0603" color="red" />
+   </board>
   )
 `}
 />


### PR DESCRIPTION
## Before 
<img width="293" height="308" alt="Screenshot_2025-12-07_23-34-42" src="https://github.com/user-attachments/assets/59f5d807-10ca-4a3c-b719-2589325349d5" />

## After
<img width="984" height="662" alt="Screenshot_2025-12-07_23-35-21" src="https://github.com/user-attachments/assets/505d13df-8ec0-4658-95b4-0dcecef486e0" />
