### PR TITLE
docs: update online editor navbar link

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -179,8 +179,8 @@ const config: Config = {
         },
         { to: "https://blog.tscircuit.com", label: "Blog", position: "left" },
         {
-          to: "https://tscircuit.com",
-          label: "Use Online",
+          to: "https://tscircuit.com/editor",
+          label: "Try Online",
           position: "left",
         },
 


### PR DESCRIPTION
## Summary
- Rename the docs navbar link from "Use Online" to "Try Online"
- Point the link directly to `https://tscircuit.com/editor`

## Bounty claim
This implements the request from the archived bounty issue:
https://github.com/tscircuit/docs-old/issues/67

`/attempt #67` could not be posted because `tscircuit/docs-old` is archived/read-only and the issue is locked. This PR applies the fix in the active docs repository.

/claim #67

## Testing
- `npm run typecheck`
- `./node_modules/.bin/docusaurus build` with local verification install pinned to `webpack@5.99.9` because npm otherwise resolves `webpack@5.106.2`, which is incompatible with Docusaurus 3.8.1 progress options. The repository normally uses Bun, but Bun was unavailable in this WSL environment.
