### PR TITLE
fix add board tag to Pinheader for rendering 3d view

### DIFF
--- a/docs/elements/pinheader.mdx
+++ b/docs/elements/pinheader.mdx
@@ -15,17 +15,20 @@ import CircuitPreview from "@site/src/components/CircuitPreview"
 <CircuitPreview
   defaultView="schematic"
   code={`export default () => (
+   <board width="30mm" height="10mm">
     <pinheader
       name="J1"
       pinCount={8}
       gender="male"
       pitch="2.54mm"
+      footprint="pinrow8_rows2"
       doubleRow={true}
       showSilkscreenPinLabels={true}
       pinLabels={["VCC", "GND", "SDA", "SCL", "MISO", "MOSI", "SCK", "CS"]}
       pcbX={0}
       pcbY={0}
     />
+   </board>
   )
 `}
 />


### PR DESCRIPTION
preview https://docs-8c6u6ltpx-tscircuit.vercel.app/elements/pinheader