### PR TITLE
docs: add anchor alignment examples for <courtyardoutline />

### DIFF
--- a/docs/elements/courtyardoutline.mdx
+++ b/docs/elements/courtyardoutline.mdx
@@ -108,35 +108,3 @@ export default () => {
 }
 `}
 />
-
-## Filled Outline Example
-
-<CircuitPreview
-  showCourtyards
-  defaultView="pcb"
-  hideSchematicTab
-  hide3DTab
-  code={`
-export default () => (
-  <board width="28mm" height="22mm">
-    <chip
-      name="ANT1"
-      footprint={
-        <footprint>
-          <platedhole shape="circle" pcbX={0} pcbY={-3} outerDiameter={2.2} holeDiameter={1.1} />
-          <courtyardoutline
-            outline={[
-              { x: -7, y: -5 },
-              { x: 7, y: -5 },
-              { x: 7, y: 4 },
-              { x: 0, y: 7 },
-              { x: -7, y: 4 },
-            ]}
-          />
-        </footprint>
-      }
-    />
-  </board>
-)
-`}
-/>

--- a/docs/elements/courtyardoutline.mdx
+++ b/docs/elements/courtyardoutline.mdx
@@ -44,6 +44,71 @@ export default () => (
 `}
 />
 
+## Anchor Alignment Examples
+
+`<courtyardoutline />` draws the polygon you provide in footprint coordinates.
+To make the footprint origin act like a specific anchor (center, top-left,
+bottom-right, etc.), translate the outline points accordingly.
+
+<CircuitPreview
+  showCourtyards
+  defaultView="pcb"
+  hideSchematicTab
+  hide3DTab
+  code={`
+export default () => {
+  const W = 10
+  const H = 6
+
+  const rect = [
+    { x: 0, y: 0 },
+    { x: W, y: 0 },
+    { x: W, y: H },
+    { x: 0, y: H },
+  ]
+
+  const translate = (outline, dx, dy) =>
+    outline.map((p) => ({ x: p.x + dx, y: p.y + dy }))
+
+  return (
+    <board width="70mm" height="26mm">
+      <chip
+        name="CENTER"
+        pcbX={-20}
+        footprint={
+          <footprint>
+            <platedhole shape="circle" pcbX={0} pcbY={0} outerDiameter={1.6} holeDiameter={0.8} />
+            <courtyardoutline outline={translate(rect, -W / 2, -H / 2)} />
+          </footprint>
+        }
+      />
+
+      <chip
+        name="TOP_LEFT"
+        footprint={
+          <footprint>
+            <platedhole shape="circle" pcbX={0} pcbY={0} outerDiameter={1.6} holeDiameter={0.8} />
+            <courtyardoutline outline={translate(rect, 0, -H)} />
+          </footprint>
+        }
+      />
+
+      <chip
+        name="BOTTOM_RIGHT"
+        pcbX={30}
+        footprint={
+          <footprint>
+            <platedhole shape="circle" pcbX={0} pcbY={0} outerDiameter={1.6} holeDiameter={0.8} />
+            <courtyardoutline outline={translate(rect, -W, 0)} />
+          </footprint>
+        }
+      />
+    </board>
+  )
+}
+`}
+/>
+
 ## Filled Outline Example
 
 <CircuitPreview


### PR DESCRIPTION
This pull request adds new documentation to demonstrate how to align the anchor point of a `<courtyardoutline />` polygon in footprint coordinates. The update provides practical code examples for aligning the outline to different anchor positions (center, top-left, bottom-right).

Documentation improvements:

* Added an "Anchor Alignment Examples" section to `courtyardoutline.mdx`, including code and visual examples showing how to translate outline points to achieve different anchor alignments for the `<courtyardoutline />` component.

/fix #498 