### PR TITLE
Fix docs navbar editor link

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -179,8 +179,8 @@ const config: Config = {
         },
         { to: "https://blog.tscircuit.com", label: "Blog", position: "left" },
         {
-          to: "https://tscircuit.com",
-          label: "Use Online",
+          to: "https://tscircuit.com/editor",
+          label: "Try Online",
           position: "left",
         },
 


### PR DESCRIPTION
## Summary
- rename the top navbar editor link from "Use Online" to "Try Online"
- point the link directly to https://tscircuit.com/editor

## Bounty
Fixes tscircuit/docs-old#67
/claim #67
/claim tscircuit/docs-old#67

## Verification
- npx --yes bun run typecheck
- npx --yes bun run build
- git diff --check