### PR TITLE
Fix blank preview in keyboard tutorial

### DIFF
--- a/docs/tutorials/build-a-custom-keyboard-with-tscircuit.mdx
+++ b/docs/tutorials/build-a-custom-keyboard-with-tscircuit.mdx
@@ -314,7 +314,7 @@ const rowPins = ["net.ROW0", "net.ROW1", "net.ROW2", "net.ROW3", "net.ROW4"];
 const colPins = ["net.COL0", "net.COL1", "net.COL2", "net.COL3", "net.COL4", "net.COL5", "net.COL6", "net.COL7", "net.COL8", "net.COL9", "net.COL10", "net.COL11", "net.COL12", "net.COL13", "net.COL14"];
 
 export default () => (
-  <board>
+  <board routingDisabled>
     {/* Place the Pico */}
     <PICO
       name="U1"


### PR DESCRIPTION
This pr fixes the blank preview in the Building a Keyboard with tscircuit tutorial by disabling routing for the final 60% keyboard example.

The smaller 4-key keyboard preview can render with routing enabled, but the 60% layout creates a much larger matrix and can fail or time out during embedded preview rendering. The overview example on the same page already uses `routingDisabled`; this makes the final example consistent with it.

Tested locally.


### Before -

<img width="1437" height="807" alt="Screenshot 2026-05-10 at 9 54 56 AM" src="https://github.com/user-attachments/assets/0cd6a887-b743-48d7-8ecd-1cc3a4759010" />


### After -

<img width="1437" height="807" alt="Screenshot 2026-05-10 at 9 55 48 AM" src="https://github.com/user-attachments/assets/7a26e04e-9b2e-41be-bd28-75afccb7b185" />



