### PR TITLE
fix add board tag to Resistor for rendering 3d view

### DIFF
--- a/docs/elements/resistor.mdx
+++ b/docs/elements/resistor.mdx
@@ -27,11 +27,13 @@ import CircuitPreview from "@site/src/components/CircuitPreview"
   code={`
 
 export default () => (
+ <board width="10mm" height="10mm">
     <resistor
       name="R1"
       footprint="0402"
       resistance="1k"
     />
+ </board>
 )
 
   `}


### PR DESCRIPTION
Before
<img width="955" height="457" alt="Screenshot_2025-12-15_19-31-09" src="https://github.com/user-attachments/assets/3b0ea470-713e-440b-8581-10c857969881" />

After
<img width="923" height="450" alt="Screenshot_2025-12-15_19-31-41" src="https://github.com/user-attachments/assets/03bbcb83-6cf7-4659-b9ba-b11a5035ea5c" />
