### PR TITLE
Remove `is_fatal` from Ordering API base error docs

### DIFF
--- a/docs/web-apis/ordering-api.mdx
+++ b/docs/web-apis/ordering-api.mdx
@@ -99,7 +99,7 @@ curl -X GET "https://api.tscircuit.com/orders/get?order_id=123e4567-e89b-12d3-a4
 ## Additional Notes
 
 - Timestamps are returned in ISO-8601 format.
-- Errors follow this structure:
+- Errors follow this base structure (no `is_fatal` field):
 
 ```json
 {


### PR DESCRIPTION
### Motivation
- Clarify the Ordering API documentation to reflect that the base error object no longer includes an `is_fatal` field.

### Description
- Update `docs/web-apis/ordering-api.mdx` to change the error description to: "Errors follow this base structure (no `is_fatal` field):" and include the example error JSON.

### Testing
- Ran `bunx tsc --noEmit` and `bun run format`, both completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6980dff930e8832e894ccbb35317df7d)