### PR TITLE
docs: add document {NAME}, {REF}, and {REFERENCE} substitution in <symbol />

### DIFF
--- a/docs/elements/symbol.mdx
+++ b/docs/elements/symbol.mdx
@@ -118,6 +118,78 @@ export default () => (
 )
 `} />
 
+## Reference Designator Substitution
+
+You can use `{NAME}`, `{REF}`, or `{REFERENCE}` in the `text` property of a `<schematictext />` element. When the schematic is rendered, these variables are automatically replaced with the name (reference designator) of the component it belongs to.
+
+This is particularly useful when creating custom symbols for components like chips.
+
+<CircuitPreview
+  hide3DTab
+  hidePCBTab
+  defaultView="schematic"
+  code={`
+export default () => (
+  <board width="20mm" height="20mm">
+    <chip
+      name="U1"
+      pcbX={0}
+      pcbY={0}
+      symbol={
+        <symbol>
+          <schematictext schX={0} schY={1} text="{NAME}" fontSize={0.2} />
+          <schematicline
+            x1={-0.5}
+            y1={-0.7}
+            x2={-0.5}
+            y2={0.7}
+            strokeWidth={0.05}
+          />
+          <schematicline
+            x1={-0.5}
+            y1={0.7}
+            x2={0.7}
+            y2={0}
+            strokeWidth={0.05}
+          />
+          <schematicline
+            x1={0.7}
+            y1={0}
+            x2={-0.5}
+            y2={-0.7}
+            strokeWidth={0.05}
+          />
+          <schematictext schX={-0.35} schY={0.35} text="+" fontSize={0.3} />
+          <schematictext schX={-0.35} schY={-0.35} text="-" fontSize={0.3} />
+          <port
+            name="IN_POS"
+            schX={-1}
+            schY={0.35}
+            direction="left"
+            schStemLength={0.5}
+          />
+          <port
+            name="IN_NEG"
+            schX={-1}
+            schY={-0.35}
+            direction="left"
+            schStemLength={0.5}
+          />
+          <port
+            name="OUT"
+            schX={1.2}
+            schY={0}
+            direction="right"
+            schStemLength={0.5}
+          />
+        </symbol>
+      }
+    />
+  </board>
+)
+  `}
+/>
+
 ## Available Schematic Drawing Components
 
 Within a `<symbol />`, you can use the following primitive components to draw your custom schematic representation:


### PR DESCRIPTION
Preview :https://docs-jb5qlihpy-tscircuit.vercel.app/elements/symbol

<img width="944" height="848" alt="Screenshot_2026-03-18_10-35-26" src="https://github.com/user-attachments/assets/d3147120-79bd-4681-a934-0b3e006ec451" />
