### PR TITLE
disable schematic view for silkscreenrect element

### DIFF
--- a/docs/footprints/silkscreenrect.mdx
+++ b/docs/footprints/silkscreenrect.mdx
@@ -10,7 +10,7 @@ chip
 
 import CircuitPreview from "@site/src/components/CircuitPreview"
 
-<CircuitPreview code={`
+<CircuitPreview hideSchematicTab code={`
   export default () => (
  <board width="5mm" height="5mm">
     <footprint>


### PR DESCRIPTION
Before
<img width="954" height="396" alt="Screenshot_2026-02-10_20-51-41" src="https://github.com/user-attachments/assets/0cce5008-6953-43c5-84e6-7995d76479df" />

After
<img width="979" height="455" alt="Screenshot_2026-02-10_21-16-06" src="https://github.com/user-attachments/assets/cfe63749-bc59-4d7d-a6cb-6e32b7d10e67" />
