### PR TITLE
docs: update text property to support multiline input in schematictext and silkscreentext components

### DIFF
--- a/docs/elements/schematictext.mdx
+++ b/docs/elements/schematictext.mdx
@@ -16,7 +16,7 @@ import CircuitPreview from "@site/src/components/CircuitPreview"
   code={`
 export default () => (
     <board width="10mm" height="10mm">
-      <schematictext text="Hello" schX={2} schY={3} color="red" anchor="center" />
+      <schematictext text="Hello\\nWorld!" schX={2} schY={3} color="red" anchor="center" />
     </board>
   )
   `}
@@ -27,7 +27,7 @@ export default () => (
 
 | Property | Type | Description |
 |---------|------|-------------|
-| `text` | string | The text string to render. |
+| `text` | string | The text string to render, create multiline text by using `\n` |
 | `schX` | length | X coordinate of the text. |
 | `schY` | length | Y coordinate of the text. |
 | `anchor` | enum | Anchor position such as `"center"`, `"left"`, `"right"`, `"top"`, `"bottom"`, or corner positions. Defaults to `"center"`. |

--- a/docs/footprints/silkscreentext.mdx
+++ b/docs/footprints/silkscreentext.mdx
@@ -17,7 +17,7 @@ import CircuitPreview from "@site/src/components/CircuitPreview"
   code={`
   export default () => (
     <board width="10mm" height="10mm">
-      <silkscreentext text="Hello, World!" fontSize="1mm" />
+      <silkscreentext text="Hello\\nWorld!" fontSize="1mm" />
     </board>
   )`}
 />
@@ -28,7 +28,7 @@ import CircuitPreview from "@site/src/components/CircuitPreview"
 
 | Property        | Type   | Description                                                                                                   |
 |-----------------|--------|---------------------------------------------------------------------------------------------------------------|
-| `text`            | string | The text string to display.                                                                                   |
+| `text`            | string | The text string to display, create multiline text by using `\n`                                                                                   |
 | `anchorAlignment` | enum   | Alignment of the text. One of "center", "top_left", "top_right", "bottom_left", "bottom_right". Defaults to "center". |
 | `font`            | enum   | Optional. The font type, e.g. `"tscircuit2024"`.                                                                |
 | `fontSize`        | length | Optional. The size of the font. If not specified, inherits from the board's `pcbStyle.silkscreenFontSize` if set. |


### PR DESCRIPTION
This pull request updates the documentation for the `schematictext` and `silkscreentext` components to clarify how to create multiline text using the `\n` character. It also updates the example code to demonstrate multiline text usage.

**Documentation and Example Updates:**

* Updated the example in `docs/elements/schematictext.mdx` to use `"Hello\nWorld!"` for the `text` property, demonstrating multiline text.
* Clarified the `text` property description in the `schematictext` documentation table to explain that multiline text can be created with `\n`.
* Updated the example in `docs/footprints/silkscreentext.mdx` to use `"Hello\nWorld!"` for the `text` property, demonstrating multiline text.
* Clarified the `text` property description in the `silkscreentext` documentation table to explain that multiline text can be created with `\n`.