### PR TITLE
Add `pcbSx` guide with CircuitPreview and link from `<chip />` properties

### DIFF
--- a/docs/elements/chip.mdx
+++ b/docs/elements/chip.mdx
@@ -62,6 +62,7 @@ export const A555Timer = (props: Props) => {
 | `schHeight` | `Distance` | Schematic symbol height |
 | `pcbX`, `pcbY` | `Distance` | PCB board coordinates |
 | `pcbRotation` | `number` | Rotation angle on PCB |
+| [`pcbSx`](/guides/tscircuit-essentials/pcb-sx) | `PcbSx` | PCB style overrides for footprint primitives |
 | `schX`, `schY` | `Distance` | Schematic coordinates |
 | `schRotation` | `number` | Rotation angle on schematic |
 | `layer` | `string` | PCB layer (e.g., "top", "bottom") |
@@ -664,4 +665,3 @@ guide! This is often much easier and reliable than configuring a chip yourself.
 :::tip
 If you're only looking to use a standard footprint from KiCad, you can skip importing entirely by referencing the footprint directly with the `kicad:` prefix (e.g. `footprint="kicad:Resistor_SMD/R_0402_1005Metric"`). See [KiCad Footprints](/footprints/kicad-footprints) for details.
 :::
-

--- a/docs/guides/tscircuit-essentials/pcb-sx.mdx
+++ b/docs/guides/tscircuit-essentials/pcb-sx.mdx
@@ -1,0 +1,59 @@
+---
+title: pcbSx
+sidebar_position: 7
+---
+
+import CircuitPreview from "@site/src/components/CircuitPreview"
+
+The `pcbSx` prop lets you apply PCB-specific style overrides to a component and
+its footprint children using selector-like keys. It is useful when you want to
+adjust details such as silkscreen text sizing without editing the footprint
+itself.
+
+## Basic usage
+
+Use `pcbSx` on a component (like `<chip />`) and target PCB primitives with
+selectors prefixed by `&`.
+
+<CircuitPreview alwaysShowCode defaultView="pcb" code={`
+export default () => (
+  <board width="20mm" height="15mm">
+    <chip
+      name="U1"
+      footprint={
+        <footprint>
+          <smtpad portHints={["1"]} pcbX={-2} pcbY={0} width="1mm" height="1mm" />
+          <smtpad portHints={["2"]} pcbX={2} pcbY={0} width="1mm" height="1mm" />
+          <silkscreentext text="U1" pcbX={0} pcbY={-2} fontSize="1mm" />
+        </footprint>
+      }
+      pcbSx={{
+        "& silkscreentext": {
+          fontSize: "2mm",
+        },
+      }}
+    />
+  </board>
+)
+`} />
+
+## Targeting library footprints
+
+You can scope selectors to specific footprint sources. For example, this targets
+KiCad-derived footprints and updates their silkscreen text size:
+
+<CircuitPreview alwaysShowCode defaultView="pcb" code={`
+export default () => (
+  <board width="20mm" height="15mm">
+    <chip
+      name="U1"
+      footprint="kicad:Resistor_SMD:R_0402_1005Metric"
+      pcbSx={{
+        "& footprint[src^='kicad:'] silkscreentext": {
+          fontSize: "2mm",
+        },
+      }}
+    />
+  </board>
+)
+`} />


### PR DESCRIPTION
### Motivation
- Provide documentation for the `pcbSx` prop so users can apply PCB-specific style overrides and understand selector scoping for footprints. 
- Replace a plain code sample with a live-renderable example so the library-footprint usage is shown in-context.

### Description
- Added a new guide `docs/guides/tscircuit-essentials/pcb-sx.mdx` that explains `pcbSx` and includes two `CircuitPreview` examples demonstrating basic usage and targeting `kicad:` footprints. 
- Updated the `<chip />` properties table in `docs/elements/chip.mdx` to add a `pcbSx` entry linking to the new guide. 
- Replaced the standalone library-footprint code block in the guide with a `CircuitPreview` so the example renders alongside the basic usage example.

### Testing
- Ran `bunx tsc --noEmit` to typecheck the project and it completed successfully. 
- Ran `bun run format` (biome) and formatting completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6985334f260c832eb6a0206de26f8e26)