### PR TITLE
Update pcbSx guide KiCad footprint example

### DIFF
--- a/docs/guides/tscircuit-essentials/pcb-sx.mdx
+++ b/docs/guides/tscircuit-essentials/pcb-sx.mdx
@@ -47,7 +47,7 @@ export default () => (
   <board width="20mm" height="15mm">
     <chip
       name="U1"
-      footprint="kicad:Resistor_SMD:R_0402_1005Metric"
+      footprint="kicad:Resistor_SMD/R_0603_1608Metric"
       pcbSx={{
         "& footprint[src^='kicad:'] silkscreentext": {
           fontSize: "2mm",


### PR DESCRIPTION
### Motivation
- Use a 0603 KiCad footprint in the `pcbSx` guide example so the sample demonstrates the `kicad:Resistor_SMD/R_0603_1608Metric` footprint variant.

### Description
- Replace the `footprint` prop in `docs/guides/tscircuit-essentials/pcb-sx.mdx` from `"kicad:Resistor_SMD:R_0402_1005Metric"` to `"kicad:Resistor_SMD/R_0603_1608Metric"`.

### Testing
- Ran `bunx tsc --noEmit` and `bun run format`, both commands completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6985725a4ffc832eaa02f32bb23930ce)