### PR TITLE
docs: document `tsci push --compress` flag

### DIFF
--- a/docs/command-line/tsci-push.md
+++ b/docs/command-line/tsci-push.md
@@ -9,6 +9,16 @@ tscircuit code, like React code, is distributed as a "package". `tsci push` uplo
 
 After publishing, you can use the [tsci add](https://docs.tscircuit.com/command-line/tsci-add) command to install your package as part of a larger circuit.
 
+## Usage
+
+```bash
+tsci push [options]
+```
+
+## Options
+
+- `--compress` – Compresses the payload before upload. This is useful for large projects and slower connections because it reduces upload size.
+
 After running `tsci push` you can see your package on your tscircuit registry page. Packages default to private visibility, but you can change this from your registry page to enable sharing your package with the broader ecosystem.
 
 import tsciPushImage from "../../static/img/tsci-push.png"


### PR DESCRIPTION
### Motivation
- Document the new `--compress` option for `tsci push` so users know how to reduce upload size for large projects or slow connections.

### Description
- Added a `Usage` section and an `Options` subsection to `docs/command-line/tsci-push.md` and documented the `--compress` flag with its intended effect.

### Testing
- Ran `bun run format` (success) and `bunx tsc --noEmit` (success).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69b0c438c690832e824447fc5a4ec31b)