### PR TITLE
fix add board tag to Capacitor for rendering 3d view

### DIFF
--- a/docs/elements/capacitor.mdx
+++ b/docs/elements/capacitor.mdx
@@ -31,7 +31,6 @@ import CircuitPreview from "@site/src/components/CircuitPreview"
       polarized
     /> 
   </board>
-
   )
 
   `}

--- a/docs/elements/capacitor.mdx
+++ b/docs/elements/capacitor.mdx
@@ -23,12 +23,15 @@ import CircuitPreview from "@site/src/components/CircuitPreview"
   code={`
 
   export default () => (
+   <board width="10mm" height="10mm">
     <capacitor
       name="C2"
       footprint="axial_p5mm"
       capacitance="10μF"
       polarized
-    />
+    /> 
+  </board>
+
   )
 
   `}


### PR DESCRIPTION
before 
<img width="952" height="462" alt="Screenshot_2025-12-13_19-35-12" src="https://github.com/user-attachments/assets/a9853bed-77cd-4ef5-aa1d-1add9e01d688" />


After
<img width="893" height="433" alt="Screenshot_2025-12-13_19-36-14" src="https://github.com/user-attachments/assets/2d62e59d-f64b-4310-aa72-601ef0341913" />
