### PR TITLE
docs: remove unused courtyardoutline props

### DIFF
--- a/docs/elements/courtyardoutline.mdx
+++ b/docs/elements/courtyardoutline.mdx
@@ -35,7 +35,6 @@ export default () => (
               { x: 0, y: 7 },
               { x: -6, y: 5 },
             ]}
-            strokeWidth={0.1}
           />
         </footprint>
       }
@@ -68,7 +67,6 @@ export default () => (
               { x: 0, y: 7 },
               { x: -7, y: 4 },
             ]}
-            isFilled
           />
         </footprint>
       }


### PR DESCRIPTION
### Motivation
- Clean up the courtyard outline documentation by removing example props that are not used by the component (`strokeWidth` and `isFilled`).

### Description
- Updated `docs/elements/courtyardoutline.mdx` to remove the unused `strokeWidth` from the basic example and `isFilled` from the filled example. 

### Testing
- Ran typecheck with `bunx tsc --noEmit` which passed and ran formatting with `bun run format` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69af2282c8f0832eaaeb098924c273b3)