### PR TITLE
fix: change 'Use Online' to 'Try Online' and point to /editor

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -179,8 +179,8 @@ const config: Config = {
         },
         { to: "https://blog.tscircuit.com", label: "Blog", position: "left" },
         {
-          to: "https://tscircuit.com",
-          label: "Use Online",
+          to: "https://tscircuit.com/editor",
+          label: "Try Online",
           position: "left",
         },
 


### PR DESCRIPTION
## Summary

Changes the navbar link from "Use Online" → tscircuit.com to "Try Online" → tscircuit.com/editor

Fixes https://github.com/tscircuit/docs-old/issues/67

/claim tscircuit/docs-old#67