### PR TITLE
Fix docs content centering

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -10,6 +10,7 @@
 :root {
   --ifm-font-family-base: "Google Sans", system-ui, -apple-system, sans-serif;
   --ifm-heading-font-family: "Google Sans", system-ui, -apple-system, sans-serif;
+  --doc-content-max-width: 1100px;
   --ifm-color-primary: #1877f2;
   --ifm-color-primary-dark: #166bda;
   --ifm-color-primary-darker: #1564ce;
@@ -746,10 +747,10 @@ body {
   line-height: 1.2;
   text-align: left;
   white-space: nowrap;
-  max-width: 970px;
+  max-width: var(--doc-content-max-width);
   margin-left: auto;
   margin-right: auto;
-  padding-left: 4rem;
+  padding-left: 5rem;
   padding-right: 2rem;
   box-sizing: border-box;
 }
@@ -853,7 +854,7 @@ article h4 {
 
 /* Force center all documentation content */
 .col:not(.col--3) {
-  max-width: 1000px !important;
+  max-width: var(--doc-content-max-width) !important;
   margin-left: auto !important;
   margin-right: auto !important;
 }
@@ -898,10 +899,10 @@ article h4 {
       div,
       article
     )[class*="generatedIndexPage"] {
-    max-width: 1000px !important;
+    max-width: var(--doc-content-max-width) !important;
     margin-left: auto !important;
     margin-right: auto !important;
-    width: 1000px !important;
+    width: var(--doc-content-max-width) !important;
   }
 }
 

--- a/src/theme/DocItem/Layout/index.tsx
+++ b/src/theme/DocItem/Layout/index.tsx
@@ -1,13 +1,11 @@
 import React, { type ReactNode } from "react"
 import clsx from "clsx"
-import { useWindowSize } from "@docusaurus/theme-common"
 import { useDoc } from "@docusaurus/plugin-content-docs/client"
 import DocItemPaginator from "@theme/DocItem/Paginator"
 import DocVersionBanner from "@theme/DocVersionBanner"
 import DocVersionBadge from "@theme/DocVersionBadge"
 import DocItemFooter from "@theme/DocItem/Footer"
 import DocItemTOCMobile from "@theme/DocItem/TOC/Mobile"
-import DocItemTOCDesktop from "@theme/DocItem/TOC/Desktop"
 import DocItemContent from "@theme/DocItem/Content"
 import DocBreadcrumbs from "@theme/DocBreadcrumbs"
 import ContentVisibility from "@theme/ContentVisibility"
@@ -21,22 +19,15 @@ import styles from "./styles.module.css"
  */
 function useDocTOC() {
   const { frontMatter, toc } = useDoc()
-  const windowSize = useWindowSize()
 
   const hidden = frontMatter.hide_table_of_contents
   const canRender = !hidden && toc.length > 0
 
   const mobile = canRender ? <DocItemTOCMobile /> : undefined
 
-  const desktop =
-    canRender && (windowSize === "desktop" || windowSize === "ssr") ? (
-      <DocItemTOCDesktop />
-    ) : undefined
-
   return {
     hidden,
     mobile,
-    desktop,
   }
 }
 
@@ -44,8 +35,8 @@ export default function DocItemLayout({ children }: Props): ReactNode {
   const docTOC = useDocTOC()
   const { metadata } = useDoc()
   return (
-    <div className="row">
-      <div className={clsx("col", !docTOC.hidden && styles.docItemCol)}>
+    <div className={clsx("row", styles.docItemRow)}>
+      <div className={clsx("col", styles.docItemCol)}>
         <ContentVisibility metadata={metadata} />
         <DocVersionBanner />
         <div className={styles.docItemContainer}>
@@ -66,7 +57,6 @@ export default function DocItemLayout({ children }: Props): ReactNode {
           <DocItemPaginator />
         </div>
       </div>
-      {docTOC.desktop && <div className="col col--3">{docTOC.desktop}</div>}
     </div>
   )
 }

--- a/src/theme/DocItem/Layout/styles.module.css
+++ b/src/theme/DocItem/Layout/styles.module.css
@@ -1,3 +1,18 @@
+.docItemRow {
+  justify-content: center;
+}
+
+.docItemCol {
+  flex: 0 1 var(--doc-content-max-width);
+  max-width: var(--doc-content-max-width) !important;
+  min-width: 0;
+  width: 100%;
+}
+
+.docItemContainer {
+  width: 100%;
+}
+
 .docItemContainer header + *,
 .docItemContainer article > *:first-child {
   margin-top: 0;
@@ -35,11 +50,5 @@
   .docItemWithButton :global(.markdown) > :global(h1):first-child {
     padding-right: 0;
     margin-bottom: 0.75rem;
-  }
-}
-
-@media (min-width: 997px) {
-  .docItemCol {
-    max-width: 75% !important;
   }
 }


### PR DESCRIPTION
## Summary
- Center docs pages through the `DocItemLayout` row/column instead of relying on the hidden desktop TOC column.
- Add a shared `--doc-content-max-width` value and reuse it for standard docs and generated index pages.
- Keep the section label aligned with the page title at the wider content width.

/claim tscircuit/docs-old#64

Note: I tried to comment `/attempt #64`, but `tscircuit/docs-old` is archived/read-only and GitHub rejected the comment because the issue is locked.

## Verification
- `bunx @biomejs/biome format src/theme/DocItem/Layout/index.tsx src/theme/DocItem/Layout/styles.module.css src/css/custom.css --write`
- `bun run typecheck`
- `bun run build`
- `git diff --check`
- Desktop screenshot: `bunx playwright screenshot --browser=chromium --viewport-size=1440,900 --wait-for-timeout=3000 http://127.0.0.1:3123/intro/installation /private/tmp/tscircuit-docs-after-install.png`
- Mobile screenshot: `bunx playwright screenshot --browser=chromium --viewport-size=390,844 --wait-for-timeout=3000 http://127.0.0.1:3123/intro/installation /private/tmp/tscircuit-docs-after-install-mobile.png`

## Risk
- This changes the docs layout wrapper, so the main visual risk is unintended width changes on uncommon generated-index or MDX-heavy pages. The max-width is centralized so follow-up tuning is one variable.