### PR TITLE
Add knockout text feature to silkscreentext documentation

### DIFF
--- a/docs/footprints/silkscreentext.mdx
+++ b/docs/footprints/silkscreentext.mdx
@@ -32,6 +32,30 @@ import CircuitPreview from "@site/src/components/CircuitPreview"
 | `anchorAlignment` | enum   | Alignment of the text. One of "center", "top_left", "top_right", "bottom_left", "bottom_right". Defaults to "center". |
 | `font`            | enum   | Optional. The font type, e.g. `"tscircuit2024"`.                                                                |
 | `fontSize`        | length | Optional. The size of the font. If not specified, inherits from the board's `pcbStyle.silkscreenFontSize` if set. |
+| `isKnockout`      | boolean| Optional. If true, the text will "knock out" the silkscreen background around it.                              |
+| `knockoutPadding` | length | Optional. Padding around the text when `isKnockout` is true. Can be a single value or individual sides (e.g., `knockoutPaddingLeft`). |
+
+## Knockout Text
+
+Knockout text allows you to create readable text by removing the background silkscreen material. This is particularly useful when text is placed over other silkscreen elements or copper pours.
+
+<CircuitPreview
+  hideSchematicTab
+  defaultView="pcb"
+  code={`
+  export default () => (
+    <board width="20mm" height="20mm">
+      <silkscreentext 
+        text="KNOCKOUT" 
+        pcbX={0} 
+        pcbY={0} 
+        fontSize="1.5mm" 
+        isKnockout 
+      />
+    </board>
+  )`}
+/>
+
 
 ## Global Font Size
 


### PR DESCRIPTION
Added knockout text feature with relevant properties and example.

https://docs-mxzzczwgn-tscircuit.vercel.app/footprints/silkscreentext


<img width="997" height="537" alt="Screenshot_2026-02-23_00-50-53" src="https://github.com/user-attachments/assets/8559c5fd-5be7-4258-975d-55ae50a73d97" />
