### PR TITLE
Update header links

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -179,17 +179,11 @@ const config: Config = {
         },
         { to: "https://blog.tscircuit.com", label: "Blog", position: "left" },
         {
-          to: "https://tscircuit.com",
-          label: "Use Online",
+          to: "https://tscircuit.com/editor",
+          label: "Try Online",
           position: "left",
         },
 
-        {
-          href: "https://discord.com/invite/V7FGE5ZCbA",
-          position: "right",
-          className: "header-discord-link header-icon-link",
-          html: '<img src="/img/discord.svg" alt="Discord" style="height: 18px; width: 18px; margin-bottom: -4px;" class="github-icon" />',
-        },
         {
           href: "https://github.com/tscircuit/tscircuit",
           position: "right",


### PR DESCRIPTION
## Summary
- Point the header CTA to `https://tscircuit.com/editor` and relabel it from `Use Online` to `Try Online`.
- Remove the Discord/support icon-only navbar item so the top header only keeps the GitHub icon link.

Fixes tscircuit/docs-old#66
Fixes tscircuit/docs-old#67
/claim tscircuit/docs-old#66
/claim tscircuit/docs-old#67

## Review & Testing Checklist for Human
- [ ] Verify the docs header shows `Try Online` and opens the editor.
- [ ] Confirm the Discord/support icon no longer appears in the top navbar while the GitHub icon still does.
- [ ] Run the Docusaurus build or inspect the preview to confirm the navbar renders correctly.

### Notes
Tested locally:
- `bun run typecheck`
- `bun run build`