### PR TITLE
fix: update capacitor example so that its 3d model renders

### DIFF
--- a/docs/elements/capacitor.mdx
+++ b/docs/elements/capacitor.mdx
@@ -24,10 +24,9 @@ import CircuitPreview from "@site/src/components/CircuitPreview"
 
   export default () => (
     <capacitor
-      name="C2"
-      footprint="axial_p5mm"
-      capacitance="10μF"
-      polarized
+      name="C1"
+      footprint="0402"
+      capacitance="1000pF"
     />
   )
 


### PR DESCRIPTION
## Before
<img width="880" height="408" alt="Screenshot_20251213_191125" src="https://github.com/user-attachments/assets/c0ffc0a6-b967-4e99-a5e3-5037b4be3aa5" />


## After
<img width="880" height="408" alt="image" src="https://github.com/user-attachments/assets/32978af1-2ad3-408c-9faa-8ca920f80e0f" />
