### PR TITLE
This PR updates the CLI docs to cover several `tsci` options that were missing or incomplete across the command reference pages.

### DIFF
--- a/docs/command-line/tsci-build.md
+++ b/docs/command-line/tsci-build.md
@@ -38,6 +38,7 @@ For example, `src/blink.circuit.tsx` becomes `dist/src/blink/circuit.json`.
 #### Build Control
 - `--ci` – run install and optional prebuild/build commands (or default CI build).
 - `--disable-pcb` – disable PCB outputs.
+- `--routing-disabled` – disable routing during circuit generation.
 - `--disable-parts-engine` – disable the parts engine.
 - `--concurrency <number>` – number of files to build in parallel (default: 1).
 
@@ -46,18 +47,22 @@ For example, `src/blink.circuit.tsx` becomes `dist/src/blink/circuit.json`.
 ##### Images & 3D Models
 - `--preview-images` – generate images for one selected build output.
 - `--all-images` – generate images for every successful build output.
-- `--pngs` – Generate PNG outputs during build generation`.
+- `--pngs` – generate PNG outputs during build generation.
+- `--pcb-png` – generate PCB PNG outputs during build generation.
 - `--svgs` – generate both `pcb.svg` and `schematic.svg`.
 - `--pcb-svgs` – generate only `pcb.svg`.
 - `--schematic-svgs` – generate only `schematic.svg`.
-- `--3d` – include `3d.png` while keeping the default SVG behavior.
+- `--3d-png` – generate `3d.png`.
+- `--3d` – alias for `--3d-png`.
 - `--pcb-only` – generate only `pcb.svg` from the selected SVG outputs.
 - `--schematic-only` – generate only `schematic.svg` from the selected SVG outputs.
 - `--preview-gltf` – generate a GLTF file from the preview entrypoint.
 - `--glbs` – generate GLB 3D model files for every successful build output.
+- `--show-courtyards` – show courtyard outlines in PCB SVG outputs.
 
 ##### KiCad Export
 - `--kicad-project` – generate KiCad project directories (`.kicad_sch`, `.kicad_pcb`, `.kicad_pro`) for each successful build output.
+- `--kicad-project-zip` – generate a zipped KiCad project for each successful build output.
 - `--kicad-library` – generate KiCad symbol/footprint library in `dist/kicad-library`.
 - `--kicad-library-name <name>` – specify the name of the KiCad library.
 - `--kicad-pcm` – generate KiCad PCM (Plugin and Content Manager) assets in `dist/pcm`.
@@ -69,6 +74,10 @@ For example, `src/blink.circuit.tsx` becomes `dist/src/blink/circuit.json`.
 - `--transpile` – transpile the entry file to JavaScript for use as a library.
 - `--site` – generate a static site in the dist directory.
 - `--use-cdn-javascript` – use CDN-hosted JavaScript instead of bundled standalone file for `--site`.
+
+##### Injecting Props
+- `--inject-props <json>` – inject JSON props into the built file's default export.
+- `--inject-props-file <path>` – load injected props JSON from a file.
 
 ### Targeting specific sources
 - `tsci build path/to/file.circuit.tsx` – builds the given file, even if it does not match the `includeBoardFiles` glob in `tscircuit.config.json`.

--- a/docs/command-line/tsci-export.md
+++ b/docs/command-line/tsci-export.md
@@ -29,6 +29,7 @@ tsci export <file> [options]
 - `-f, --format <format>`: Output format (defaults to "json")
 - `-o, --output <path>`: Custom output file path
 - `--disable-parts-engine`: Disable the parts engine during circuit evaluation
+- `--show-courtyards`: Show courtyard outlines in PCB SVG output
 
 ## Supported Formats
 
@@ -66,6 +67,12 @@ tsci export circuit.tsx -f schematic-svg
 Export PCB layout with custom output path:
 ```bash
 tsci export circuit.tsx -f pcb-svg -o my-pcb-layout.svg
+```
+
+Export PCB SVG with courtyard outlines:
+
+```bash
+tsci export circuit.tsx -f pcb-svg --show-courtyards
 ```
 
 Export to Specctra DSN format:

--- a/docs/command-line/tsci-snapshot.md
+++ b/docs/command-line/tsci-snapshot.md
@@ -18,6 +18,11 @@ tsci snapshot [options] [path]
 - `--pcb-only` – generate only PCB snapshots.
 - `--schematic-only` – generate only schematic snapshots.
 - `--disable-parts-engine` – disable the parts engine while rendering snapshots.
+- `--show-courtyards` – show courtyard outlines in PCB snapshots.
+- `--camera-preset <preset>` – choose the camera angle preset for 3D snapshots. This also implies `--3d`.
+- `--ci` – enable CI mode and generate diff artifacts.
+- `--test` – enable test mode and generate diff artifacts.
+- `--concurrency <number>` – number of files to snapshot in parallel (default: `1`).
 
 ### Arguments
 - `[path]` – optional file path, directory, or glob pattern used to limit what gets snapshotted.


### PR DESCRIPTION
## Summary

This PR updates the CLI docs to cover several `tsci` options that were missing or incomplete across the command reference pages.

## What changed

- added missing `tsci build` flags, including:
  - `--routing-disabled`
  - `--pcb-png`
  - `--3d-png` and clarified `--3d` as its alias
  - `--show-courtyards`
  - `--kicad-project-zip`
  - `--inject-props`
  - `--inject-props-file`
- fixed and normalized some existing `tsci build` option descriptions
- documented `--show-courtyards` for `tsci export`
- added an example for exporting PCB SVGs with courtyard outlines
- documented additional `tsci snapshot` flags, including:
  - `--show-courtyards`
  - `--camera-preset`
  - `--ci`
  - `--test`
  - `--concurrency`

## Why

The command reference was missing several supported flags, which made the docs incomplete and harder to trust when using the CLI. This PR brings the docs closer to the actual interface and makes less-common but useful options easier to discover.

## Scope

Documentation only. No runtime or algorithmic changes.
