### PR TITLE
Fix: Add svgPath and strokeColor example for schematicpath

### DIFF
--- a/docs/elements/schematicpath.mdx
+++ b/docs/elements/schematicpath.mdx
@@ -121,4 +121,4 @@ export default () => (
 | points | array | Yes | - | Array of points defining the path. Each point is an object with `x` and `y` coordinates |
 | svgPath | string | No | - | SVG path string (e.g., "M 0 0 L 1 1") for complex shapes |
 | strokeWidth | distance | No | - | Width of the path stroke |
-| strokeColor | string | No | "#000000" | Color of the path stroke |
+| strokeColor | string | No | "#840000" | Color of the path stroke |

--- a/docs/elements/schematicpath.mdx
+++ b/docs/elements/schematicpath.mdx
@@ -64,7 +64,6 @@ export default () => (
         <symbol>
           <schematicpath
             strokeWidth={0.04}
-            color="#1f78d1"
             points={[
               { x: -1.2, y: 0 },
               { x: 0.6, y: 0 },
@@ -73,6 +72,38 @@ export default () => (
               { x: 0.6, y: -0.4 },
               { x: 0.6, y: 0 },
             ]}
+            strokeColor="#1f78d1"
+          />
+          <port name="in" direction="left" schX={-1.5} schY={0} />
+          <port name="out" direction="right" schX={1.5} schY={0} />
+        </symbol>
+      }
+    />
+  </board>
+)
+`} />
+
+## SVG Path
+
+You can use standard SVG path syntax with the `svgPath` prop for more complex shapes:
+
+<CircuitPreview
+  hide3DTab
+  hidePCBTab
+  defaultView="schematic"
+  code={`
+export default () => (
+  <board width="12mm" height="10mm">
+    <chip
+      name="U1"
+      symbol={
+        <symbol>
+          {/* Star shape using SVG path */}
+          <schematicpath
+            points={[]}
+            svgPath="M 0 -1 L 0.3 -0.3 L 1 -0.3 L 0.4 0.1 L 0.6 0.8 L 0 0.4 L -0.6 0.8 L -0.4 0.1 L -1 -0.3 L -0.3 -0.3 Z"
+            strokeWidth={0.05}
+            strokeColor="#e63946"
           />
           <port name="in" direction="left" schX={-1.5} schY={0} />
           <port name="out" direction="right" schX={1.5} schY={0} />
@@ -88,5 +119,6 @@ export default () => (
 | Property | Type | Required | Default | Description |
 |----------|------|----------|---------|-------------|
 | points | array | Yes | - | Array of points defining the path. Each point is an object with `x` and `y` coordinates |
+| svgPath | string | No | - | SVG path string (e.g., "M 0 0 L 1 1") for complex shapes |
 | strokeWidth | distance | No | - | Width of the path stroke |
-| color | string | No | "#000000" | Color of the path |
+| strokeColor | string | No | "#000000" | Color of the path stroke |


### PR DESCRIPTION
<img width="584" height="701" alt="image" src="https://github.com/user-attachments/assets/12928c93-8022-4e1e-a560-69de43fadb6f" />
