### PR TITLE
fix: remove negative margin-top from copy-page-button-container

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -1109,7 +1109,7 @@ article,
   position: relative;
   display: inline-block;
   margin-right: 2rem;
-  margin-top: -2.8rem;
+  margin-top: 0;
 }
 
 .copy-page-button-wrapper {


### PR DESCRIPTION
Fixes #3179 - Copy page button overlapping with title on docs.tscircuit.com

## Root Cause
The `.copy-page-button-container` had `margin-top: -2.8rem` which pulled the button upward, causing it to overlap with the page title.

## Fix
Changed `margin-top` from `-2.8rem` to `0`, placing the button in its natural flow position below the title.

## Testing
- [x] Visual inspection confirms button now sits below the title instead of overlapping it