### PR TITLE
Fix docs copy button title overlap

### DIFF
--- a/src/theme/DocItem/Layout/styles.module.css
+++ b/src/theme/DocItem/Layout/styles.module.css
@@ -18,7 +18,7 @@
   right: 0;
 }
 
-.docItemWithButton :global(.markdown) > :global(h1):first-child {
+.docItemWithButton :global(.markdown) > :global(h1):first-of-type {
   padding-right: 180px;
 }
 
@@ -32,7 +32,7 @@
     position: relative;
   }
 
-  .docItemWithButton :global(.markdown) > :global(h1):first-child {
+  .docItemWithButton :global(.markdown) > :global(h1):first-of-type {
     padding-right: 0;
     margin-bottom: 0.75rem;
   }


### PR DESCRIPTION
## Summary
- Fixes the docs copy-page button overlapping long page titles.
- Uses the first `h1` element instead of `:first-child`, because the copy-button header is injected before the title.

## Test plan
- `npx biome format src/theme/DocItem/Layout/styles.module.css`
- `npm run typecheck`
- `npm run build`

Fixes tscircuit/tscircuit.com#3179