### PR TITLE
refactor: simplify USB flashlight tutorial by removing unused imports and components

### DIFF
--- a/docs/tutorials/building-a-simple-usb-flashlight.mdx
+++ b/docs/tutorials/building-a-simple-usb-flashlight.mdx
@@ -11,28 +11,32 @@ tscircuit.
 import TscircuitIframe from "@site/src/components/TscircuitIframe"
 
 <TscircuitIframe defaultView="3d" code={`
-import { usePushButton } from "@tsci/seveibar.push-button"
-import { useUsbC } from "@tsci/seveibar.smd-usb-c"
+// use the built-in lowercase element which uses the default footprint
+import { SmdUsbC } from "@tsci/seveibar.smd-usb-c"
 
 export default () => {
-  const USBCPort = useUsbC("USBC")
-  const Button = usePushButton("SW1")
   return (
-    <board width="12mm" height="30mm">
-      <USBCPort
-        GND1="net.GND"
-        GND2="net.GND"
-        VBUS1="net.VBUS"
-        VBUS2="net.VBUS"
-        pcbY={-10}
-        schX={-4}
+   <board width="12mm" height="30mm">
+      <SmdUsbC
+      name="J1"
+      connections={{ GND1: "net.GND", GND2: "net.GND", VBUS1: "net.VBUS", VBUS2: "net.VBUS" }}
+      pcbY={-10}
+      schX={-4}
+    />
+      <pushbutton
+        name="SW1"
+        footprint="pushbutton"
+        layer="top"
+        connections={{ pin1: ".R1 > .pos", pin2: "net.VBUS" }}
+        pcbX={0}
+        pcbY={-1}
       />
-      <led name="LED" color="red" footprint="0603" pcbY={12} schY={2} />
-      <Button pcbY={0} pin2=".R1 > .pos" pin3="net.VBUS" schY={-2} />
+      <led name="LED" color="red" footprint="0603" pcbY={12} />
+     
       <resistor name="R1" footprint="0603" resistance="1k" pcbY={7} />
       <trace from=".R1 .neg" to=".LED .pos" />
       <trace from=".LED .neg" to="net.GND" />
     </board>
   )
 }
-`} />
+`} />

--- a/docs/tutorials/building-a-simple-usb-flashlight.mdx
+++ b/docs/tutorials/building-a-simple-usb-flashlight.mdx
@@ -11,7 +11,7 @@ tscircuit.
 import TscircuitIframe from "@site/src/components/TscircuitIframe"
 
 <TscircuitIframe defaultView="3d" code={`
-// use the built-in lowercase element which uses the default footprint
+
 import { SmdUsbC } from "@tsci/seveibar.smd-usb-c"
 
 export default () => {


### PR DESCRIPTION
This pull request updates the USB flashlight tutorial in `docs/tutorials/building-a-simple-usb-flashlight.mdx` to simplify component usage and improve clarity. The main changes involve switching to built-in elements for the USB-C port and pushbutton, and updating their connection syntax.

Component usage simplification:

* Replaced custom hooks (`usePushButton`, `useUsbC`) with built-in elements (`SmdUsbC`, `pushbutton`) for easier usage and clearer code.
* Updated the USB-C port instantiation to use the `SmdUsbC` element with a `connections` prop, and the pushbutton to use the `pushbutton` element with explicit connection mapping.

Code clarity improvements:

* Removed unnecessary imports and component definitions, reducing boilerplate and making the tutorial easier to follow.
* Modified the LED and resistor placement to align with the new connection syntax and element usage.

before 
<img width="1080" height="676" alt="Screenshot 2026-02-21 at 1 40 10 PM" src="https://github.com/user-attachments/assets/8d4acb2a-3d8e-4523-95f4-b72a12dcac78" />
after
<img width="1080" height="676" alt="Screenshot 2026-02-21 at 1 39 59 PM" src="https://github.com/user-attachments/assets/34ac67ba-d71d-428f-954c-19f80f9eccfd" />
