### PR TITLE
Add SPICE guide links to analogsimulation page

### DIFF
--- a/docs/elements/analogsimulation.mdx
+++ b/docs/elements/analogsimulation.mdx
@@ -8,6 +8,8 @@ description: Configure and run SPICE simulations for a tscircuit board.
 `<analogsimulation />` enables SPICE simulation for a `<board />` and sets the simulation parameters, such as duration and time step. Place this element inside
 your board alongside sources and probes to generate simulation results.
 
+If you're new to simulation workflows, check out the [SPICE simulation guide](/category/spice-simulation) for step-by-step examples.
+
 import CircuitPreview from "@site/src/components/CircuitPreview"
 
 <CircuitPreview
@@ -45,3 +47,6 @@ export default () => (
 Use `<analogsimulation />` once per `<board />` to define how the simulation
 runs. Combine it with `<voltagesource />` and `<voltageprobe />` elements to
 create and observe waveforms.
+
+For more end-to-end examples and best practices, we recommend reviewing the
+[SPICE simulation guide](/category/spice-simulation).


### PR DESCRIPTION
### Motivation
- Make the `<analogsimulation />` element docs more helpful by directing readers to the broader SPICE simulation guide for step‑by‑step examples and end‑to‑end best practices.

### Description
- Updated `docs/elements/analogsimulation.mdx` to add a link to the SPICE simulation guide (`/category/spice-simulation`) near the top of the Overview and another recommendation at the bottom of the page.

### Testing
- Ran formatting with `bun run format` which completed successfully. 
- Ran type checking with `bunx tsc --noEmit` which completed successfully. 
- Ran `bun test docs/elements` which returned no matching test files for that folder (no tests were executed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_698c00555ef8832e9ab0add53c39c0f7)