### PR TITLE
refactor: update the 3d model rendering for constraint

### DIFF
--- a/docs/footprints/constraint.mdx
+++ b/docs/footprints/constraint.mdx
@@ -16,8 +16,8 @@ Below is a reference example that demonstrates how constraints are used within a
 import CircuitPreview from "@site/src/components/CircuitPreview"
 
 <CircuitPreview defaultView="pcb" code={`
-
-  /**
+  
+   /**
    * A switch shaft you can use to connect a pluggable Kailh socket.
    */
   const KeyswitchSocket = (props: {
@@ -27,13 +27,13 @@ import CircuitPreview from "@site/src/components/CircuitPreview"
     layer?: "top" | "bottom"
   }) => (
     <chip
-      {...props}
-      cadModel={{
-        objUrl: "/easyeda/C5184526",
-      }}
+      name={props.name}
+      pcbX={props.pcbX}
+      pcbY={props.pcbY}
+      layer={props.layer}
       footprint={
         <footprint>
-          {/* <silkscreentext text={props.name} /> */}
+         {/* <silkscreentext text={props.name} /> */}
           <smtpad
             shape="rect"
             width="2.55mm"


### PR DESCRIPTION
This pull request makes a small change to the `CircuitPreview` component usage in the `docs/footprints/constraint.mdx` file. The update simplifies the way props are passed to the `chip` component by removing the spread operator and the `cadModel` property, and instead explicitly passes individual props.

* Simplified prop passing to the `chip` component by removing the spread operator and the `cadModel` property, and explicitly passing `name`, `pcbX`, `pcbY`, and `layer` props in `docs/footprints/constraint.mdx`.

before 
<img width="1086" height="771" alt="Screenshot 2026-02-27 at 12 03 47 PM" src="https://github.com/user-attachments/assets/545e5260-6ca9-4654-a86a-d95eb03b5daf" />

after 
<img width="1086" height="771" alt="Screenshot 2026-02-27 at 12 03 36 PM" src="https://github.com/user-attachments/assets/f8e1808c-752e-48ea-9221-8ec41ab98519" />
