### PR TITLE
fix: update coordinates for silkscreenline example in documentation

### DIFF
--- a/docs/footprints/silkscreenline.mdx
+++ b/docs/footprints/silkscreenline.mdx
@@ -18,10 +18,10 @@ import CircuitPreview from "@site/src/components/CircuitPreview"
     <board width="50mm" height="50mm">
       <footprint>
         <silkscreenline 
-          x1="10mm" 
-          y1="10mm" 
-          x2="40mm" 
-          y2="40mm"
+          x1="-20mm" 
+          y1="0mm" 
+          x2="20mm" 
+          y2="0mm"
           strokeWidth="0.1mm"
         />
       </footprint>


### PR DESCRIPTION
The previous example was going out of board making the pcb view difficult to grasp

Documentation improvements:

* Changed the `silkscreenline` example in `docs/footprints/silkscreenline.mdx` to draw a horizontal line from `(-20mm, 0mm)` to `(20mm, 0mm)` instead of a diagonal line from `(10mm, 10mm)` to `(40mm, 40mm)`.

## Before
<img width="860" height="564" alt="image" src="https://github.com/user-attachments/assets/d1313adb-671b-4007-bd1f-1f79f9e5850b" />

## After
<img width="860" height="564" alt="Screenshot_20251213_230514" src="https://github.com/user-attachments/assets/db728d32-0b08-4b83-9464-e69213777863" />
