### PR TITLE
docs: add capacitive touch slider tutorial

### DIFF
--- a/docs/tutorials/building-a-capacitive-touch-slider.mdx
+++ b/docs/tutorials/building-a-capacitive-touch-slider.mdx
@@ -1,0 +1,193 @@
+---
+title: Building a Capacitive Touch Slider
+description: >-
+  Learn how to design a capacitive touch slider PCB element in tscircuit using
+  polygon smtpads with solder mask and connect it to a microcontroller.
+---
+
+## Overview
+
+Capacitive touch sliders are used in consumer electronics for volume controls,
+brightness sliders, and scroll wheels. They detect changes in capacitance when a
+finger approaches a set of exposed or solder-mask-covered copper pads.
+
+In this tutorial we'll build a five-pad capacitive touch slider using tscircuit,
+connect it to an ATtiny85 microcontroller, and explore how the
+`coveredWithSolderMask` property works.
+
+import TscircuitIframe from "@site/src/components/TscircuitIframe"
+
+## The Finished Circuit
+
+<TscircuitIframe defaultView="pcb" code={`
+export default () => {
+  // Five slider pads — progressively taller toward the center
+  const pads = [
+    { name: "PAD1", pcbX: -8, width: 2.5, height: 6  },
+    { name: "PAD2", pcbX: -4, width: 2.5, height: 8  },
+    { name: "PAD3", pcbX:  0, width: 2.5, height: 10 },
+    { name: "PAD4", pcbX:  4, width: 2.5, height: 8  },
+    { name: "PAD5", pcbX:  8, width: 2.5, height: 6  },
+  ]
+
+  return (
+    <board width="30mm" height="20mm">
+      {pads.map(({ name, pcbX, width, height }) => (
+        <smtpad
+          key={name}
+          name={name}
+          shape="rect"
+          width={\`\${width}mm\`}
+          height={\`\${height}mm\`}
+          pcbX={\`\${pcbX}mm\`}
+          pcbY="0mm"
+          layer="top"
+          coveredWithSolderMask
+          portHints={[name.toLowerCase()]}
+        />
+      ))}
+
+      <chip
+        name="U1"
+        footprint="soic8"
+        pcbX="0mm"
+        pcbY="-7mm"
+        connections={{
+          pin1: ".PAD1",
+          pin2: ".PAD2",
+          pin3: ".PAD3",
+          pin5: ".PAD4",
+          pin6: ".PAD5",
+          pin4: "net.GND",
+          pin8: "net.VCC",
+        }}
+      />
+    </board>
+  )
+}
+`} />
+
+## Why `coveredWithSolderMask`?
+
+Normally, copper pads are left uncovered so solder will bond to them. For a
+capacitive touch element we **don't** want bare copper — we want the green
+solder-mask layer to act as a thin dielectric between the finger and the pad.
+
+Setting `coveredWithSolderMask` on an `<smtpad />` tells tscircuit to apply
+solder mask over the copper area. The underlying `circuit-json` property is
+`is_covered_with_solder_mask: true`, which renderers use to draw the pad in the
+correct layer color and suppress solder paste generation.
+
+```tsx
+<smtpad
+  shape="rect"
+  width="2.5mm"
+  height="8mm"
+  coveredWithSolderMask   // ← covers the pad with solder mask
+  portHints={["pad2"]}
+/>
+```
+
+## Step-by-Step Breakdown
+
+### 1. Define the Pad Array
+
+The slider effect comes from varying pad heights — the center pad is tallest,
+creating a larger sensing area for the midpoint of a finger swipe.
+
+```tsx
+const pads = [
+  { name: "PAD1", pcbX: -8, width: 2.5, height: 6  },
+  { name: "PAD2", pcbX: -4, width: 2.5, height: 8  },
+  { name: "PAD3", pcbX:  0, width: 2.5, height: 10 },
+  { name: "PAD4", pcbX:  4, width: 2.5, height: 8  },
+  { name: "PAD5", pcbX:  8, width: 2.5, height: 6  },
+]
+```
+
+### 2. Render Pads with Solder Mask
+
+Map over the array and render each pad with `coveredWithSolderMask`:
+
+```tsx
+{pads.map(({ name, pcbX, width, height }) => (
+  <smtpad
+    key={name}
+    name={name}
+    shape="rect"
+    width={`${width}mm`}
+    height={`${height}mm`}
+    pcbX={`${pcbX}mm`}
+    pcbY="0mm"
+    layer="top"
+    coveredWithSolderMask
+    portHints={[name.toLowerCase()]}
+  />
+))}
+```
+
+### 3. Connect to a Microcontroller
+
+Use a SOIC-8 ATtiny85 (or any 8-pin MCU) and wire each pad to a GPIO pin:
+
+```tsx
+<chip
+  name="U1"
+  footprint="soic8"
+  pcbX="0mm"
+  pcbY="-7mm"
+  connections={{
+    pin1: ".PAD1",
+    pin2: ".PAD2",
+    pin3: ".PAD3",
+    pin5: ".PAD4",
+    pin6: ".PAD5",
+    pin4: "net.GND",
+    pin8: "net.VCC",
+  }}
+/>
+```
+
+## Polygon Pad Variant
+
+For a more ergonomic slider with tapered ends, use `shape="polygon"` instead
+of `shape="rect"`:
+
+```tsx
+// Tapered polygon pad — wider at top, narrower at bottom
+const polygonPad = (width: number, height: number) => [
+  { x: -width / 2,       y:  height / 2 },
+  { x:  width / 2,       y:  height / 2 },
+  { x:  width / 4,       y: -height / 2 },
+  { x: -width / 4,       y: -height / 2 },
+]
+
+<smtpad
+  name="PAD3"
+  shape="polygon"
+  points={polygonPad(2.5, 10)}
+  pcbX="0mm"
+  pcbY="0mm"
+  layer="top"
+  coveredWithSolderMask
+  portHints={["pad3"]}
+/>
+```
+
+## How It Works in Hardware
+
+When your finger approaches the slider:
+
+1. Each pad forms a small capacitor with your fingertip
+2. The solder mask (a few microns thick) acts as the dielectric
+3. Your microcontroller measures capacitance on each pin
+4. The position is interpolated by comparing relative capacitance values across pads
+
+This technique is used in products ranging from laptop trackpads to industrial
+control panels.
+
+## Related Resources
+
+- [`<smtpad />` element reference](/elements/smtpad)
+- [`coveredWithSolderMask` prop](https://github.com/tscircuit/props/blob/main/lib/components/smtpad.ts)
+- [GitHub issue: tscircuit/tscircuit#786](https://github.com/tscircuit/tscircuit/issues/786)


### PR DESCRIPTION
## Summary

/claim #786 (partial)

Adds a step-by-step tutorial showing how to build a 5-pad capacitive touch slider PCB element using `coveredWithSolderMask` smtpads in tscircuit.

**What this covers:**
- How `coveredWithSolderMask` works (solder mask as a capacitive dielectric layer)
- Defining a pad array with varying heights for ergonomic slider feel
- Connecting slider pads to an ATtiny85 microcontroller via `connections`
- Polygon pad variant for curved/tapered slider designs
- Hardware explanation of how capacitive position sensing works

**Companion PR:** tscircuit/core#2021 (snapshot test)

## Related

Closes (partial): tscircuit/tscircuit#786