### PR TITLE
docs: mention enabling kicadPcm when KiCad PCM URL is missing

### DIFF
--- a/docs/guides/kicad/using-tscircuit-kicad-pcm-urls.md
+++ b/docs/guides/kicad/using-tscircuit-kicad-pcm-urls.md
@@ -13,7 +13,7 @@ This guide walks you through the process of adding a tscircuit package to KiCad 
 
 ## Step 1: Find the KiCad PCM URL
 
-Navigate to your tscircuit package page on [tscircuit.com](https://tscircuit.com). In the **Releases** section on the right sidebar, you'll find a **KiCad PCM URL** link.
+Navigate to your tscircuit package page on [tscircuit.com](https://tscircuit.com). In the **Releases** section on the right sidebar, you'll find a **KiCad PCM URL** link. If you don't see this link, enable `kicadPcm` in your tscircuit config (see [tscircuit config](https://docs.tscircuit.com/guides/tscircuit-essentials/tscircuit-config)).
 
 ![Find the KiCad PCM URL link on the tscircuit package page](/img/guides/using-pcm-url/01-find-pcm-url-on-package-page.png)
 


### PR DESCRIPTION
### Motivation
- Make the KiCad PCM URL guide clearer by telling users what to do if the **KiCad PCM URL** link is not shown on their package page and directing them to the tscircuit config documentation.

### Description
- Updated Step 1 in `docs/guides/kicad/using-tscircuit-kicad-pcm-urls.md` to add a sentence that instructs users to enable `kicadPcm` in their tscircuit config and links to the tscircuit config docs page.

### Testing
- Ran `bun run format` and `bunx tsc --noEmit`, both completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69af71f84c10832eb8db4bc8b285e2dc)