### PR TITLE
fix: fixing the pcb and schematic view of keyboard

### DIFF
--- a/docs/tutorials/build-a-custom-keyboard-with-tscircuit.mdx
+++ b/docs/tutorials/build-a-custom-keyboard-with-tscircuit.mdx
@@ -314,7 +314,7 @@ const rowPins = ["net.ROW0", "net.ROW1", "net.ROW2", "net.ROW3", "net.ROW4"];
 const colPins = ["net.COL0", "net.COL1", "net.COL2", "net.COL3", "net.COL4", "net.COL5", "net.COL6", "net.COL7", "net.COL8", "net.COL9", "net.COL10", "net.COL11", "net.COL12", "net.COL13", "net.COL14"];
 
 export default () => (
-  <board>
+  <board routingDisabled>
     {/* Place the Pico */}
     <PICO
       name="U1"

--- a/docs/tutorials/build-a-custom-keyboard-with-tscircuit.mdx
+++ b/docs/tutorials/build-a-custom-keyboard-with-tscircuit.mdx
@@ -305,7 +305,51 @@ export const default60 = [
 
 Now, update `index.tsx` to use this layout. We also need to expand our `rowPins` and `colPins` to match the requirements of a 60% keyboard (typically 5 rows and up to 15 columns).
 
-<CircuitPreview defaultView="pcb" code={`
+```tsx title="index.tsx"
+import { PICO } from "@tsci/seveibar.PICO";
+import { type KLELayout, KeyMatrix, layouts } from "@tsci/seveibar.keyboard-utils";
+
+// We'll need more rows and columns for a 60% keyboard
+const rowPins = ["net.ROW0", "net.ROW1", "net.ROW2", "net.ROW3", "net.ROW4"];
+const colPins = [
+  "net.COL0", "net.COL1", "net.COL2", "net.COL3", "net.COL4",
+  "net.COL5", "net.COL6", "net.COL7", "net.COL8", "net.COL9",
+  "net.COL10", "net.COL11", "net.COL12", "net.COL13", "net.COL14",
+];
+
+export default () => (
+  <board >
+    {/* Place the Pico */}
+    <PICO
+      name="U1"
+      pcbX={-150}
+      pcbY={20}
+      layer="bottom"
+      pcbRotation="90deg"
+      connections={{
+        GP15: rowPins[0], GP16: rowPins[1], GP17: rowPins[2],
+        GP18: rowPins[3], GP19: rowPins[4],
+        GP0: colPins[0],  GP1: colPins[1],  GP2: colPins[2],
+        GP3: colPins[3],  GP4: colPins[4],  GP5: colPins[5],
+        GP6: colPins[6],  GP7: colPins[7],  GP8: colPins[8],
+        GP9: colPins[9],  GP10: colPins[10], GP11: colPins[11],
+        GP12: colPins[12], GP13: colPins[13], GP14: colPins[14],
+      }}
+    />
+
+    {/* Place the KeyMatrix */}
+    <KeyMatrix
+      layout={layouts.default60}
+      rowToMicroPin={rowPins}
+      colToMicroPin={colPins}
+      pcbX={25}
+      pcbY={10}
+    />
+  </board>
+)
+```
+
+<TscircuitIframe code={`
 import { PICO } from "@tsci/seveibar.PICO";
 import { type KLELayout, KeyMatrix, layouts } from "@tsci/seveibar.keyboard-utils";
 
@@ -314,7 +358,7 @@ const rowPins = ["net.ROW0", "net.ROW1", "net.ROW2", "net.ROW3", "net.ROW4"];
 const colPins = ["net.COL0", "net.COL1", "net.COL2", "net.COL3", "net.COL4", "net.COL5", "net.COL6", "net.COL7", "net.COL8", "net.COL9", "net.COL10", "net.COL11", "net.COL12", "net.COL13", "net.COL14"];
 
 export default () => (
-  <board routingDisabled>
+  <board>
     {/* Place the Pico */}
     <PICO
       name="U1"
@@ -357,7 +401,6 @@ export default () => (
     />
   </board>
 )
-
 `} />
 
 With this setup, you can easily swap `default60` with any other KLE layout JSON data to generate different keyboard PCBs!


### PR DESCRIPTION

before 
<img width="1086" height="771" alt="Screenshot 2026-02-28 at 12 26 13 PM" src="https://github.com/user-attachments/assets/f10dd68b-7704-4f62-9fe3-d0efed2c8293" />
after 
<img width="1086" height="771" alt="Screenshot 2026-02-28 at 12 51 10 PM" src="https://github.com/user-attachments/assets/15ab2717-c218-463b-89f5-32f91ba0c47e" />
This pull request updates the tutorial for building a custom keyboard with TSCircuit to provide a more complete and clear example for creating a 60% keyboard. The main change is replacing the previous `CircuitPreview` code block with a full, annotated `index.tsx` implementation, and switching the preview component to `TscircuitIframe`. This helps readers understand how to wire up a 60% keyboard with the correct row and column pins and visualize the result.


