### PR TITLE
Document per-build output layout and clarify image generation flags for tsci build

### DIFF
--- a/docs/command-line/tsci-build.md
+++ b/docs/command-line/tsci-build.md
@@ -89,40 +89,6 @@ Preview target selection uses this precedence:
 2. `mainEntrypoint`
 3. The first successful build
 
-### Examples
-
-These examples show which image files each flag combination selects. Use `--preview-images` or `--all-images` to choose which build outputs receive those files.
-
-```bash
-tsci build --svgs
-```
-
-Writes `dist/<outputDir>/pcb.svg` and `dist/<outputDir>/schematic.svg` for the selected build outputs.
-
-```bash
-tsci build --pngs
-```
-
-Writes only `dist/<outputDir>/3d.png` for the selected build outputs.
-
-```bash
-tsci build --3d --pcb-only
-```
-
-Writes `dist/<outputDir>/pcb.svg` and `dist/<outputDir>/3d.png` for the selected build outputs.
-
-```bash
-tsci build --preview-images
-```
-
-Writes `dist/<outputDir>/pcb.svg`, `dist/<outputDir>/schematic.svg`, and `dist/<outputDir>/3d.png` for one selected build.
-
-```bash
-tsci build --all-images --pngs
-```
-
-Writes only `dist/<outputDir>/3d.png` for every successful build output.
-
 ## Output Directory Structure
 
 When using various build options, the output structure looks like:
@@ -131,9 +97,9 @@ When using various build options, the output structure looks like:
 dist/
 ├── my-circuit/
 │   ├── circuit.json          # Always generated for that build output
-│   ├── pcb.svg               # When SVG generation includes PCB
-│   ├── schematic.svg         # When SVG generation includes schematic
-│   ├── 3d.png                # When image generation includes 3D
+│   ├── pcb.svg               # With --preview-images/--all-images, --svgs, --pcb-svgs, etc.
+│   ├── schematic.svg         # With --preview-images/--all-images, --svgs, --schematic-svgs, etc
+│   ├── 3d.png                # With --preview-images/--all-images, --pngs, or --3d
 │   ├── 3d.glb                # With --glbs
 │   └── kicad/
 │       ├── my-circuit.kicad_sch   # With --kicad-project

--- a/docs/command-line/tsci-build.md
+++ b/docs/command-line/tsci-build.md
@@ -15,7 +15,14 @@ tsci build [file] [options]
 - `file` *(optional)* – path to a source file or directory. If omitted, the command searches for a project entrypoint such as `index.tsx` or the `mainEntrypoint` defined in `tscircuit.config.json`. In addition, all files matching the `*.circuit.tsx` pattern are built automatically.
 
 ### Output
-Output files are placed in a `dist/` directory relative to your project. The main entrypoint produces `dist/circuit.json`. Each `*.circuit.tsx` file generates its own subdirectory. For example, `src/blink.circuit.tsx` becomes `dist/src/blink/circuit.json`.
+Output files are placed in a `dist/` directory relative to your project. Each successful build writes to its own output directory:
+
+- `dist/<outputDir>/circuit.json`
+- `dist/<outputDir>/pcb.svg`
+- `dist/<outputDir>/schematic.svg`
+- `dist/<outputDir>/3d.png`
+
+For example, `src/blink.circuit.tsx` becomes `dist/src/blink/circuit.json`.
 
 ### Options
 
@@ -33,8 +40,15 @@ Output files are placed in a `dist/` directory relative to your project. The mai
 #### Output Formats
 
 ##### Images & 3D Models
