### PR TITLE
docs: add rectangular hole support and update properties in hole documentation

### DIFF
--- a/docs/elements/hole.mdx
+++ b/docs/elements/hole.mdx
@@ -18,10 +18,11 @@ import CircuitPreview from "@site/src/components/CircuitPreview"
 
 ## Hole Shapes
 
-Two hole shapes are supported:
+Three hole shapes are supported:
 
 - `circle` - A circular hole (default)
 - `pill` - A pill-shaped hole (rounded rectangle)
+- `rect` - A rectangular hole
 
 ### Circle Hole
 
@@ -78,14 +79,37 @@ Pill-shaped holes can be rotated using the `pcbRotation` property:
   )`}
 />
 
+### Rectangular Hole
+
+Rectangular holes provide sharp-cornered cutouts, useful for specific mounting requirements:
+
+<CircuitPreview
+  defaultView="pcb"
+  browser3dView={false}
+  code={`export default () => (
+    <board width="30mm" height="20mm">
+      <hole 
+        shape="rect" 
+        width="4mm" 
+        height="2mm" 
+        pcbX={0} 
+        pcbY={0} 
+      />
+    </board>
+  )`}
+/>
+
 ## Properties
 
 | Property | Shape | Type | Default | Description |
 |----------|-------|------|---------|-------------|
-| shape | all | `"circle"` \| `"pill"` | `"circle"` | Shape of the hole |
+| shape | all | `"circle"` \| `"pill"` \| `"rect"` | `"circle"` | Shape of the hole |
 | diameter | circle | number \| string | - | Diameter of the circular hole |
-| width | pill | number \| string | - | Width of the pill-shaped hole |
-| height | pill | number \| string | - | Height of the pill-shaped hole |
+| radius | circle | number \| string | - | Radius of the circular hole (alternative to diameter) |
+| width | pill, rect | number \| string | - | Width of the pill or rectangular hole |
+| height | pill, rect | number \| string | - | Height of the pill or rectangular hole |
 | pcbX | all | number | 0 | X position of the hole center on the PCB |
 | pcbY | all | number | 0 | Y position of the hole center on the PCB |
-| pcbRotation | pill | number \| string | 0 | Rotation angle in degrees (e.g., `"45deg"` or `45`) |
+| pcbRotation | all | number \| string | 0 | Rotation angle in degrees (e.g., `"45deg"` or `45`) |
+| solderMaskMargin | all | number \| string | - | Margin for solder mask opening around the hole |
+| coveredWithSolderMask | all | boolean | - | Whether the hole is covered with solder mask |


### PR DESCRIPTION
This pull request updates the documentation for the `hole` element to introduce support for rectangular holes and clarify the available properties. The most important changes are the addition of the new `rect` shape, an example usage, and updates to the properties table to reflect the expanded functionality.

**Support for new hole shapes:**

* Added support for a third hole shape, `rect`, in addition to the existing `circle` and `pill` shapes.
* Updated the documentation to include an example of how to use the new rectangular hole in a board design, using the `CircuitPreview` component.

**Documentation and properties table updates:**

* Updated the properties table to:
  * Include the new `rect` shape in the `shape` property.
  * Show that `width` and `height` now apply to both `pill` and `rect` shapes.
  * Add the `radius` property as an alternative to `diameter` for circles.
  * Indicate that `pcbRotation` now applies to all shapes, not just `pill`.
  * Add documentation for `solderMaskMargin` and `coveredWithSolderMask` properties.