### PR TITLE
fix add board tag to Fuse for rendering 3d view

### DIFF
--- a/docs/elements/fuse.mdx
+++ b/docs/elements/fuse.mdx
@@ -22,12 +22,14 @@ import CircuitPreview from "@site/src/components/CircuitPreview"
   code={`
 
 export default () => (
+  <board width="10mm" height="10mm">
     <fuse
       name="F1"
       footprint="0603"
       currentRating="2A"
       voltageRating="32V"
     />
+  </board>
 )
 
   `}


### PR DESCRIPTION
Before
<img width="895" height="454" alt="Screenshot_2025-12-15_19-08-28" src="https://github.com/user-attachments/assets/de76cbaf-ed0b-4be2-bd12-470af43bb50c" />


After
<img width="974" height="453" alt="Screenshot_2025-12-15_19-09-01" src="https://github.com/user-attachments/assets/9fe7b5d6-66d8-4d9d-bf97-d1eab061187b" />
