### PR TITLE
Hide empty schematic tabs for PCB-only examples

### DIFF
--- a/docs/building-electronics/what-are-electronics-made-of.mdx
+++ b/docs/building-electronics/what-are-electronics-made-of.mdx
@@ -58,7 +58,7 @@ the top layer can pass to the bottom.
 <figcaption>Vias connect different layers of a PCB</figcaption> 
 </figure>
 
-<CircuitPreview defaultView="pcb" code={`
+<CircuitPreview defaultView="pcb" hideSchematicTab code={`
 
 
 export default () => (
@@ -85,7 +85,7 @@ holes. Chips with big pins that must go through holes are called "through-hole"
 chips, and chips with small
 pins are called "surface-mount" chips.
 
-<CircuitPreview defaultView="pcb" code={`
+<CircuitPreview defaultView="pcb" hideSchematicTab code={`
 
 export default () => (
   <board width="2mm" height="2mm">
@@ -109,7 +109,7 @@ Unplated holes or "regular holes" are just holes in the printed circuit board
 without any copper around them. They don't electrically connect anything, but
 can be very helpful for mounting the printed circuit board.
 
-<CircuitPreview defaultView="pcb" code={`
+<CircuitPreview defaultView="pcb" hideSchematicTab code={`
 
 export default () => (
   <board width="2mm" height="2mm">


### PR DESCRIPTION
The What are electronics made of? page shows schematic tabs for vias, plated holes, and regular holes.

These examples use physical PCB, footprint elements, so the schematic view has nothing meaningful to render when selected.

Tested locally.

### Before 

<img width="1437" height="807" alt="Screenshot 2026-05-10 at 11 43 14 AM" src="https://github.com/user-attachments/assets/6b44b218-b445-4501-af52-f577fb4e042c" />


### After 

<img width="1437" height="807" alt="Screenshot 2026-05-10 at 11 42 54 AM" src="https://github.com/user-attachments/assets/f9715f60-9c46-4b95-9d8d-6f2e48c3ac94" />
