### PR TITLE
Center docs content column

### DIFF
--- a/src/theme/DocItem/Layout/styles.module.css
+++ b/src/theme/DocItem/Layout/styles.module.css
@@ -40,6 +40,8 @@
 
 @media (min-width: 997px) {
   .docItemCol {
-    max-width: 75% !important;
+    max-width: 70ch !important;
+    margin-left: auto;
+    margin-right: auto;
   }
 }


### PR DESCRIPTION
## Summary
- Narrow the desktop documentation content column to a readable `70ch` width.
- Center the doc column with automatic side margins so pages align more like the Bun docs reference.

Fixes tscircuit/docs-old#64
/claim tscircuit/docs-old#64

## Review & Testing Checklist for Human
- [ ] Compare a docs page against the issue screenshot and confirm the article column is centered on desktop.
- [ ] Check a mobile/narrow viewport to confirm the existing responsive layout is unchanged.
- [ ] Inspect the Vercel preview for pages with and without a table of contents.

### Notes
Tested locally:
- `bunx @biomejs/biome format --write src/theme/DocItem/Layout/styles.module.css`
- `bunx @biomejs/biome lint src/theme/DocItem/Layout/styles.module.css`
- `bun run typecheck`
- `bun run build`