### PR TITLE
fix add board tag to Testooint for rendering 3d view

### DIFF
--- a/docs/elements/testpoint.mdx
+++ b/docs/elements/testpoint.mdx
@@ -22,12 +22,14 @@ import CircuitPreview from "@site/src/components/CircuitPreview"
   code={`
 
 export default () => (
+  <board width="10mm" height="10mm">
     <testpoint
       name="TP1"
       footprintVariant="pad"
       padShape="circle"
       padDiameter="1mm"
     />
+  </board>
 )
 
   `}


### PR DESCRIPTION
Before 
<img width="927" height="489" alt="Screenshot_2025-12-27_18-57-39" src="https://github.com/user-attachments/assets/342060e8-8a8e-48ca-99fe-b9e7146a966e" />

After
<img width="977" height="551" alt="Screenshot_2025-12-27_18-56-53" src="https://github.com/user-attachments/assets/bf8c9e2f-83c7-4d34-9335-23cd6531d10e" />
