### PR TITLE
Add Package Builds create/get API docs and registry index entries

### DIFF
--- a/docs/web-apis/package-builds-create-api.md
+++ b/docs/web-apis/package-builds-create-api.md
@@ -1,0 +1,87 @@
+---
+title: Package Builds Create API
+description: Create one-off builds for a package release, including optional prop injection
+---
+
+# `package_builds/create`
+
+Create a one-off package build from an existing package release.
+
+This endpoint is useful when you want to rebuild a published release with runtime
+props injected into the build command (without changing the release's active
+build).
+
+Base URL: `https://api.tscircuit.com`
+
+Auth header:
+
+```http
+Authorization: Bearer <your_token>
+```
+
+## Request
+
+### `POST /package_builds/create`
+
+Request body:
+
+```json
+{
+  "package_release_id": "<uuid>",
+  "props_to_inject": {
+    "resistance": "10k",
+    "nested": {
+      "ledColor": "green"
+    }
+  }
+}
+```
+
+### Fields
+
+- `package_release_id` (required, UUID): The package release to build from.
+- `props_to_inject` (optional, object): Arbitrary JSON object written to
+  `props.json` and passed to the build process with
+  `--inject-props-file props.json`.
+
+## Example Success Response
+
+```json
+{
+  "ok": true,
+  "package_build_id": "3ab679fa-09bc-4c66-8fd8-b3a4f2d262f8"
+}
+```
+
+## Example Error Responses
+
+### Package release not found
+
+```json
+{
+  "error": {
+    "error_code": "package_release_not_found",
+    "message": "Package release not found"
+  }
+}
+```
+
+### No permission to manage package
+
+```json
+{
+  "error": {
+    "error_code": "forbidden",
+    "message": "You do not have permission to create a build for this package release"
+  }
+}
+```
+
+## Notes
+
+- This endpoint requires a logged-in session authorized to manage the package's
+  owner org.
+- Builds created with this endpoint are queued as one-off package builds and do
+  not update `active_package_build_id` on the package release.
+- Use [`/package_builds/get`](./package-builds-get-api) with the returned
+  `package_build_id` to poll status and read `user_code_job_log_stream_url`.

--- a/docs/web-apis/package-builds-get-api.md
+++ b/docs/web-apis/package-builds-get-api.md
@@ -1,0 +1,89 @@
+---
+title: Package Builds Get API
+description: Fetch build status, errors, and log stream URL for a package build
+---
+
+# `package_builds/get`
+
+Get a package build by `package_build_id`.
+
+Use this endpoint to poll build progress after creating a one-off build with
+[`/package_builds/create`](./package-builds-create-api), and to read the
+`user_code_job_log_stream_url` field for long-running build logs.
+
+Base URL: `https://api.tscircuit.com`
+
+## Request
+
+### `POST /package_builds/get`
+
+Request body:
+
+```json
+{
+  "package_build_id": "77259a87-8a4f-4365-888c-45d5d70567a8"
+}
+```
+
+### Fields
+
+- `package_build_id` (required, UUID): The package build ID returned by
+  [`/package_builds/create`](./package-builds-create-api).
+
+## Example Success Response
+
+```json
+{
+  "ok": true,
+  "package_build": {
+    "package_build_id": "77259a87-8a4f-4365-888c-45d5d70567a8",
+    "package_release_id": "96cc184a-fb65-4458-8eca-488c38977a8d",
+    "created_at": "2025-08-15T16:13:14.625Z",
+    "build_in_progress": false,
+    "transpilation_in_progress": false,
+    "circuit_json_build_in_progress": false,
+    "image_generation_in_progress": false,
+    "transpilation_error": null,
+    "circuit_json_build_error": null,
+    "image_generation_error": null,
+    "user_code_job_error": null,
+    "user_code_job_log_stream_url": null,
+    "user_code_job_completed_logs": null
+  }
+}
+```
+
+## Example Error Responses
+
+### Missing `package_build_id`
+
+```json
+{
+  "ok": false,
+  "error": {
+    "message": "`package_build_id` is required",
+    "error_code": "validation_error"
+  }
+}
+```
+
+### Build not found
+
+```json
+{
+  "error": {
+    "error_code": "package_build_not_found",
+    "message": "Package build not found"
+  }
+}
+```
+
+## Polling and log stream workflow
+
+1. Create a build with [`POST /package_builds/create`](./package-builds-create-api).
+2. Poll `POST /package_builds/get` every few seconds with the returned
+   `package_build_id`.
+3. While `build_in_progress` is `true`, check `user_code_job_log_stream_url`:
+   - if non-null, connect to that URL to follow the long stream of logs.
+4. When `build_in_progress` becomes `false`, inspect `*_error` fields and
+   `user_code_job_completed_logs`.

--- a/docs/web-apis/the-registry-api.md
+++ b/docs/web-apis/the-registry-api.md
@@ -52,6 +52,8 @@ The following endpoints are available:
 | `/package_releases/update` | Update a package release, e.g. to lock it from modifications |
 | [`/package_releases/get`](./package-releases-get-api) | Get a package release                                        |
 | [`/package_releases/list`](./package-releases-list-api) | List package releases for a package                          |
+| [`/package_builds/create`](./package-builds-create-api) | Create a one-off build for a package release                |
+| [`/package_builds/get`](./package-builds-get-api) | Get status and log stream URL for a package build           |
 
 To learn how to find `package_id`, `package_release_id`, and latest release versions, see [Finding Package Releases](./finding-package-releases).
 


### PR DESCRIPTION
### Motivation

- Document new endpoints to create one-off package builds with injected runtime props and to poll build status and logs so clients can trigger and monitor rebuilds without changing active releases.

### Description

- Add `docs/web-apis/package-builds-create-api.md` documenting `POST /package_builds/create`, request schema, `props_to_inject` behavior, examples, and error cases. 
- Add `docs/web-apis/package-builds-get-api.md` documenting `POST /package_builds/get`, the `package_build` response structure, polling workflow, and example responses. 
- Update `docs/web-apis/the-registry-api.md` to include links to the new `package_builds/create` and `package_builds/get` endpoints in the registry endpoints table.

### Testing

- Ran the documentation lint and static site build checks using `markdownlint` and `mkdocs build`, and both checks completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69a8c0edc584832ea520fb069a0e3b58)