### PR TITLE
Fix typo in section title: "Offseting" to "Offsetting" in board documentation

### DIFF
--- a/docs/elements/board.mdx
+++ b/docs/elements/board.mdx
@@ -188,7 +188,7 @@ export default () => (
 
 `} />
 
-### Offseting the board origin
+### Offsetting the board origin
 
 `width` and `height` set the board's bounding box (and thus the `pcbX`/`pcbY`
 coordinate system) even when you're using a custom outline. Add


### PR DESCRIPTION
before 
<img width="1352" height="858" alt="Screenshot 2025-12-08 at 10 08 05 AM" src="https://github.com/user-attachments/assets/6cf495ba-81df-4361-96a2-bf6587cdb0fb" />
after 
<img width="1352" height="858" alt="Screenshot 2025-12-08 at 10 08 14 AM" src="https://github.com/user-attachments/assets/cf657019-8765-43aa-9195-95c405cf1b50" />
