### PR TITLE
fix: adjust pcbX position for fabrication note in example

### DIFF
--- a/docs/footprints/fabricationnotetext.mdx
+++ b/docs/footprints/fabricationnotetext.mdx
@@ -24,7 +24,7 @@ Below is a simple board with a fabrication note reminding the assembler about a 
       <led name="D1" footprint="0603" pcbX={5} pcbY={0} />
       <fabricationnotetext
         text="Install connector last"
-        pcbX={0}
+        pcbX={-4}
         pcbY={6}
         fontSize="1.6mm"
         anchorAlignment="top_left"


### PR DESCRIPTION
before 
<img width="870" height="830" alt="Screenshot 2026-02-24 at 6 54 01 PM" src="https://github.com/user-attachments/assets/6e446d61-0313-4965-ab08-4bef21f9d7eb" />

after 
<img width="870" height="830" alt="Screenshot 2026-02-24 at 6 53 57 PM" src="https://github.com/user-attachments/assets/300b907f-c9f4-47cb-8faa-b0fae1052af2" />
