### PR TITLE
add showAsTranslucentModel documentation to cadmodel 

### DIFF
--- a/docs/elements/cadmodel.mdx
+++ b/docs/elements/cadmodel.mdx
@@ -149,6 +149,35 @@ You can render a component as translucent (semi-transparent) by setting `showAsT
   `}
 />
 
+### Translucent Model in cadmodel
+
+You can also use `showAsTranslucentModel` inside a `<cadmodel />`.
+
+<CircuitPreview
+  defaultView="3d"
+  hidePCBTab
+  hideSchematicTab
+  browser3dView={false}
+  code={`
+  export default () => (
+    <board width="10mm" height="10mm">
+      <chip
+        name="U2"
+        footprint="soic8"
+        cadModel={
+          <cadmodel
+            modelUrl="https://modelcdn.tscircuit.com/jscad_models/soic8.glb"
+            showAsTranslucentModel
+          />
+        }
+      />
+    </board>
+  )
+  `}
+/>
+
+
+
 
 ## Supported File Formats
 
@@ -171,4 +200,5 @@ The following model file formats are supported:
 | `rotationOffset` | `number \| {x: number, y: number, z: number}` | Rotate the model (number = Z-axis rotation in degrees) |
 | `zOffsetFromSurface` | `Distance` | Vertical offset from the PCB surface (e.g., "2mm", "0.1in") |
 | `size` | `{x: number, y: number, z: number}` | Scale the model size |
+| `showAsTranslucentModel` | `boolean` | Render the model as translucent |
 | `modelUnitToMmScale` | `Distance` | Scale factor to convert model units to millimeters |

--- a/docs/elements/cadmodel.mdx
+++ b/docs/elements/cadmodel.mdx
@@ -31,6 +31,20 @@ import CircuitPreview from "@site/src/components/CircuitPreview"
   `}
 />
 
+## Properties
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `modelUrl` | `string` | URL to the 3D model file (GLB, GLTF, OBJ, STL, STEP, WRL) |
+| `stepUrl` | `string` | URL to a STEP model file for export purposes |
+| `positionOffset` | `{x: number, y: number, z: number}` | Offset the model position from the component center |
+| `rotationOffset` | `number \| {x: number, y: number, z: number}` | Rotate the model (number = Z-axis rotation in degrees) |
+| `zOffsetFromSurface` | `Distance` | Vertical offset from the PCB surface (e.g., "2mm", "0.1in") |
+| `size` | `{x: number, y: number, z: number}` | Scale the model size |
+| `showAsTranslucentModel` | `boolean` | Render the model as translucent |
+| `modelUnitToMmScale` | `Distance` | Scale factor to convert model units to millimeters |
+
+
 ## Repositioning the Model
 
 You can use `positionOffset`, `rotationOffset`, and `zOffsetFromSurface` to reposition the model.
@@ -164,16 +178,3 @@ The following model file formats are supported:
 - STEP
 - STL
 - WRL
-
-## Properties
-
-| Property | Type | Description |
-|----------|------|-------------|
-| `modelUrl` | `string` | URL to the 3D model file (GLB, GLTF, OBJ, STL, STEP, WRL) |
-| `stepUrl` | `string` | URL to a STEP model file for export purposes |
-| `positionOffset` | `{x: number, y: number, z: number}` | Offset the model position from the component center |
-| `rotationOffset` | `number \| {x: number, y: number, z: number}` | Rotate the model (number = Z-axis rotation in degrees) |
-| `zOffsetFromSurface` | `Distance` | Vertical offset from the PCB surface (e.g., "2mm", "0.1in") |
-| `size` | `{x: number, y: number, z: number}` | Scale the model size |
-| `showAsTranslucentModel` | `boolean` | Render the model as translucent |
-| `modelUnitToMmScale` | `Distance` | Scale factor to convert model units to millimeters |


### PR DESCRIPTION
Added documentation for using translucent models in cadmodel.

preview: https://docs-eq3lam5cc-tscircuit.vercel.app/elements/cadmodel

<img width="1010" height="545" alt="Screenshot_2026-02-18_17-52-26" src="https://github.com/user-attachments/assets/fa900bcb-ce4a-4424-913c-582fda1f8aee" />
