### PR TITLE
Add Micro MELF and Mini MELF package descriptions and parameters

### DIFF
--- a/docs/footprints/footprinter-strings.mdx
+++ b/docs/footprints/footprinter-strings.mdx
@@ -378,3 +378,37 @@ Parameters:
 | `doublesidedpinlabel` | false | Add silkscreen pins in top and bottom layers |
 | `bottomsidepinlabel` | false | Place silkscreen reference text on bottom layer |
 
+## micromelf
+
+Micro MELF (Metal Electrode Leadless Face) package. `3.0mm × 1.80mm`
+
+<FootprintPreview footprint="micromelf" />
+
+Parameters:
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `num_pins` | `2` | Number of pins (fixed at 2) |
+| `w` | `"3.0mm"` | Package width |
+| `h` | `"1.80mm"` | Package height |
+| `pl` | `"0.80mm"` | Pad length |
+| `pw` | `"1.20mm"` | Pad width |
+| `p` | `"1.6mm"` | Pin pitch |
+
+## minimelf
+
+Mini MELF (Metal Electrode Leadless Face) package. `5.40mm × 2.30mm`
+
+<FootprintPreview footprint="minimelf" />
+
+Parameters:
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `num_pins` | `2` | Number of pins (fixed at 2) |
+| `w` | `"5.40mm"` | Package width |
+| `h` | `"2.30mm"` | Package height |
+| `pl` | `"1.30mm"` | Pad length |
+| `pw` | `"1.70mm"` | Pad width |
+| `p` | `"3.5mm"` | Pin pitch |
+

--- a/docs/footprints/footprinter-strings.mdx
+++ b/docs/footprints/footprinter-strings.mdx
@@ -380,7 +380,7 @@ Parameters:
 
 ## micromelf
 
-Micro MELF (Metal Electrode Leadless Face) package. `3.0mm × 1.80mm`
+Micro MELF (Metal Electrode Leadless Face) package.
 
 <FootprintPreview footprint="micromelf" />
 
@@ -397,7 +397,7 @@ Parameters:
 
 ## minimelf
 
-Mini MELF (Metal Electrode Leadless Face) package. `5.40mm × 2.30mm`
+Mini MELF (Metal Electrode Leadless Face) package.
 
 <FootprintPreview footprint="minimelf" />
 


### PR DESCRIPTION
This pull request adds documentation for two new surface-mount device (SMD) package footprints: Micro MELF and Mini MELF. Each section includes a description, a preview, and a table of configurable parameters for the respective footprint.

New footprint documentation:

* Added a section for the `micromelf` (Micro MELF) package, including a description, preview, and parameter table with default values and descriptions.
<img width="865" height="777" alt="image" src="https://github.com/user-attachments/assets/126bfe3c-e5f2-4585-8281-3b691b635955" />

* Added a section for the `minimelf` (Mini MELF) package, including a description, preview, and parameter table with default values and descriptions.
<img width="865" height="777" alt="image" src="https://github.com/user-attachments/assets/db42ca0e-b782-4e5f-9c44-6b25dc2bc325" />
