### PR TITLE
Add edit page action to docs pages

### DIFF
--- a/src/theme/DocItem/Layout/index.tsx
+++ b/src/theme/DocItem/Layout/index.tsx
@@ -56,7 +56,19 @@ export default function DocItemLayout({ children }: Props): ReactNode {
             <div className={styles.docItemWithButton}>
               <DocItemContent>
                 <div className={styles.contentHeader}>
-                  <CopyPageButton />
+                  <div className={styles.contentHeaderActions}>
+                    {metadata.editUrl && (
+                      <a
+                        className={styles.editPageLink}
+                        href={metadata.editUrl}
+                        target="_blank"
+                        rel="noreferrer"
+                      >
+                        Edit page
+                      </a>
+                    )}
+                    <CopyPageButton />
+                  </div>
                 </div>
                 {children}
               </DocItemContent>

--- a/src/theme/DocItem/Layout/styles.module.css
+++ b/src/theme/DocItem/Layout/styles.module.css
@@ -12,14 +12,50 @@
   z-index: 10;
 }
 
-.contentHeader :global(.copy-page-button-container) {
+.contentHeaderActions {
   position: absolute;
   top: 0;
   right: 0;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.contentHeader :global(.copy-page-button-container) {
+  margin: 0;
 }
 
 .docItemWithButton :global(.markdown) > :global(h1):first-child {
-  padding-right: 180px;
+  padding-right: 260px;
+}
+
+.editPageLink {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.375rem 0.625rem;
+  border: 1px solid #e5e7eb;
+  border-radius: 0.375rem;
+  color: #374151;
+  font-size: 0.8125rem;
+  font-weight: 500;
+  line-height: 1.25rem;
+  white-space: nowrap;
+}
+
+.editPageLink:hover {
+  background-color: #f9fafb;
+  color: #111827;
+  text-decoration: none;
+}
+
+[data-theme="dark"] .editPageLink {
+  border-color: rgba(255, 255, 255, 0.12);
+  color: var(--ifm-color-emphasis-800);
+}
+
+[data-theme="dark"] .editPageLink:hover {
+  background-color: rgba(255, 255, 255, 0.07);
+  color: #f9fafb;
 }
 
 @media (max-width: 800px) {
@@ -28,8 +64,9 @@
     margin-bottom: 1rem;
   }
 
-  .contentHeader :global(.copy-page-button-container) {
+  .contentHeaderActions {
     position: relative;
+    justify-content: flex-end;
   }
 
   .docItemWithButton :global(.markdown) > :global(h1):first-child {


### PR DESCRIPTION
## Summary
- Add a visible `Edit page` action near the existing copy page controls on each doc page.
- Use Docusaurus doc metadata `editUrl` so links point directly to the GitHub source file for the current page.
- Keep the action responsive with the existing doc header layout.

Fixes tscircuit/docs-old#65
/claim tscircuit/docs-old#65

## Review & Testing Checklist for Human
- [ ] Open several docs pages and verify the `Edit page` link points to the correct GitHub source file.
- [ ] Check desktop and mobile widths to confirm the header actions do not overlap page titles.
- [ ] Inspect the Vercel preview alongside the issue request and Bun docs reference.

### Notes
Tested locally:
- `bunx @biomejs/biome format --write src/theme/DocItem/Layout/index.tsx src/theme/DocItem/Layout/styles.module.css`
- `bunx @biomejs/biome lint src/theme/DocItem/Layout/index.tsx src/theme/DocItem/Layout/styles.module.css`
- `bun run typecheck`
- `bun run build`