-- `--preview-images` – generate preview images (PCB SVG, schematic SVG, 3D PNG) for the preview entrypoint.
-- `--all-images` – generate preview images for every successful build output.
+- `--preview-images` – generate images for one selected build output.
+- `--all-images` – generate images for every successful build output.
+- `--pngs` – Generate PNG outputs during build generation`.
+- `--svgs` – generate both `pcb.svg` and `schematic.svg`.
+- `--pcb-svgs` – generate only `pcb.svg`.
+- `--schematic-svgs` – generate only `schematic.svg`.
+- `--3d` – include `3d.png` while keeping the default SVG behavior.
+- `--pcb-only` – generate only `pcb.svg` from the selected SVG outputs.
+- `--schematic-only` – generate only `schematic.svg` from the selected SVG outputs.
 - `--preview-gltf` – generate a GLTF file from the preview entrypoint.
 - `--glbs` – generate GLB 3D model files for every successful build output.
 
@@ -54,6 +68,61 @@ Output files are placed in a `dist/` directory relative to your project. The mai
 
 Use this command before publishing or in CI to ensure your circuits evaluate correctly.
 
+## Image generation behavior
+
+`--preview-images` and `--all-images` choose which build outputs receive images:
+
+- `--preview-images` writes image files for one selected build.
+- `--all-images` writes image files for every successful build.
+
+The image selection flags choose which files are written for each selected build:
+
+- If you do not pass any image selection flags, the default image set is `pcb.svg`, `schematic.svg`, and `3d.png`.
+- If you pass any image selection flags, those flags explicitly control which files are written.
+- `--pcb-only` and `--schematic-only` filter SVG outputs.
+- `--3d` can be combined with the newer flags and adds `3d.png`.
+- Use the image selection flags with either `--preview-images` or `--all-images`.
+
+Preview target selection uses this precedence:
+
+1. `previewComponentPath`
+2. `mainEntrypoint`
+3. The first successful build
+
+### Examples
+
+These examples show which image files each flag combination selects. Use `--preview-images` or `--all-images` to choose which build outputs receive those files.
+
+```bash
+tsci build --svgs
+```
+
+Writes `dist/<outputDir>/pcb.svg` and `dist/<outputDir>/schematic.svg` for the selected build outputs.
+
+```bash
+tsci build --pngs
+```
+
+Writes only `dist/<outputDir>/3d.png` for the selected build outputs.
+
+```bash
+tsci build --3d --pcb-only
+```
+
+Writes `dist/<outputDir>/pcb.svg` and `dist/<outputDir>/3d.png` for the selected build outputs.
+
+```bash
+tsci build --preview-images
+```
+
+Writes `dist/<outputDir>/pcb.svg`, `dist/<outputDir>/schematic.svg`, and `dist/<outputDir>/3d.png` for one selected build.
+
+```bash
+tsci build --all-images --pngs
+```
+
+Writes only `dist/<outputDir>/3d.png` for every successful build output.
+
 ## Output Directory Structure
 
 When using various build options, the output structure looks like:
@@ -61,10 +130,10 @@ When using various build options, the output structure looks like:
 ```text
 dist/
 ├── my-circuit/
-│   ├── circuit.json          # Always generated
-│   ├── pcb.svg               # With --preview-images or --all-images
-│   ├── schematic.svg         # With --preview-images or --all-images
-│   ├── 3d.png                # With --preview-images or --all-images
+│   ├── circuit.json          # Always generated for that build output
+│   ├── pcb.svg               # When SVG generation includes PCB
+│   ├── schematic.svg         # When SVG generation includes schematic
+│   ├── 3d.png                # When image generation includes 3D
 │   ├── 3d.glb                # With --glbs
 │   └── kicad/
 │       ├── my-circuit.kicad_sch   # With --kicad-project

--- a/docs/guides/running-tscircuit/building-static-sites-with-tsci.mdx
+++ b/docs/guides/running-tscircuit/building-static-sites-with-tsci.mdx
@@ -24,7 +24,7 @@ Run the build command from the root of your project:
 npx tsci build --site
 ```
 
-The CLI resolves your entrypoint, evaluates every circuit, and then writes a static site to `dist/site/` alongside the usual `dist/circuit.json` outputs. The generated folder contains:
+The CLI resolves your entrypoint, evaluates every circuit, and then writes a static site to `dist/site/` alongside the usual `dist/<outputDir>/circuit.json` outputs. The generated folder contains:
 
 - `index.html` – a ready-to-host viewer.
 - `lib/…/circuit.json` – one JSON file per design so the viewer can lazy load each project.
@@ -65,4 +65,3 @@ Because the output is plain HTML/JS/CSS, you can host it almost anywhere:
 - **S3/CloudFront or static buckets** – upload the generated files with `aws s3 sync dist s3://your-bucket`.
 
 Once deployed, the site stays fast and inexpensive to serve because no server-side rendering or API proxy is required—the viewer fetches the prebuilt `circuit.json` files directly from storage.
-

--- a/docs/guides/running-tscircuit/building-static-sites-with-tsci.mdx
+++ b/docs/guides/running-tscircuit/building-static-sites-with-tsci.mdx
@@ -24,7 +24,7 @@ Run the build command from the root of your project:
 npx tsci build --site
 ```
 
-The CLI resolves your entrypoint, evaluates every circuit, and then writes a static site to `dist/site/` alongside the usual `dist/<outputDir>/circuit.json` outputs. The generated folder contains:
+The CLI resolves your entrypoint, evaluates every circuit, and then writes a static site to `dist/site/` alongside the usual `dist/circuit.json` outputs. The generated folder contains:
 
 - `index.html` – a ready-to-host viewer.
 - `lib/…/circuit.json` – one JSON file per design so the viewer can lazy load each project.


### PR DESCRIPTION

This PR updates the `tsci build` docs to reflect the current output structure and image generation behavior.

It:

* clarifies that each build writes to its own `dist/<outputDir>/` directory
* documents generated artifacts like `circuit.json`, `pcb.svg`, `schematic.svg`, and `3d.png`
* explains how `--preview-images`, `--all-images`, and the newer image selection flags interact
* adds concrete examples for common image generation combinations
* updates the static site guide to reference `dist/<outputDir>/circuit.json`

This should make the build outputs easier to understand and reduce confusion around image flag behavior.
