### PR TITLE
docs: add M.2 host connector footprint documentation

### DIFF
--- a/docs/footprints/footprinter-strings.mdx
+++ b/docs/footprints/footprinter-strings.mdx
@@ -429,3 +429,18 @@ Parameters:
 | `pw` | `"1.70mm"` | Pad width |
 | `p` | `"3.5mm"` | Pin pitch |
 
+## m2host
+
+M.2 host connector footprint for WiFi/Bluetooth modules and other M.2 cards.
+
+<FootprintPreview footprint="m2host" />
+
+Parameters:
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `num_pins` | `75` | Total number of pads (pins 24-31 are omitted for key) |
+| `pad_width` | `"0.35mm"` | Pad width |
+| `pad_length` | `"1.5mm"` | Pad length |
+| `pitch` | `"0.5mm"` | Pin pitch |
+


### PR DESCRIPTION
This pull request adds documentation for a new M.2 host connector footprint, including a preview and parameter table, to the `footprinter-strings.mdx` documentation.

Documentation updates:

* Added a new section describing the `m2host` M.2 host connector footprint, including a preview component and a table of parameters such as `num_pins`, `pad_width`, `pad_length`, and `pitch`.