### PR TITLE
Add "Making Lab Boards" contributing page

### DIFF
--- a/docs/contributing/making-lab-boards.mdx
+++ b/docs/contributing/making-lab-boards.mdx
@@ -1,0 +1,28 @@
+---
+title: Making Lab Boards
+description: Overview of the lab process and board template for making lab boards.
+sidebar_position: 7
+---
+
+import CircuitPreview from "@site/src/components/CircuitPreview"
+
+The tscircuit lab features a Commarker Omni X UV Laser capable of ablating copper
+clad.
+
+The standard copper clad in the lab is single-sided at 100mmx70mm. You should
+generally try to use the entire board to make post-processing simpler.
+
+<CircuitPreview defaultView="pcb" code={`export default () => (
+  <board width="100mm" height="70mm">
+    ...
+  </board>
+)
+`} />
+
+We maintain a [lab inventory full of components](https://links.tscircuit.com/),
+please prefer to use stocked components.
+
+Our standard lab process involves ablating copper clad, applying a Solder Mask
+to the entire board, curing mask, then ablating the exposed pads (laser off the
+negative solder mask layer). We then apply solder paste manually and assemble on
+a hot plate.


### PR DESCRIPTION
### Motivation
- Provide a simple contributing guide for making lab boards that documents the lab laser capability and the standard copper-clad template size.

### Description
- Add a new MDX file `docs/contributing/making-lab-boards.mdx` containing frontmatter, a short description of the Commarker Omni X UV Laser, and the standard single-sided copper-clad size (100mm x 70mm).
- Include a `CircuitPreview` snippet that demonstrates a `<board width="100mm" height="70mm">...</board>` template and outline the preferred workflow and inventory link for building lab boards (ablate copper, apply and cure solder mask, ablate pads, apply solder paste, and assemble on a hot plate).

### Testing
- Run `bunx tsc --noEmit` to typecheck the docs which completed successfully.
- Run `bun run format` which formatted the repository files successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_697e682c2f84832eb2eac5040c380bac)