### PR TITLE
Add showCourtyards support to CircuitPreview and courtyard examples

### DIFF
--- a/docs/elements/courtyardcircle.mdx
+++ b/docs/elements/courtyardcircle.mdx
@@ -12,6 +12,7 @@ Use `<courtyardcircle />` inside a `<footprint />` to define circular courtyard 
 ## Basic Example
 
 <CircuitPreview
+  showCourtyards
   defaultView="pcb"
   hideSchematicTab
   hide3DTab
@@ -36,6 +37,7 @@ export default () => (
 ## Filled Circle Example
 
 <CircuitPreview
+  showCourtyards
   defaultView="pcb"
   hideSchematicTab
   hide3DTab

--- a/docs/elements/courtyardoutline.mdx
+++ b/docs/elements/courtyardoutline.mdx
@@ -12,6 +12,7 @@ Use `<courtyardoutline />` when your footprint needs a non-rectangular, non-circ
 ## Basic Outline Example
 
 <CircuitPreview
+  showCourtyards
   defaultView="pcb"
   hideSchematicTab
   hide3DTab
@@ -47,6 +48,7 @@ export default () => (
 ## Filled Outline Example
 
 <CircuitPreview
+  showCourtyards
   defaultView="pcb"
   hideSchematicTab
   hide3DTab

--- a/docs/elements/courtyardrect.mdx
+++ b/docs/elements/courtyardrect.mdx
@@ -12,6 +12,7 @@ Use `<courtyardrect />` to create rectangular courtyard boundaries for packages 
 ## Basic Example
 
 <CircuitPreview
+  showCourtyards
   defaultView="pcb"
   hideSchematicTab
   hide3DTab
@@ -42,6 +43,7 @@ export default () => (
 ## Dashed Courtyard Example
 
 <CircuitPreview
+  showCourtyards
   defaultView="pcb"
   hideSchematicTab
   hide3DTab

--- a/src/components/CircuitPreview.tsx
+++ b/src/components/CircuitPreview.tsx
@@ -90,6 +90,7 @@ export default function CircuitPreview({
   rightView,
   showSimulationGraph = false,
   verticalStack = false,
+  showCourtyards = false,
 }: {
   code?: string
   showTabs?: boolean
@@ -110,6 +111,7 @@ export default function CircuitPreview({
   projectBaseUrl?: string
   showSimulationGraph?: boolean
   verticalStack?: boolean
+  showCourtyards?: boolean
 }) {
   const { isDarkTheme } = useColorMode()
   const windowSize = useWindowSize()
@@ -146,7 +148,14 @@ export default function CircuitPreview({
     ? fsMap || code
     : code || Object.values(fsMap ?? {})[0]
 
-  const pcbUrl = useMemo(() => createSvgUrl(fsMapOrCode, "pcb"), [fsMapOrCode])
+  const pcbUrl = useMemo(() => {
+    const basePcbUrl = createSvgUrl(fsMapOrCode, "pcb")
+
+    if (!showCourtyards) return basePcbUrl
+
+    const separator = basePcbUrl.includes("?") ? "&" : "?"
+    return `${basePcbUrl}${separator}show_courtyards=true`
+  }, [fsMapOrCode, showCourtyards])
   console.log(fsMapOrCode)
   const schUrl = useMemo(
     () =>


### PR DESCRIPTION
### Motivation

- Enable rendering of courtyard layers in PCB previews by passing `show_courtyards=true` to `svg.tscircuit.com` from the docs preview component.

### Description

- Added a new `showCourtyards` boolean prop to `CircuitPreview` with a default of `false`.
- When `showCourtyards` is true the PCB preview URL appends `show_courtyards=true` to the `createSvgUrl` result so the remote renderer receives the flag.
- Updated the courtyard documentation examples `docs/elements/courtyardcircle.mdx`, `docs/elements/courtyardrect.mdx`, and `docs/elements/courtyardoutline.mdx` to pass `showCourtyards` to their `CircuitPreview` instances.

### Testing

- Ran TypeScript type-check: `bunx tsc --noEmit` (passed).
- Ran formatter: `bun run format` (succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69ab5c8a2474832ebf0d79cce2b20a85)