### PR TITLE
fix add board tag to diode for rendering 3d view

### DIFF
--- a/docs/elements/diode.mdx
+++ b/docs/elements/diode.mdx
@@ -17,7 +17,9 @@ import CircuitPreview from "@site/src/components/CircuitPreview"
   defaultView="schematic"
   code={`
   export default () => (
+   <board width="10mm" height="10mm">
     <diode name="D1" footprint="0402" />
+   </board>
   )
 `}
 />

--- a/docs/elements/diode.mdx
+++ b/docs/elements/diode.mdx
@@ -18,7 +18,7 @@ import CircuitPreview from "@site/src/components/CircuitPreview"
   code={`
   export default () => (
    <board width="10mm" height="10mm">
-    <diode name="D1" footprint="0402" />
+    <diode name="D1" footprint="sod123" />
    </board>
   )
 `}


### PR DESCRIPTION
Before 
<img width="891" height="465" alt="Screenshot_2025-12-09_20-57-13" src="https://github.com/user-attachments/assets/af8c1607-e51a-4fd7-8695-46ed994e7e25" />


After
<img width="893" height="450" alt="Screenshot_2025-12-09_22-14-21" src="https://github.com/user-attachments/assets/8c756229-2123-489b-8ee5-fa558def33e1" />

