### PR TITLE
Fix invalid JSX in lab board preview snippet

### DIFF
--- a/docs/contributing/making-lab-boards.mdx
+++ b/docs/contributing/making-lab-boards.mdx
@@ -13,7 +13,9 @@ The standard copper clad in the lab is single-sided at 100mmx70mm. You should
 generally try to use the entire board to make post-processing simpler.
 
 <CircuitPreview defaultView="pcb" code={`export default () => (
-  <board width="100mm" height="70mm" />
+  <board width="100mm" height="70mm">
+    {/* ... */}
+  </board>
 )
 `} />
 

--- a/docs/contributing/making-lab-boards.mdx
+++ b/docs/contributing/making-lab-boards.mdx
@@ -13,9 +13,7 @@ The standard copper clad in the lab is single-sided at 100mmx70mm. You should
 generally try to use the entire board to make post-processing simpler.
 
 <CircuitPreview defaultView="pcb" code={`export default () => (
-  <board width="100mm" height="70mm">
-    ...
-  </board>
+  <board width="100mm" height="70mm" />
 )
 `} />
 


### PR DESCRIPTION
### Motivation
- The `CircuitPreview` example contained a raw `...` text node inside JSX which caused the renderer to error when previewing the page.

### Description
- Removed the `...` placeholder and replaced the multi-line example with a valid self-closing element ` <board width="100mm" height="70mm" />` in `docs/contributing/making-lab-boards.mdx`.

### Testing
- Ran `bunx tsc --noEmit` and `bun run format`, and both completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_698d16c5c9f8832eae75e0929c3d28ed)