### PR TITLE
fix: override flex-grow to properly center doc content

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -853,6 +853,7 @@ article h4 {
 
 /* Force center all documentation content */
 .col:not(.col--3) {
+  flex: 0 1 auto !important;
   max-width: 1000px !important;
   margin-left: auto !important;
   margin-right: auto !important;


### PR DESCRIPTION
The `.col:not(.col--3)` rule in custom.css sets `max-width: 1000px` with `margin: auto` to center docs content, but Infima's `.col` class has `flex: 1 0` which makes the column grow to fill all available space, preventing the auto margins from actually centering.

Adding `flex: 0 1 auto !important` overrides the grow behavior so the content properly centers within the viewport, matching the Bun docs layout.

Closes tscircuit/docs-old#64
/claim tscircuit/docs-old#64