### PR TITLE
Remove issue wheel tip from contributor guide

### DIFF
--- a/docs/contributing/getting-started-as-a-contributor.md
+++ b/docs/contributing/getting-started-as-a-contributor.md
@@ -19,12 +19,6 @@ so make sure to install bun before you start contributing.
 
 To contribute to tscircuit, you need to make [Pull Requests](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests) from a fork of a repository.
 
-:::tip
-
-You can quickly find issues (with or without bounties) by [spinning the wheel of issues](https://issues.tscircuit.com/)
-
-:::
-
 ## Before You Start
 
 1. Make sure bun is installed on your system


### PR DESCRIPTION
### Motivation
- Remove an outdated tip that linked contributors to the external “wheel of issues” to avoid directing readers to that tool from the getting-started guide.

### Description
- Deleted the `:::tip` block that contained the “You can quickly find issues (with or without bounties) by [spinning the wheel of issues](https://issues.tscircuit.com/)” line from `docs/contributing/getting-started-as-a-contributor.md`.

### Testing
- Ran `bunx tsc --noEmit`, `bun run format`, and `git diff --check`, and all checks completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a035118b38c832ebbbdbdd388cfefbb)