### PR TITLE
Add CopperText docs page describing custom copper text element with examples and properties

### DIFF
--- a/docs/footprints/coppertext.mdx
+++ b/docs/footprints/coppertext.mdx
@@ -1,0 +1,60 @@
+---
+title: <coppertext />
+description: >-
+  The `<coppertext />` element is used to add text directly to the copper layer
+  of a PCB.
+---
+
+## Overview
+
+The `<coppertext />` element is used to add text directly to the copper layer of a PCB. This is commonly used for reference designators, polarity indicators, or other markings that need to be part of the copper rather than silkscreen.
+
+import CircuitPreview from "@site/src/components/CircuitPreview"
+
+<CircuitPreview
+  defaultView="pcb"
+  code={`
+  export default () => (
+    <board width="10mm" height="10mm">
+      <footprint>
+        <coppertext text="U1" pcbX="0" pcbY="0" fontSize="1mm" />
+      </footprint>
+    </board>
+  )
+`}
+/>
+
+## Properties
+
+| Property | Type | Description |
+| --- | --- | --- |
+| `text` | string | The text string to display. |
+| `pcbX` | length | X coordinate of the text position on the PCB. |
+| `pcbY` | length | Y coordinate of the text position on the PCB |
+| `anchorAlignment` | enum | Alignment of the text. One of "center", "top_left", "top_right", "bottom_left", "bottom_right". Defaults to "center". |
+| `font` | enum | Optional. The font type, e.g. `"tscircuit2024"`. |
+| `fontSize` | length | Optional. The size of the font. |
+| `layers` | array | Optional. The copper layers to render on. Defaults to `["top"]`. |
+| `knockout` | boolean | Optional. When true, removes copper under the text (creates a clear area). |
+| `mirrored` | boolean | Optional. When true, mirrors the text. |
+| `rotation` | number | Optional. Rotation angle in degrees. |
+
+## Knockout
+
+The `knockout` prop removes the copper under the text, creating a clear area. This is useful for text like "GND" or "VCC" where you want to ensure the text is readable and not affected by copper pour.
+
+<CircuitPreview
+  defaultView="pcb"
+  code={`
+  export default () => (
+    <board width="12mm" height="10mm">
+      <footprint>
+        <coppertext text="GND" pcbX="-2.5" pcbY="0" fontSize="1.5mm" knockout />
+        <coppertext text="VCC" pcbX="2.5" pcbY="0" fontSize="1.5mm" />
+      </footprint>
+    </board>
+  )
+`}
+/>
+
+The left text has `knockout={true}` (copper removed underneath), while the right text does not.

--- a/docs/footprints/coppertext.mdx
+++ b/docs/footprints/coppertext.mdx
@@ -12,6 +12,7 @@ The `<coppertext />` element is used to add text directly to the copper layer of
 import CircuitPreview from "@site/src/components/CircuitPreview"
 
 <CircuitPreview
+  hideSchematicTab
   defaultView="pcb"
   code={`
   export default () => (
@@ -44,6 +45,7 @@ import CircuitPreview from "@site/src/components/CircuitPreview"
 The `knockout` prop removes the copper under the text, creating a clear area. This is useful for text like "GND" or "VCC" where you want to ensure the text is readable and not affected by copper pour.
 
 <CircuitPreview
+  hideSchematicTab
   defaultView="pcb"
   code={`
   export default () => (


### PR DESCRIPTION
This pull request adds new documentation for the `<coppertext />` element, which allows users to place text directly on the copper layer of a PCB. The documentation explains the purpose, properties, and usage of the element, including visual examples and details about the `knockout` feature.

Documentation additions:

* Introduced a new page describing the `<coppertext />` element, its use cases, and its properties, including examples and a preview component.
* Added a section explaining the `knockout` property, with a visual demonstration comparing copper text with and without knockout.

<img width="724" height="942" alt="image" src="https://github.com/user-attachments/assets/9122b3f3-60ed-49ef-9aba-68ffd7f30868" />
