### PR TITLE
docs: remove Tips section from Relative Positioning guide

### DIFF
--- a/docs/guides/tscircuit-essentials/relative-positioning.mdx
+++ b/docs/guides/tscircuit-essentials/relative-positioning.mdx
@@ -182,10 +182,3 @@ export default () => (
 
 This pattern makes it easy to keep a circuit block aligned to the edge while
 preserving internal spacing.
-
-## Tips
-
-- Prefer edge references (`minx`, `maxx`, etc.) when clearance matters.
-- Use pin references (`pin1.x`, `pin2.maxx`, etc.) for pad-specific alignment.
-- Avoid circular dependencies (A depends on B while B depends on A).
-- Keep units explicit in offsets (`+ 2mm`, `- 0.1in`) for readability.


### PR DESCRIPTION
### Motivation
- Remove the `## Tips` section from the Relative Positioning guide to streamline the end of the document and avoid duplicated or unnecessary guidance.

### Description
- Deleted the `## Tips` header and its four bullet points from `docs/guides/tscircuit-essentials/relative-positioning.mdx` so the guide now ends after the final example and paragraph.

### Testing
- Ran `bunx tsc --noEmit` which completed successfully.
- Ran `bun run format` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_698ecea0f5a0832e95560c641fb24a40)