### PR TITLE
Add documentation for SPICE simulation elements

### DIFF
--- a/docs/elements/analogsimulation.mdx
+++ b/docs/elements/analogsimulation.mdx
@@ -1,0 +1,48 @@
+---
+title: <analogsimulation />
+description: Configure and run SPICE simulations for a tscircuit board.
+---
+
+## Overview
+
+`<analogsimulation />` enables SPICE simulation for a `<board />` and sets the
+solver configuration, such as duration and time step. Place this element inside
+your board alongside sources and probes to generate simulation results.
+
+import CircuitPreview from "@site/src/components/CircuitPreview"
+
+<CircuitPreview
+  defaultView="schematic"
+  hidePCBTab={true}
+  hide3DTab={true}
+  verticalStack={true}
+  showSimulationGraph={true}
+  code={`
+export default () => (
+  <board routingDisabled>
+    <voltagesource name="V1" voltage="5V" />
+    <resistor name="R1" resistance="1k" />
+
+    <trace from=".V1 > .pin1" to=".R1 > .pin1" />
+    <trace from=".V1 > .pin2" to=".R1 > .pin2" />
+
+    <voltageprobe name="VP_IN" connectsTo=".V1 > .pin1" />
+    <voltageprobe name="VP_OUT" connectsTo=".R1 > .pin1" />
+
+    <analogsimulation duration="10ms" timePerStep="0.1ms" spiceEngine="ngspice" />
+  </board>
+)
+`}
+/>
+
+## Properties
+
+| Property | Description | Example |
+| --- | --- | --- |
+| `duration` | Total simulation time. Accepts numbers or time strings. | `"10ms"` |
+| `timePerStep` | Time interval between simulation steps. | `"0.1ms"` |
+| `spiceEngine` | SPICE engine to use. Typically `"ngspice"` or `"spicey"`. | `"ngspice"` |
+
+Use `<analogsimulation />` once per `<board />` to define how the simulation
+runs. Combine it with `<voltagesource />` and `<voltageprobe />` elements to
+create and observe waveforms.

--- a/docs/elements/voltageprobe.mdx
+++ b/docs/elements/voltageprobe.mdx
@@ -1,0 +1,53 @@
+---
+title: <voltageprobe />
+description: Measure voltages at specific nodes during SPICE simulation.
+---
+
+## Overview
+
+`<voltageprobe />` records voltage values during SPICE simulation. It attaches to
+an existing node in your schematic and appears in the simulation graph output.
+Use probes to capture input/output signals or differential measurements across
+components.
+
+import CircuitPreview from "@site/src/components/CircuitPreview"
+
+<CircuitPreview
+  defaultView="schematic"
+  hidePCBTab={true}
+  hide3DTab={true}
+  verticalStack={true}
+  showSimulationGraph={true}
+  code={`
+export default () => (
+  <board routingDisabled>
+    <voltagesource name="V1" voltage="5V" />
+    <resistor name="R1" resistance="1k" />
+
+    <trace from=".V1 > .pin1" to=".R1 > .pin1" />
+    <trace from=".V1 > .pin2" to=".R1 > .pin2" />
+
+    <voltageprobe name="VP_IN" connectsTo=".V1 > .pin1" />
+    <voltageprobe
+      name="VP_DIFF"
+      connectsTo=".R1 > .pin1"
+      referenceTo=".R1 > .pin2"
+    />
+
+    <analogsimulation duration="10ms" timePerStep="0.1ms" spiceEngine="ngspice" />
+  </board>
+)
+`}
+/>
+
+## Properties
+
+| Property | Description | Example |
+| --- | --- | --- |
+| `name` | Optional label for the probe trace in graphs. | `"VP_OUT"` |
+| `connectsTo` | Port selector that identifies the measurement node. | `".R1 > .pin1"` |
+| `referenceTo` | Optional port selector for differential measurements. | `".R1 > .pin2"` |
+
+Add probes for every signal you want plotted in the simulation graph. When you
+provide `referenceTo`, the probe measures the voltage difference between the
+`connectsTo` node and the reference node.

