### PR TITLE
Update pinrow parameters and add additional configuration options

### DIFF
--- a/docs/footprints/footprinter-strings.mdx
+++ b/docs/footprints/footprinter-strings.mdx
@@ -353,14 +353,28 @@ is specified the 3d model will update accordingly.
 
 <FootprintPreview footprint="pinrow4" />
 
-Parameters:
+### Parameters
 
 | Parameter | Default | Description |
 |-----------|---------|-------------|
-| `num_pins` |  | Number of pins |
-| `p` | `"2.3mm"` | Pin pitch |
-| `id` | `"1mm"` | Inner diameter |
+| `num_pins` | 6 | Number of pins |
+| `p` | `"0.1in"` | Pin pitch |
+| `id` | `"1.0mm"` | Inner diameter |
 | `od` | `"1.5mm"` | Outer diameter |
-| `rows` | `1` | Number of rows (single- or double-row headers) |
-| `male` | `true` | Male header |
-| `female` | `false` | Female header |
+| `rows` | 1 | Number of rows (single- or double-row headers) |
+| `male` | true | Male header |
+| `female` | false | Female header |
+| `smd` | false | Surface mount device |
+| `rightangle` | false | Right angle configuration |
+| `pw` | `"1.0mm"` | Pad width for SMD |
+| `pl` | `"2.0mm"` | Pad length for SMD |
+| `pinlabeltextalignleft` | false | Align pin labels to the left |
+| `pinlabeltextaligncenter` | false | Align pin labels to the center |
+| `pinlabeltextalignright` | false | Align pin labels to the right |
+| `pinlabelverticallyinverted` | false | Vertically invert pin labels |
+| `pinlabelorthogonal` | false | Make pin labels orthogonal |
+| `nosquareplating` | false | Do not use rectangular pad for pin 1 |
+| `nopinlabels` | false | Omit silkscreen pin labels |
+| `doublesidedpinlabel` | false | Add silkscreen pins in top and bottom layers |
+| `bottomsidepinlabel` | false | Place silkscreen reference text on bottom layer |
+

--- a/docs/footprints/footprinter-strings.mdx
+++ b/docs/footprints/footprinter-strings.mdx
@@ -353,7 +353,7 @@ is specified the 3d model will update accordingly.
 
 <FootprintPreview footprint="pinrow4" />
 
-### Parameters
+Parameters:
 
 | Parameter | Default | Description |
 |-----------|---------|-------------|


### PR DESCRIPTION
This pull request updates the documentation for the `pinrow4` footprint parameters, making the parameter table more complete and accurate. It adds default values for existing parameters, corrects some defaults, and documents several new configuration options for the footprint generator.

**Documentation improvements:**

* Added default values for existing parameters such as `num_pins`, `p`, `id`, `rows`, `male`, and `female` in the `pinrow4` footprint documentation.
* Documented new parameters including `smd`, `rightangle`, `pw`, `pl`, and various pin label configuration options (`pinlabeltextalignleft`, `pinlabeltextaligncenter`, `pinlabeltextalignright`, `pinlabelverticallyinverted`, `pinlabelorthogonal`, `nosquareplating`, `nopinlabels`, `doublesidedpinlabel`, `bottomsidepinlabel`).