### PR TITLE
fix: correct typo "critial" to "critical" in resistor documentation

### DIFF
--- a/docs/elements/resistor.mdx
+++ b/docs/elements/resistor.mdx
@@ -3,14 +3,14 @@ title: <resistor />
 sidebar_position: 2
 description: >-
   A `<resistor />` is an extremely common element of electronic designs. It limits
-  the flow of electricity and is critial to making sure digital signals are
+  the flow of electricity and is critical to making sure digital signals are
   properly "pulled up" or "pulled down" to set their default value as `1` or `0`
 ---
 
 ## Overview
 
 A `<resistor />` is an extremely common element of electronic designs. It limits
-the flow of electricity and is critial to making sure digital signals are
+the flow of electricity and is critical to making sure digital signals are
 properly "pulled up" or "pulled down" to set their default value as `1` or `0`
 
 A resistor element has two pins and is non-polar, meaning it doesn't matter if


### PR DESCRIPTION
before
<img width="1426" height="857" alt="Screenshot 2025-12-13 at 6 44 25 PM" src="https://github.com/user-attachments/assets/42ce0122-9a17-4851-87a8-e115c8a874ba" />

after - critial to critical
<img width="1426" height="857" alt="Screenshot 2025-12-13 at 6 53 35 PM" src="https://github.com/user-attachments/assets/59ce021b-d637-4539-ab0b-5c8c1d91ecd9" />
