### PR TITLE
docs: add missing tsci snapshot flags

### DIFF
--- a/docs/command-line/tsci-snapshot.md
+++ b/docs/command-line/tsci-snapshot.md
@@ -8,12 +8,19 @@ description: Generate schematic and PCB snapshots for regression tests
 ## Usage
 
 ```bash
-tsci snapshot [options]
+tsci snapshot [options] [path]
 ```
 
 ### Options
 - `-u, --update` – write new snapshots to disk.
+- `--force-update` – force writing snapshots even when no visual diff is detected.
 - `--3d` – also generate 3D preview snapshots.
+- `--pcb-only` – generate only PCB snapshots.
+- `--schematic-only` – generate only schematic snapshots.
+- `--disable-parts-engine` – disable the parts engine while rendering snapshots.
+
+### Arguments
+- `[path]` – optional file path, directory, or glob pattern used to limit what gets snapshotted.
 
 ### Which files are snapped?
 The command searches the current project for:


### PR DESCRIPTION
### Motivation
- Ensure the `tsci snapshot` command documentation matches the actual CLI behavior by documenting the missing flags and optional path argument.

### Description
- Update the usage line to `tsci snapshot [options] [path]` to show the optional path argument. 
- Add new documented options: `--force-update`, `--pcb-only`, `--schematic-only`, and `--disable-parts-engine`.
- Add an `Arguments` section describing the optional `[path]` file/directory/glob filter.

### Testing
- Ran `bunx tsc --noEmit` which completed successfully. 
- Ran `bun run format` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69a22bf0812c832e8e5e878d24ddf3a9)