### PR TITLE
Add documentation pages for <courtyardcircle />, <courtyardrect />, and <courtyardoutline />

### DIFF
--- a/docs/elements/courtyardcircle.mdx
+++ b/docs/elements/courtyardcircle.mdx
@@ -22,8 +22,8 @@ export default () => (
       name="U1"
       footprint={
         <footprint>
-          <platedhole pcbX={-2.5} pcbY={0} outerDiameter={2.2} holeDiameter={1.1} />
-          <platedhole pcbX={2.5} pcbY={0} outerDiameter={2.2} holeDiameter={1.1} />
+          <platedhole shape="circle" pcbX={-2.5} pcbY={0} outerDiameter={2.2} holeDiameter={1.1} />
+          <platedhole shape="circle" pcbX={2.5} pcbY={0} outerDiameter={2.2} holeDiameter={1.1} />
           <courtyardcircle pcbX={0} pcbY={0} radius={4} strokeWidth={0.1} />
         </footprint>
       }
@@ -46,7 +46,7 @@ export default () => (
       name="TP1"
       footprint={
         <footprint>
-          <platedhole pcbX={0} pcbY={0} outerDiameter={2.2} holeDiameter={1.1} />
+          <platedhole shape="circle" pcbX={0} pcbY={0} outerDiameter={2.2} holeDiameter={1.1} />
           <courtyardcircle
             pcbX={0}
             pcbY={0}

--- a/docs/elements/courtyardcircle.mdx
+++ b/docs/elements/courtyardcircle.mdx
@@ -19,8 +19,8 @@ Use `<courtyardcircle />` inside a `<footprint />` to define circular courtyard 
 export default () => (
   <board width="20mm" height="20mm">
     <footprint name="U1" pcbX={0} pcbY={0}>
-      <smtpad shape="rect" width={1.2} height={1.6} pcbX={-2} pcbY={0} portHints={["1"]} />
-      <smtpad shape="rect" width={1.2} height={1.6} pcbX={2} pcbY={0} portHints={["2"]} />
+      <platedhole pcbX={-2.5} pcbY={0} outerDiameter={2.2} holeDiameter={1.1} />
+      <platedhole pcbX={2.5} pcbY={0} outerDiameter={2.2} holeDiameter={1.1} />
       <courtyardcircle pcbX={0} pcbY={0} radius={4} strokeWidth={0.1} />
     </footprint>
   </board>

--- a/docs/elements/courtyardcircle.mdx
+++ b/docs/elements/courtyardcircle.mdx
@@ -18,11 +18,16 @@ Use `<courtyardcircle />` inside a `<footprint />` to define circular courtyard 
   code={`
 export default () => (
   <board width="20mm" height="20mm">
-    <footprint name="U1" pcbX={0} pcbY={0}>
-      <platedhole pcbX={-2.5} pcbY={0} outerDiameter={2.2} holeDiameter={1.1} />
-      <platedhole pcbX={2.5} pcbY={0} outerDiameter={2.2} holeDiameter={1.1} />
-      <courtyardcircle pcbX={0} pcbY={0} radius={4} strokeWidth={0.1} />
-    </footprint>
+    <chip
+      name="U1"
+      footprint={
+        <footprint>
+          <platedhole pcbX={-2.5} pcbY={0} outerDiameter={2.2} holeDiameter={1.1} />
+          <platedhole pcbX={2.5} pcbY={0} outerDiameter={2.2} holeDiameter={1.1} />
+          <courtyardcircle pcbX={0} pcbY={0} radius={4} strokeWidth={0.1} />
+        </footprint>
+      }
+    />
   </board>
 )
 `}
@@ -37,16 +42,21 @@ export default () => (
   code={`
 export default () => (
   <board width="18mm" height="18mm">
-    <footprint name="TP1" pcbX={0} pcbY={0}>
-      <platedhole pcbX={0} pcbY={0} outerDiameter={2.2} holeDiameter={1.1} />
-      <courtyardcircle
-        pcbX={0}
-        pcbY={0}
-        radius={3.2}
-        strokeWidth={0.1}
-        isFilled
-      />
-    </footprint>
+    <chip
+      name="TP1"
+      footprint={
+        <footprint>
+          <platedhole pcbX={0} pcbY={0} outerDiameter={2.2} holeDiameter={1.1} />
+          <courtyardcircle
+            pcbX={0}
+            pcbY={0}
+            radius={3.2}
+            strokeWidth={0.1}
+            isFilled
+          />
+        </footprint>
+      }
+    />
   </board>
 )
 `}

--- a/docs/elements/courtyardcircle.mdx
+++ b/docs/elements/courtyardcircle.mdx
@@ -1,0 +1,53 @@
+---
+title: <courtyardcircle />
+description: Draw circular IPC courtyard markings around footprint features.
+---
+
+import CircuitPreview from "@site/src/components/CircuitPreview"
+
+## Overview
+
+Use `<courtyardcircle />` inside a `<footprint />` to define circular courtyard boundaries and clearance regions.
+
+## Basic Example
+
+<CircuitPreview
+  defaultView="pcb"
+  hideSchematicTab
+  hide3DTab
+  code={`
+export default () => (
+  <board width="20mm" height="20mm">
+    <footprint name="U1" pcbX={0} pcbY={0}>
+      <smtpad shape="rect" width={1.2} height={1.6} pcbX={-2} pcbY={0} portHints={["1"]} />
+      <smtpad shape="rect" width={1.2} height={1.6} pcbX={2} pcbY={0} portHints={["2"]} />
+      <courtyardcircle pcbX={0} pcbY={0} radius={4} strokeWidth={0.1} />
+    </footprint>
+  </board>
+)
+`}
+/>
+
+## Filled Circle Example
+
+<CircuitPreview
+  defaultView="pcb"
+  hideSchematicTab
+  hide3DTab
+  code={`
+export default () => (
+  <board width="18mm" height="18mm">
+    <footprint name="TP1" pcbX={0} pcbY={0}>
+      <platedhole pcbX={0} pcbY={0} outerDiameter={2.2} holeDiameter={1.1} />
+      <courtyardcircle
+        pcbX={0}
+        pcbY={0}
+        radius={3.2}
+        strokeWidth={0.1}
+        isFilled
+      />
+    </footprint>
+  </board>
+)
+`}
+/>

--- a/docs/elements/courtyardoutline.mdx
+++ b/docs/elements/courtyardoutline.mdx
@@ -18,22 +18,27 @@ Use `<courtyardoutline />` when your footprint needs a non-rectangular, non-circ
   code={`
 export default () => (
   <board width="30mm" height="24mm">
-    <footprint name="U1" pcbX={0} pcbY={0}>
-      <platedhole pcbX={-4} pcbY={-2.5} outerDiameter={2.2} holeDiameter={1.1} />
-      <platedhole pcbX={-4} pcbY={2.5} outerDiameter={2.2} holeDiameter={1.1} />
-      <platedhole pcbX={4} pcbY={-2.5} outerDiameter={2.2} holeDiameter={1.1} />
-      <platedhole pcbX={4} pcbY={2.5} outerDiameter={2.2} holeDiameter={1.1} />
-      <courtyardoutline
-        points={[
-          { x: -6, y: -5 },
-          { x: 6, y: -5 },
-          { x: 6, y: 5 },
-          { x: 0, y: 7 },
-          { x: -6, y: 5 },
-        ]}
-        strokeWidth={0.1}
-      />
-    </footprint>
+    <chip
+      name="U1"
+      footprint={
+        <footprint>
+          <platedhole pcbX={-4} pcbY={-2.5} outerDiameter={2.2} holeDiameter={1.1} />
+          <platedhole pcbX={-4} pcbY={2.5} outerDiameter={2.2} holeDiameter={1.1} />
+          <platedhole pcbX={4} pcbY={-2.5} outerDiameter={2.2} holeDiameter={1.1} />
+          <platedhole pcbX={4} pcbY={2.5} outerDiameter={2.2} holeDiameter={1.1} />
+          <courtyardoutline
+            points={[
+              { x: -6, y: -5 },
+              { x: 6, y: -5 },
+              { x: 6, y: 5 },
+              { x: 0, y: 7 },
+              { x: -6, y: 5 },
+            ]}
+            strokeWidth={0.1}
+          />
+        </footprint>
+      }
+    />
   </board>
 )
 `}
@@ -48,19 +53,24 @@ export default () => (
   code={`
 export default () => (
   <board width="28mm" height="22mm">
-    <footprint name="ANT1" pcbX={0} pcbY={0}>
-      <platedhole pcbX={0} pcbY={-3} outerDiameter={2.2} holeDiameter={1.1} />
-      <courtyardoutline
-        points={[
-          { x: -7, y: -5 },
-          { x: 7, y: -5 },
-          { x: 7, y: 4 },
-          { x: 0, y: 7 },
-          { x: -7, y: 4 },
-        ]}
-        isFilled
-      />
-    </footprint>
+    <chip
+      name="ANT1"
+      footprint={
+        <footprint>
+          <platedhole pcbX={0} pcbY={-3} outerDiameter={2.2} holeDiameter={1.1} />
+          <courtyardoutline
+            points={[
+              { x: -7, y: -5 },
+              { x: 7, y: -5 },
+              { x: 7, y: 4 },
+              { x: 0, y: 7 },
+              { x: -7, y: 4 },
+            ]}
+            isFilled
+          />
+        </footprint>
+      }
+    />
   </board>
 )
 `}

--- a/docs/elements/courtyardoutline.mdx
+++ b/docs/elements/courtyardoutline.mdx
@@ -19,10 +19,10 @@ Use `<courtyardoutline />` when your footprint needs a non-rectangular, non-circ
 export default () => (
   <board width="30mm" height="24mm">
     <footprint name="U1" pcbX={0} pcbY={0}>
-      <smtpad shape="rect" width={1.2} height={1.8} pcbX={-4} pcbY={-2} portHints={["1"]} />
-      <smtpad shape="rect" width={1.2} height={1.8} pcbX={-4} pcbY={2} portHints={["2"]} />
-      <smtpad shape="rect" width={1.2} height={1.8} pcbX={4} pcbY={-2} portHints={["3"]} />
-      <smtpad shape="rect" width={1.2} height={1.8} pcbX={4} pcbY={2} portHints={["4"]} />
+      <platedhole pcbX={-4} pcbY={-2.5} outerDiameter={2.2} holeDiameter={1.1} />
+      <platedhole pcbX={-4} pcbY={2.5} outerDiameter={2.2} holeDiameter={1.1} />
+      <platedhole pcbX={4} pcbY={-2.5} outerDiameter={2.2} holeDiameter={1.1} />
+      <platedhole pcbX={4} pcbY={2.5} outerDiameter={2.2} holeDiameter={1.1} />
       <courtyardoutline
         points={[
           { x: -6, y: -5 },
@@ -49,7 +49,7 @@ export default () => (
 export default () => (
   <board width="28mm" height="22mm">
     <footprint name="ANT1" pcbX={0} pcbY={0}>
-      <smtpad shape="rect" width={2.5} height={1.5} pcbX={0} pcbY={-3} portHints={["1"]} />
+      <platedhole pcbX={0} pcbY={-3} outerDiameter={2.2} holeDiameter={1.1} />
       <courtyardoutline
         points={[
           { x: -7, y: -5 },

--- a/docs/elements/courtyardoutline.mdx
+++ b/docs/elements/courtyardoutline.mdx
@@ -22,10 +22,10 @@ export default () => (
       name="U1"
       footprint={
         <footprint>
-          <platedhole pcbX={-4} pcbY={-2.5} outerDiameter={2.2} holeDiameter={1.1} />
-          <platedhole pcbX={-4} pcbY={2.5} outerDiameter={2.2} holeDiameter={1.1} />
-          <platedhole pcbX={4} pcbY={-2.5} outerDiameter={2.2} holeDiameter={1.1} />
-          <platedhole pcbX={4} pcbY={2.5} outerDiameter={2.2} holeDiameter={1.1} />
+          <platedhole shape="circle" pcbX={-4} pcbY={-2.5} outerDiameter={2.2} holeDiameter={1.1} />
+          <platedhole shape="circle" pcbX={-4} pcbY={2.5} outerDiameter={2.2} holeDiameter={1.1} />
+          <platedhole shape="circle" pcbX={4} pcbY={-2.5} outerDiameter={2.2} holeDiameter={1.1} />
+          <platedhole shape="circle" pcbX={4} pcbY={2.5} outerDiameter={2.2} holeDiameter={1.1} />
           <courtyardoutline
             points={[
               { x: -6, y: -5 },
@@ -57,7 +57,7 @@ export default () => (
       name="ANT1"
       footprint={
         <footprint>
-          <platedhole pcbX={0} pcbY={-3} outerDiameter={2.2} holeDiameter={1.1} />
+          <platedhole shape="circle" pcbX={0} pcbY={-3} outerDiameter={2.2} holeDiameter={1.1} />
           <courtyardoutline
             points={[
               { x: -7, y: -5 },

--- a/docs/elements/courtyardoutline.mdx
+++ b/docs/elements/courtyardoutline.mdx
@@ -1,0 +1,67 @@
+---
+title: <courtyardoutline />
+description: Draw custom polygon courtyard boundaries for irregular package geometry.
+---
+
+import CircuitPreview from "@site/src/components/CircuitPreview"
+
+## Overview
+
+Use `<courtyardoutline />` when your footprint needs a non-rectangular, non-circular courtyard shape.
+
+## Basic Outline Example
+
+<CircuitPreview
+  defaultView="pcb"
+  hideSchematicTab
+  hide3DTab
+  code={`
+export default () => (
+  <board width="30mm" height="24mm">
+    <footprint name="U1" pcbX={0} pcbY={0}>
+      <smtpad shape="rect" width={1.2} height={1.8} pcbX={-4} pcbY={-2} portHints={["1"]} />
+      <smtpad shape="rect" width={1.2} height={1.8} pcbX={-4} pcbY={2} portHints={["2"]} />
+      <smtpad shape="rect" width={1.2} height={1.8} pcbX={4} pcbY={-2} portHints={["3"]} />
+      <smtpad shape="rect" width={1.2} height={1.8} pcbX={4} pcbY={2} portHints={["4"]} />
+      <courtyardoutline
+        points={[
+          { x: -6, y: -5 },
+          { x: 6, y: -5 },
+          { x: 6, y: 5 },
+          { x: 0, y: 7 },
+          { x: -6, y: 5 },
+        ]}
+        strokeWidth={0.1}
+      />
+    </footprint>
+  </board>
+)
+`}
+/>
+
+## Filled Outline Example
+
+<CircuitPreview
+  defaultView="pcb"
+  hideSchematicTab
+  hide3DTab
+  code={`
+export default () => (
+  <board width="28mm" height="22mm">
+    <footprint name="ANT1" pcbX={0} pcbY={0}>
+      <smtpad shape="rect" width={2.5} height={1.5} pcbX={0} pcbY={-3} portHints={["1"]} />
+      <courtyardoutline
+        points={[
+          { x: -7, y: -5 },
+          { x: 7, y: -5 },
+          { x: 7, y: 4 },
+          { x: 0, y: 7 },
+          { x: -7, y: 4 },
+        ]}
+        isFilled
+      />
+    </footprint>
+  </board>
+)
+`}
+/>

--- a/docs/elements/courtyardrect.mdx
+++ b/docs/elements/courtyardrect.mdx
@@ -1,0 +1,61 @@
+---
+title: <courtyardrect />
+description: Draw rectangular IPC courtyard markings around a footprint body.
+---
+
+import CircuitPreview from "@site/src/components/CircuitPreview"
+
+## Overview
+
+Use `<courtyardrect />` to create rectangular courtyard boundaries for packages with rectangular bodies.
+
+## Basic Example
+
+<CircuitPreview
+  defaultView="pcb"
+  hideSchematicTab
+  hide3DTab
+  code={`
+export default () => (
+  <board width="26mm" height="20mm">
+    <footprint name="U1" pcbX={0} pcbY={0}>
+      <smtpad shape="rect" width={1.2} height={2} pcbX={-4} pcbY={0} portHints={["1"]} />
+      <smtpad shape="rect" width={1.2} height={2} pcbX={4} pcbY={0} portHints={["2"]} />
+      <courtyardrect
+        pcbX={0}
+        pcbY={0}
+        width={12}
+        height={8}
+        strokeWidth={0.1}
+      />
+    </footprint>
+  </board>
+)
+`}
+/>
+
+## Dashed Courtyard Example
+
+<CircuitPreview
+  defaultView="pcb"
+  hideSchematicTab
+  hide3DTab
+  code={`
+export default () => (
+  <board width="30mm" height="24mm">
+    <footprint name="J1" pcbX={0} pcbY={0}>
+      <platedhole pcbX={-3} pcbY={0} outerDiameter={2.2} holeDiameter={1.1} />
+      <platedhole pcbX={3} pcbY={0} outerDiameter={2.2} holeDiameter={1.1} />
+      <courtyardrect
+        pcbX={0}
+        pcbY={0}
+        width={14}
+        height={10}
+        strokeWidth={0.1}
+        isStrokeDashed
+      />
+    </footprint>
+  </board>
+)
+`}
+/>

--- a/docs/elements/courtyardrect.mdx
+++ b/docs/elements/courtyardrect.mdx
@@ -18,17 +18,22 @@ Use `<courtyardrect />` to create rectangular courtyard boundaries for packages 
   code={`
 export default () => (
   <board width="26mm" height="20mm">
-    <footprint name="U1" pcbX={0} pcbY={0}>
-      <platedhole pcbX={-4} pcbY={0} outerDiameter={2.2} holeDiameter={1.1} />
-      <platedhole pcbX={4} pcbY={0} outerDiameter={2.2} holeDiameter={1.1} />
-      <courtyardrect
-        pcbX={0}
-        pcbY={0}
-        width={12}
-        height={8}
-        strokeWidth={0.1}
-      />
-    </footprint>
+    <chip
+      name="U1"
+      footprint={
+        <footprint>
+          <platedhole pcbX={-4} pcbY={0} outerDiameter={2.2} holeDiameter={1.1} />
+          <platedhole pcbX={4} pcbY={0} outerDiameter={2.2} holeDiameter={1.1} />
+          <courtyardrect
+            pcbX={0}
+            pcbY={0}
+            width={12}
+            height={8}
+            strokeWidth={0.1}
+          />
+        </footprint>
+      }
+    />
   </board>
 )
 `}
@@ -43,18 +48,23 @@ export default () => (
   code={`
 export default () => (
   <board width="30mm" height="24mm">
-    <footprint name="J1" pcbX={0} pcbY={0}>
-      <platedhole pcbX={-3} pcbY={0} outerDiameter={2.2} holeDiameter={1.1} />
-      <platedhole pcbX={3} pcbY={0} outerDiameter={2.2} holeDiameter={1.1} />
-      <courtyardrect
-        pcbX={0}
-        pcbY={0}
-        width={14}
-        height={10}
-        strokeWidth={0.1}
-        isStrokeDashed
-      />
-    </footprint>
+    <chip
+      name="J1"
+      footprint={
+        <footprint>
+          <platedhole pcbX={-3} pcbY={0} outerDiameter={2.2} holeDiameter={1.1} />
+          <platedhole pcbX={3} pcbY={0} outerDiameter={2.2} holeDiameter={1.1} />
+          <courtyardrect
+            pcbX={0}
+            pcbY={0}
+            width={14}
+            height={10}
+            strokeWidth={0.1}
+            isStrokeDashed
+          />
+        </footprint>
+      }
+    />
   </board>
 )
 `}

--- a/docs/elements/courtyardrect.mdx
+++ b/docs/elements/courtyardrect.mdx
@@ -22,8 +22,8 @@ export default () => (
       name="U1"
       footprint={
         <footprint>
-          <platedhole pcbX={-4} pcbY={0} outerDiameter={2.2} holeDiameter={1.1} />
-          <platedhole pcbX={4} pcbY={0} outerDiameter={2.2} holeDiameter={1.1} />
+          <platedhole shape="circle" pcbX={-4} pcbY={0} outerDiameter={2.2} holeDiameter={1.1} />
+          <platedhole shape="circle" pcbX={4} pcbY={0} outerDiameter={2.2} holeDiameter={1.1} />
           <courtyardrect
             pcbX={0}
             pcbY={0}
@@ -52,8 +52,8 @@ export default () => (
       name="J1"
       footprint={
         <footprint>
-          <platedhole pcbX={-3} pcbY={0} outerDiameter={2.2} holeDiameter={1.1} />
-          <platedhole pcbX={3} pcbY={0} outerDiameter={2.2} holeDiameter={1.1} />
+          <platedhole shape="circle" pcbX={-3} pcbY={0} outerDiameter={2.2} holeDiameter={1.1} />
+          <platedhole shape="circle" pcbX={3} pcbY={0} outerDiameter={2.2} holeDiameter={1.1} />
           <courtyardrect
             pcbX={0}
             pcbY={0}

--- a/docs/elements/courtyardrect.mdx
+++ b/docs/elements/courtyardrect.mdx
@@ -19,8 +19,8 @@ Use `<courtyardrect />` to create rectangular courtyard boundaries for packages 
 export default () => (
   <board width="26mm" height="20mm">
     <footprint name="U1" pcbX={0} pcbY={0}>
-      <smtpad shape="rect" width={1.2} height={2} pcbX={-4} pcbY={0} portHints={["1"]} />
-      <smtpad shape="rect" width={1.2} height={2} pcbX={4} pcbY={0} portHints={["2"]} />
+      <platedhole pcbX={-4} pcbY={0} outerDiameter={2.2} holeDiameter={1.1} />
+      <platedhole pcbX={4} pcbY={0} outerDiameter={2.2} holeDiameter={1.1} />
       <courtyardrect
         pcbX={0}
         pcbY={0}


### PR DESCRIPTION
### Motivation
- Provide user-facing documentation for the three courtyard drawing elements so footprint authors can declare clearance areas for circular, rectangular and arbitrary polygon courtyards. 
- Include runnable `CircuitPreview` examples to demonstrate common usages (outlined, filled, dashed) for each element.

### Description
- Add `docs/elements/courtyardcircle.mdx` with an overview and two `CircuitPreview` examples showing basic and filled circular courtyards and usage of props like `pcbX`, `pcbY`, `radius`, `strokeWidth`, and `isFilled`.
- Add `docs/elements/courtyardrect.mdx` with an overview and two `CircuitPreview` examples showing basic and dashed rectangular courtyards and usage of props like `width`, `height`, `strokeWidth`, and `isStrokeDashed`.
- Add `docs/elements/courtyardoutline.mdx` with an overview and two `CircuitPreview` examples showing polygon outlines (including a filled example) and usage of `points`, `strokeWidth`, and `isFilled`.

### Testing
- Ran `bunx tsc --noEmit` to typecheck the project and it completed successfully.
- Ran `bun run format` to format documentation files and the formatter completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69aa602035a0832ea7d97dcab65e80b4)