### PR TITLE
docs: add fiducial component documentation with overview and properties

### DIFF
--- a/docs/elements/fiducial.mdx
+++ b/docs/elements/fiducial.mdx
@@ -1,0 +1,47 @@
+---
+title: <fiducial />
+description: >-
+  A reference marker used for optical alignment during automated PCB assembly.
+---
+
+## Overview
+
+A fiducial is a reference marker placed on a PCB that pick-and-place machines use for optical alignment during automated assembly. It consists of a circular copper pad with soldermask clearance (pullback) around it, creating a high-contrast marker that's easily detected by machine vision systems.
+
+Fiducials do not have a schematic representation.
+
+Fiducials are typically placed at corners of the board or near fine-pitch components to ensure accurate component placement.
+
+import CircuitPreview from "@site/src/components/CircuitPreview"
+
+<CircuitPreview
+  defaultView="pcb"
+  hideSchematicTab
+  browser3dView={false}
+  code={`export default () => (
+    <board width="30mm" height="20mm">
+      <fiducial 
+        padDiameter="1mm" 
+        soldermaskPullback="1mm" 
+        pcbX={-10} 
+        pcbY={-5} 
+      />
+      <fiducial 
+        padDiameter="1mm" 
+        soldermaskPullback="1mm" 
+        pcbX={10} 
+        pcbY={5} 
+      />
+    </board>
+  )`}
+/>
+
+## Properties
+
+| Property | Type | Default | Description |
+|----------|------|---------|-------------|
+| padDiameter | number \| string | - | Diameter of the copper pad (e.g., `"1mm"` or `1`) |
+| soldermaskPullback | number \| string | padDiameter / 2 | Margin of soldermask clearance around the pad |
+| pcbX | number | 0 | X position of the fiducial center on the PCB |
+| pcbY | number | 0 | Y position of the fiducial center on the PCB |
+| layer | `"top"` \| `"bottom"` | `"top"` | PCB layer for the fiducial |


### PR DESCRIPTION
This pull request adds new documentation for the `<fiducial />` element, providing an overview, usage example, and detailed property descriptions. This documentation will help users understand how to use fiducials for optical alignment in PCB designs.

Documentation additions:

* Added a new `docs/elements/fiducial.mdx` file with an overview of fiducials, a live code example using `<CircuitPreview>`, and a table describing all available properties for the `<fiducial />` element.

<img width="918" height="824" alt="image" src="https://github.com/user-attachments/assets/e90410ba-9e06-4b25-bc31-99fa94ee5c1b" />
