### PR TITLE
Update Try Online navbar link

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -179,8 +179,8 @@ const config: Config = {
         },
         { to: "https://blog.tscircuit.com", label: "Blog", position: "left" },
         {
-          to: "https://tscircuit.com",
-          label: "Use Online",
+          to: "https://tscircuit.com/editor",
+          label: "Try Online",
           position: "left",
         },
 


### PR DESCRIPTION
Updates the docs navbar item from `Use Online` to `Try Online` and links it directly to the online editor at `https://tscircuit.com/editor`.

This is the active docs repository equivalent of tscircuit/docs-old#67.

/claim tscircuit/docs-old#67
