### PR TITLE
docs: update online editor navbar link

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -179,8 +179,8 @@ const config: Config = {
         },
         { to: "https://blog.tscircuit.com", label: "Blog", position: "left" },
         {
-          to: "https://tscircuit.com",
-          label: "Use Online",
+          to: "https://tscircuit.com/editor",
+          label: "Try Online",
           position: "left",
         },
 


### PR DESCRIPTION
## Summary
- rename the navbar online editor link from "Use Online" to "Try Online"
- point the link directly to https://tscircuit.com/editor

## Bounty context
This addresses the archived bounty issue:
https://github.com/tscircuit/docs-old/issues/67

The old docs issue repository is archived/read-only, so I could not comment `/attempt #67` there. This PR applies the change in the active docs repository.

/claim tscircuit/docs-old#67
/claim #67

## Disclosure
This PR was AI-assisted and human-reviewed before submission.

## Testing
- `bun run typecheck`
- `bun run build`
- `git diff --check`