### PR TITLE
Fix broken Playground link in LED Matrix tutorial

### DIFF
--- a/docs/tutorials/building-led-matrix.mdx
+++ b/docs/tutorials/building-led-matrix.mdx
@@ -745,7 +745,7 @@ export default () => {
 `} />
 
 
-Check out this circuit in our [Playground](https://tscircuit.com/editor?snippet_id=e30ad928-3432-49a4-826c-f50cae1490ef).
+Check out this circuit in our [Playground](https://tscircuit.com/editor?package_id=e30ad928-3432-49a4-826c-f50cae1490ef).
 
 ## Ordering the PCB
 


### PR DESCRIPTION
This pr fixes the broken Playground link in the 3x5 LED Matrix tutorial. The old link used `snippet_id`, which opened the default blank editor. The editor now expects `package_id` for package links, so this updates the URL to load the actual LED matrix package.


Tested locally.
