### PR TITLE
docs: add tip linking to electronics-ideas/IDEAS.txt for project ideas

### DIFF
--- a/docs/contributing/getting-started-as-a-contributor.md
+++ b/docs/contributing/getting-started-as-a-contributor.md
@@ -48,6 +48,12 @@ Look around your desk or home for small electronic devices and recreate one as a
 - a digital weighing scale
 - a smart lock
 
+:::tip Need an idea?
+
+Try picking a random idea from [electronics-ideas/IDEAS.txt](https://github.com/tscircuit/electronics-ideas/blob/main/IDEAS.txt).
+
+:::
+
 This "practice being a user" approach quickly reveals high-impact improvements.
 
 ## Recommended Contribution Order


### PR DESCRIPTION
### Motivation

- Make it easier for contributors to find project ideas by surfacing the `electronics-ideas/IDEAS.txt` list in the getting-started guide.

### Description

- Add a tip block to `docs/contributing/getting-started-as-a-contributor.md` that links to `https://github.com/tscircuit/electronics-ideas/blob/main/IDEAS.txt` as a quick source of ideas.

### Testing

- No automated tests were required or run for this documentation-only change; CI was not impacted.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69d32d2cbb80832e919bfdebce1ac9e4)