### PR TITLE
docs: Add Reference Designator (RefDes) to <footprint />

### DIFF
--- a/docs/elements/footprint.mdx
+++ b/docs/elements/footprint.mdx
@@ -92,3 +92,93 @@ export default () => (
   </board>
 )
 `} />
+
+
+## Reference Designator 
+
+You can use `{NAME}`, `{REF}`, or `{REFERENCE}` in the `text` property of a [`<silkscreentext />`](../footprints/silkscreentext.mdx) element within a footprint. When the PCB is rendered, these variables are automatically replaced with the name (reference designator) of the component.
+
+This is the standard way to label components on the silkscreen layer.
+
+<CircuitPreview
+  hideSchematicTab
+  defaultView="pcb"
+  code={`
+export default () => (
+  <board width="30mm" height="30mm">
+    <chip
+      name="U1"
+      pcbX={0}
+      pcbY={0}
+      footprint={
+        <footprint>
+          <silkscreentext
+            text="{NAME}"
+            pcbX={0}
+            pcbY={4}
+            fontSize="1mm"
+          />
+           <platedhole
+            portHints={["4"]}
+            pcbX="3.2499299999998357mm"
+            pcbY="-2.249932000000058mm"
+            outerDiameter="1.9999959999999999mm"
+            holeDiameter="1.3000228mm"
+            shape="circle"
+          />
+          <platedhole
+            portHints={["2"]}
+            pcbX="3.2499299999998357mm"
+            pcbY="2.249932000000058mm"
+            outerDiameter="1.9999959999999999mm"
+            holeDiameter="1.3000228mm"
+            shape="circle"
+          />
+          <platedhole
+            portHints={["1"]}
+            pcbX="-3.2499299999999494mm"
+            pcbY="2.249932000000058mm"
+            outerDiameter="1.9999959999999999mm"
+            holeDiameter="1.3000228mm"
+            shape="circle"
+          />
+          <platedhole
+            portHints={["3"]}
+            pcbX="-3.2499299999999494mm"
+            pcbY="-2.249932000000058mm"
+            outerDiameter="1.9999959999999999mm"
+            holeDiameter="1.3000228mm"
+            shape="circle"
+          />
+          <silkscreenpath
+            route={[
+              { x: -2.2743160000001126, y: -2.999994000000015 },
+              { x: 2.274315999999999, y: -2.999994000000015 },
+            ]}
+          />
+          <silkscreenpath
+            route={[
+              { x: -2.999994000000129, y: 1.0999978000000965 },
+              { x: -2.999994000000129, y: -0.999998000000005 },
+            ]}
+          />
+          <silkscreenpath
+            route={[
+              { x: 3.0999937999998792, y: 1.0279888000000028 },
+              { x: 3.0999937999998792, y: -1.0999977999999828 },
+            ]}
+          />
+          <silkscreenpath
+            route={[
+              { x: -1.99999600000001, y: 2.999994000000015 },
+              { x: 2.274315999999999, y: 2.999994000000015 },
+            ]}
+          />
+          
+            </footprint>
+      }
+    />
+  </board>
+)
+  `}
+/>


### PR DESCRIPTION
Note: The 3D camera angle looks wrong and makes the viewer look weird.
preview: https://docs-ept9wmppa-tscircuit.vercel.app/elements/footprint

<img width="948" height="850" alt="Screenshot_2026-03-19_06-11-56" src="https://github.com/user-attachments/assets/99c89ac9-ddca-4f16-ad41-d1595891565c" />
<img width="960" height="860" alt="Screenshot_2026-03-19_06-11-44" src="https://github.com/user-attachments/assets/0467703c-1b65-4be5-8030-ccf3eb61f21b" />
