### PR TITLE
fix add board tag to Net for rendering 3d view

### DIFF
--- a/docs/elements/net.mdx
+++ b/docs/elements/net.mdx
@@ -22,11 +22,11 @@ import CircuitPreview from "@site/src/components/CircuitPreview"
   defaultView="schematic"
   code={`
   export default () => (
-    <group>
+     <board width="30mm" height="10mm">
       <capacitor capacitance="1uF" footprint="0603" name="C1" />
       <net name="V5" />
       <trace from="net.V5" to=".C1 .pos" />
-    </group>
+    </board>
   )
   `}
 />

--- a/docs/elements/net.mdx
+++ b/docs/elements/net.mdx
@@ -22,7 +22,7 @@ import CircuitPreview from "@site/src/components/CircuitPreview"
   defaultView="schematic"
   code={`
   export default () => (
-     <board width="30mm" height="10mm">
+     <board width="10mm" height="10mm">
       <capacitor capacitance="1uF" footprint="0603" name="C1" />
       <net name="V5" />
       <trace from="net.V5" to=".C1 .pos" />

--- a/docs/elements/net.mdx
+++ b/docs/elements/net.mdx
@@ -22,11 +22,13 @@ import CircuitPreview from "@site/src/components/CircuitPreview"
   defaultView="schematic"
   code={`
   export default () => (
+    <group>
      <board width="10mm" height="10mm">
       <capacitor capacitance="1uF" footprint="0603" name="C1" />
       <net name="V5" />
       <trace from="net.V5" to=".C1 .pos" />
-    </board>
+    </group>
+   </board>
   )
   `}
 />

--- a/docs/elements/net.mdx
+++ b/docs/elements/net.mdx
@@ -22,13 +22,13 @@ import CircuitPreview from "@site/src/components/CircuitPreview"
   defaultView="schematic"
   code={`
   export default () => (
-    <group>
-     <board width="10mm" height="10mm">
+    <board width="10mm" height="10mm">
+     <group>
       <capacitor capacitance="1uF" footprint="0603" name="C1" />
       <net name="V5" />
       <trace from="net.V5" to=".C1 .pos" />
-    </group>
-   </board>
+     </group>
+    </board>
   )
   `}
 />


### PR DESCRIPTION
Before
<img width="910" height="483" alt="Screenshot_2025-12-13_19-58-51" src="https://github.com/user-attachments/assets/14939055-fb5b-44f1-9c0f-4844bfb830b4" />

After
<img width="951" height="437" alt="Screenshot_2025-12-13_20-02-02" src="https://github.com/user-attachments/assets/d0dc692b-2819-42dd-bb52-ef2c861aac5b" />