--- a/docs/elements/voltagesource.mdx
+++ b/docs/elements/voltagesource.mdx
@@ -1,0 +1,59 @@
+---
+title: <voltagesource />
+description: Add a voltage source for SPICE simulations and schematic power inputs.
+---
+
+## Overview
+
+`<voltagesource />` defines a two-pin voltage source that can drive your circuit
+in SPICE simulations. It supports DC sources as well as waveform-driven sources
+(sine, square, or triangle). Use this element to provide input stimulus for
+filters, rectifiers, power converters, and other analog designs.
+
+import CircuitPreview from "@site/src/components/CircuitPreview"
+
+<CircuitPreview
+  defaultView="schematic"
+  hidePCBTab={true}
+  hide3DTab={true}
+  verticalStack={true}
+  showSimulationGraph={true}
+  code={`
+export default () => (
+  <board routingDisabled>
+    <voltagesource
+      name="V1"
+      waveShape="square"
+      amplitude="5V"
+      offset="2.5V"
+      frequency="1kHz"
+      dutyCycle={0.5}
+    />
+    <resistor name="R1" resistance="1k" />
+
+    <trace from=".V1 > .pin1" to=".R1 > .pin1" />
+    <trace from=".V1 > .pin2" to=".R1 > .pin2" />
+
+    <voltageprobe name="VP_OUT" connectsTo=".R1 > .pin1" />
+    <analogsimulation duration="5ms" timePerStep="0.05ms" spiceEngine="ngspice" />
+  </board>
+)
+`}
+/>
+
+## Properties
+
+| Property | Description | Example |
+| --- | --- | --- |
+| `name` | Reference designator for the source. | `"V1"` |
+| `voltage` | DC voltage (when you want a steady source). | `"5V"` |
+| `waveShape` | Waveform shape for AC sources. Common values are `"sinewave"`, `"square"`, and `"triangle"`. | `"square"` |
+| `frequency` | Frequency of the waveform. | `"1kHz"` |
+| `amplitude` | AC amplitude (peak) for the waveform. | `"5V"` |
+| `offset` | DC offset added to the waveform. | `"2.5V"` |
+| `dutyCycle` | Duty cycle for square waves, from `0` to `1`. | `0.5` |
+| `schX`, `schY`, `schRotation` | Schematic placement controls. | `schRotation={270}` |
+
+Use `<voltagesource />` alongside `<analogsimulation />` to define inputs for
+SPICE analysis. For physical power sources on a PCB, consider `<battery />` or a
+connector instead.


### PR DESCRIPTION
### Motivation
- Several SPICE-related JSX elements used in simulation guides were undocumented, causing confusion when examples referenced them (e.g. `<analogsimulation />`, `<voltagesource />`, `<voltageprobe />`).
- Provide clear usage, examples, and properties so users can run and interpret analog simulations in tscircuit projects.

### Description
- Added `docs/elements/analogsimulation.mdx` documenting ` <analogsimulation />` with an overview, example `CircuitPreview`, and a properties table for `duration`, `timePerStep`, and `spiceEngine`.
- Added `docs/elements/voltagesource.mdx` documenting ` <voltagesource />` with waveform options, placement example, and a properties table including `waveShape`, `frequency`, `amplitude`, `offset`, and `dutyCycle`.
- Added `docs/elements/voltageprobe.mdx` documenting ` <voltageprobe />` with example usage, differential measurement pattern, and properties including `connectsTo` and `referenceTo`.
- Each doc includes a runnable example snippet rendered via the `CircuitPreview` component to illustrate integration with traces, probes, and simulation configuration.

### Testing
- Ran `bunx tsc --noEmit` to typecheck the repo and it completed successfully.
- Ran `bun run format` (biome) which formatted files successfully.
- Attempted `bun update --latest some-dep` which failed with a 404 from the registry (package not found).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6980168ce250832e8d891dd8b7c5a4f4)