### PR TITLE
Incorrect mention of autoupdate `circuit-json-to-gltf` to `runframe`

### DIFF
--- a/docs/contributing/package-dependencies-and-auto-updates.mdx
+++ b/docs/contributing/package-dependencies-and-auto-updates.mdx
@@ -32,9 +32,6 @@ flowchart TD
     %% Circuit JSON to Gerber to Runframe
     circuitjsontogerber[circuit-json-to-gerber] --> runframe
 
-    %% Circuit JSON to GLTF to Runframe
-    circuitjsontogltf[circuit-json-to-gltf] --> runframe
-
     %% Circuit JSON to KiCad to Runframe
     circuitjsontokicad[circuit-json-to-kicad] --> runframe
 


### PR DESCRIPTION
Removed the Circuit JSON to GLTF to Runframe section, as there is no autoupdate of this package in runframe and no mention of `circuit-json-to-gltf` dependency in it's package.json (It is being used from the `tscircuit`)