### PR TITLE
Update Try Online navbar link

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -179,8 +179,8 @@ const config: Config = {
         },
         { to: "https://blog.tscircuit.com", label: "Blog", position: "left" },
         {
-          to: "https://tscircuit.com",
-          label: "Use Online",
+          to: "https://tscircuit.com/editor",
+          label: "Try Online",
           position: "left",
         },
 


### PR DESCRIPTION
Addresses archived bounty issue tscircuit/docs-old#67.

/claim tscircuit/docs-old#67

Changes:
- Rename the navbar link from Use Online to Try Online.
- Point it directly to https://tscircuit.com/editor.

Verification:
- Compared fork branch against upstream main; only docusaurus.config.ts changed.
- Read back docusaurus.config.ts from the branch and verified the Try Online label plus editor URL.
- Vercel status for commit cf01fb03fed81ac87c616abdd929c666e677ca0c is success.