### PR TITLE
disable schematic view for silkscreentext element

### DIFF
--- a/docs/footprints/silkscreentext.mdx
+++ b/docs/footprints/silkscreentext.mdx
@@ -12,6 +12,7 @@ The `<silkscreentext />` element is used to add text to the silkscreen layer wit
 import CircuitPreview from "@site/src/components/CircuitPreview"
 
 <CircuitPreview
+  hideSchematicTab
   defaultView="pcb"
   code={`
   export default () => (


### PR DESCRIPTION
Before 
<img width="937" height="399" alt="Screenshot_2026-02-10_20-51-58" src="https://github.com/user-attachments/assets/e968bbbe-7d9d-45f7-8099-924032a94fd3" />

After

<img width="927" height="476" alt="Screenshot_2026-02-10_21-13-39" src="https://github.com/user-attachments/assets/ecf12f17-539d-4dce-95a7-f4ec2a2af14a" />
