### PR TITLE
docs: add tscircuit→runframe edge to upstream update diagram

### DIFF
--- a/docs/contributing/package-dependencies-and-auto-updates.mdx
+++ b/docs/contributing/package-dependencies-and-auto-updates.mdx
@@ -53,6 +53,9 @@ flowchart TD
     %% Tscircuit to web services
     tscircuit --> svg[tscircuit/svg.tscircuit.com]
     tscircuit --> usercode[tscircuit/usercode.tscircuit.com]
+
+    %% Tscircuit release also updates Runframe package
+    tscircuit --> runframe
 ```
 
 ## Workflow Implementation

--- a/docs/contributing/package-dependencies-and-auto-updates.mdx
+++ b/docs/contributing/package-dependencies-and-auto-updates.mdx
@@ -53,9 +53,7 @@ flowchart TD
     %% Tscircuit to web services
     tscircuit --> svg[tscircuit/svg.tscircuit.com]
     tscircuit --> usercode[tscircuit/usercode.tscircuit.com]
-
-    %% Tscircuit release also updates Runframe package
-    tscircuit --> runframe
+    tscircuit --> runframe[tscircuit/runframe]
 ```
 
 ## Workflow Implementation


### PR DESCRIPTION
### Motivation
- Clarify the package auto-update graph to show that a new `tscircuit` package release also triggers updates to `@tscircuit/runframe`, removing ambiguity in the dependency flow diagram.

### Description
- Skill used: none — documentation-only change, so no special skill was required.
- Updated the Mermaid diagram in `docs/contributing/package-dependencies-and-auto-updates.mdx` by adding the edge `tscircuit --> runframe` to represent the upstream release triggering an update to the Runframe package.

### Testing
- No automated tests were run because this is a documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69aeea215ac883279fe6e7f9100dc5b2)