### PR TITLE
docs: use `outline` prop in courtyardoutline examples

### DIFF
--- a/docs/elements/courtyardoutline.mdx
+++ b/docs/elements/courtyardoutline.mdx
@@ -28,7 +28,7 @@ export default () => (
           <platedhole shape="circle" pcbX={4} pcbY={-2.5} outerDiameter={2.2} holeDiameter={1.1} />
           <platedhole shape="circle" pcbX={4} pcbY={2.5} outerDiameter={2.2} holeDiameter={1.1} />
           <courtyardoutline
-            points={[
+            outline={[
               { x: -6, y: -5 },
               { x: 6, y: -5 },
               { x: 6, y: 5 },
@@ -61,7 +61,7 @@ export default () => (
         <footprint>
           <platedhole shape="circle" pcbX={0} pcbY={-3} outerDiameter={2.2} holeDiameter={1.1} />
           <courtyardoutline
-            points={[
+            outline={[
               { x: -7, y: -5 },
               { x: 7, y: -5 },
               { x: 7, y: 4 },


### PR DESCRIPTION
### Motivation
- Align the documentation examples with the expected `<courtyardoutline />` API by using the `outline` prop (a list of points) instead of `points` so examples reflect the intended prop name and reduce confusion.

### Description
- Updated `docs/elements/courtyardoutline.mdx` to replace `points` with `outline` in both the Basic Outline and Filled Outline examples.

### Testing
- Ran TypeScript checks with `bunx tsc --noEmit` which completed successfully.
- Ran formatter with `bun run format` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69ae528dafb4832e8251dce7953b499c)