### PR TITLE
docs: add guide for using M.2 connectors with MicroMod modules

### DIFF
--- a/docs/guides/importing-modules-and-chips/using-m2-connectors-for-micromod.mdx
+++ b/docs/guides/importing-modules-and-chips/using-m2-connectors-for-micromod.mdx
@@ -12,6 +12,13 @@ In tscircuit, you model the M.2 connector as a `<chip>` component. The same comp
 - **Processor board** — the processor module exposes signals through the M.2 edge pads.
 - **Carrier board** — the carrier hosts the physical M.2 socket and routes those signals to headers, sensors, or other peripherals.
 
+## Components
+
+| Ref | Part | Description | Footprint |
+|-----|------|-------------|-----------|
+| J1 | M.2 Key E connector | 75-pin, 0.5 mm pitch | `edge_connector_75p_m2_key_e` |
+| U1 | Processor module | RP2040 / ESP32 / STM32 (varies) | Per-module stamp receiver |
+
 ## MicroMod Signal Map
 
 The MicroMod specification assigns each M.2 pin a fixed function. Odd-numbered pins are GND; even-numbered pins carry signals:

--- a/docs/guides/importing-modules-and-chips/using-m2-connectors-for-micromod.mdx
+++ b/docs/guides/importing-modules-and-chips/using-m2-connectors-for-micromod.mdx
@@ -1,0 +1,193 @@
+---
+title: Using M.2 Connectors for MicroMod Modules
+description: How to model SparkFun MicroMod M.2 Key E edge connectors in tscircuit for processor-carrier board designs.
+---
+
+## Overview
+
+SparkFun's [MicroMod](https://www.sparkfun.com/micromod) ecosystem uses the **M.2 Key E** edge connector (75 pins, 0.5 mm pitch) to create swappable processor modules. A processor board (e.g., RP2040, ESP32, STM32) plugs into any compatible carrier board via a single M.2 edge connector.
+
+In tscircuit, you model the M.2 connector as a `<chip>` component. The same component definition works on both sides:
+
+- **Processor board** — the processor module exposes signals through the M.2 edge pads.
+- **Carrier board** — the carrier hosts the physical M.2 socket and routes those signals to headers, sensors, or other peripherals.
+
+## MicroMod Signal Map
+
+The MicroMod specification assigns each M.2 pin a fixed function. Odd-numbered pins are GND; even-numbered pins carry signals:
+
+| Pin | Signal | Notes |
+|-----|--------|-------|
+| 2 | 3V3 | Regulated 3.3 V from carrier |
+| 4 | 3V3_EN | 3.3 V enable (active high) |
+| 6 | RESET | System reset (active low) |
+| 8 | BOOT | Bootloader entry |
+| 10 | USB_DM | USB D− |
+| 12 | USB_DP | USB D+ |
+| 16 | UART_TX1 | Primary UART transmit |
+| 18 | UART_RX1 | Primary UART receive |
+| 24 | I2C_SDA | Primary I²C data |
+| 26 | I2C_SCL | Primary I²C clock |
+| 34 | SPI_CS | SPI chip select |
+| 36 | SPI_SCK | SPI clock |
+| 38 | SPI_COPI | SPI controller out |
+| 40 | SPI_CIPO | SPI controller in |
+| 50 | A0 | Analog input 0 |
+| 52 | A1 | Analog input 1 |
+| 56 | PWM0 | PWM output 0 |
+| 58 | PWM1 | PWM output 1 |
+| 60 | D0 | Digital I/O 0 |
+| 62 | D1 | Digital I/O 1 |
+| 64–74 | G0–G5 | General-purpose I/O |
+
+All odd pins (1, 3, 5 … 75) are GND.
+
+## Defining the MicroMod Edge Connector
+
+Model the connector as a `<chip>` with the full 75-pin label map. Because every odd pin is GND, omit them from `schPinArrangement` to keep the schematic readable — only signal pins appear on the schematic side.
+
+import TscircuitIframe from "@site/src/components/TscircuitIframe"
+
+<TscircuitIframe defaultView="schematic" code={`
+const MicroModEdge = (props) => (
+  <chip
+    manufacturerPartNumber="MicroMod_M2_Key_E_75P"
+    footprint="edge_connector_75p_m2_key_e"
+    pinLabels={{
+      pin1: "GND",   pin2: "3V3",
+      pin3: "GND",   pin4: "3V3_EN",
+      pin5: "GND",   pin6: "RESET",
+      pin7: "GND",   pin8: "BOOT",
+      pin9: "GND",   pin10: "USB_DM",
+      pin11: "GND",  pin12: "USB_DP",
+      pin13: "GND",  pin14: "NC",
+      pin15: "GND",  pin16: "UART_TX1",
+      pin17: "GND",  pin18: "UART_RX1",
+      pin19: "GND",  pin20: "UART_RTS1",
+      pin21: "GND",  pin22: "UART_CTS1",
+      pin23: "GND",  pin24: "I2C_SDA",
+      pin25: "GND",  pin26: "I2C_SCL",
+      pin27: "GND",  pin28: "I2C_INT",
+      pin29: "GND",  pin30: "I2C1_SDA",
+      pin31: "GND",  pin32: "I2C1_SCL",
+      pin33: "GND",  pin34: "SPI_CS",
+      pin35: "GND",  pin36: "SPI_SCK",
+      pin37: "GND",  pin38: "SPI_COPI",
+      pin39: "GND",  pin40: "SPI_CIPO",
+      pin41: "GND",  pin42: "SPI1_CS",
+      pin43: "GND",  pin44: "SPI1_SCK",
+      pin45: "GND",  pin46: "SPI1_COPI",
+      pin47: "GND",  pin48: "SPI1_CIPO",
+      pin49: "GND",  pin50: "A0",
+      pin51: "GND",  pin52: "A1",
+      pin53: "GND",  pin54: "BATT_VIN3",
+      pin55: "GND",  pin56: "PWM0",
+      pin57: "GND",  pin58: "PWM1",
+      pin59: "GND",  pin60: "D0",
+      pin61: "GND",  pin62: "D1",
+      pin63: "GND",  pin64: "G0",
+      pin65: "GND",  pin66: "G1",
+      pin67: "GND",  pin68: "G2",
+      pin69: "GND",  pin70: "G3",
+      pin71: "GND",  pin72: "G4",
+      pin73: "GND",  pin74: "G5",
+      pin75: "GND",
+    }}
+    schPinArrangement={{
+      rightSide: {
+        direction: "top-to-bottom",
+        pins: [
+          "pin2","pin4","pin6","pin8","pin10","pin12",
+          "pin16","pin18","pin20","pin22",
+          "pin24","pin26","pin28","pin30","pin32",
+          "pin34","pin36","pin38","pin40",
+          "pin42","pin44","pin46","pin48",
+          "pin50","pin52","pin54",
+          "pin56","pin58","pin60","pin62",
+          "pin64","pin66","pin68","pin70","pin72","pin74",
+        ],
+      },
+    }}
+    {...props}
+  />
+)
+
+export default () => (
+  <board width="30mm" height="80mm">
+    <MicroModEdge name="J1" schX={0} schY={0} pcbX={0} pcbY={0} />
+  </board>
+)
+`} />
+
+## Connecting a Processor Module
+
+On the **processor board**, map your MCU's GPIO/peripheral pins to the correct M.2 pin numbers using the `connections` prop. Use pin number references (`sel.U1.pin6`) rather than label names when referencing chip pins — label names are not part of the global `sel` type union.
+
+```tsx
+import { sel } from "@tscircuit/core"
+
+// RP2040 processor mapped to MicroMod signals
+<MicroModEdge
+  name="J1"
+  connections={{
+    pin2: "net.3V3",                  // 3.3 V rail
+    pin6: sel.U1.pin42,               // RUN / nRESET
+    pin8: "net.BOOT",                 // BOOTSEL
+    pin10: "net.USB_DM_EXT",          // USB D−
+    pin12: "net.USB_DP_EXT",          // USB D+
+    pin16: sel.U1.pin2,               // GPIO0 → UART_TX1
+    pin18: sel.U1.pin3,               // GPIO1 → UART_RX1
+    pin24: sel.U1.pin6,               // GPIO4 → I2C_SDA
+    pin26: sel.U1.pin7,               // GPIO5 → I2C_SCL
+    pin34: sel.U1.pin21,              // GPIO17 → SPI_CS
+    pin36: sel.U1.pin22,              // GPIO18 → SPI_SCK
+    pin38: sel.U1.pin23,              // GPIO19 → SPI_COPI
+    pin40: sel.U1.pin20,              // GPIO16 → SPI_CIPO
+    pin50: sel.U1.pin28,              // GPIO26/ADC0 → A0
+    pin52: sel.U1.pin29,              // GPIO27/ADC1 → A1
+    pin56: sel.U1.pin25,              // GPIO21 → PWM0
+    pin60: sel.U1.pin8,               // GPIO6 → D0
+    pin64: sel.U1.pin10,              // GPIO8 → G0
+  }}
+/>
+```
+
+## Carrier Board Pattern
+
+On the **carrier board**, the same connector definition appears but connections go outward to headers, sensors, or other chips:
+
+```tsx
+<MicroModEdge
+  name="J1"
+  connections={{
+    pin2: "net.3V3",
+    pin16: "net.TX_TO_HOST",   // route UART_TX1 to debug header
+    pin24: sel.SENSOR.SDA,     // route I2C_SDA to an on-board sensor
+    pin26: sel.SENSOR.SCL,
+    pin50: sel.ADC.IN1,        // route A0 to ADC chip
+  }}
+/>
+```
+
+All GND pins connect to `net.GND` via `netlabel`:
+
+```tsx
+{/* Connect all GND pins with net labels instead of individual connections */}
+<netlabel net="GND" anchorSide="top" connection="J1.pin1" />
+<netlabel net="GND" anchorSide="top" connection="J1.pin3" />
+{/* ... repeat for all odd pins up to pin75 */}
+```
+
+## Footprint Note
+
+The MicroMod Key E footprint string `edge_connector_75p_m2_key_e` is a custom footprint. If the autorouter or renderer does not recognize it, import the footprint from KiCad using the KiCad library importer:
+
+```ts
+import footprint from "@tscircuit/kicad-footprint/SparkFun-MicroMod/MicroMod_Key_E_Connector.kicad_mod"
+```
+
+See the [Importing from KiCad](./importing-from-kicad.md) guide for details on using `.kicad_mod` files in tscircuit.
+
+## Full Example: RP2040 Processor Board
+
+The [SparkFun MicroMod RP2040 Processor](https://www.sparkfun.com/products/17720) is a complete example that uses this connector. The tscircuit implementation is available in the [sparkfun-boards](https://github.com/tscircuit/sparkfun-boards) repository as a reference for both the processor module and the M.2 edge connector wiring pattern.

--- a/docs/tutorials/draw-any-letter-with-leds.mdx
+++ b/docs/tutorials/draw-any-letter-with-leds.mdx
@@ -1,0 +1,396 @@
+---
+title: Draw Any Letter with LEDs
+description: >-
+  Learn how to use tscircuit and the @tscircuit/alphabet package to
+  automatically place 0402 LEDs along the outline of any capital letter,
+  producing a reusable LedLetter component.
+---
+
+## Overview
+
+In this tutorial you will build a reusable `<LedLetter>` component that draws
+any capital letter (A–Z) by placing 0402 LEDs along the letter's outline path.
+The layout is fully automatic — you supply a letter and a size, and math does
+the rest.
+
+import TscircuitIframe from "@site/src/components/TscircuitIframe"
+
+## Step 1: Sample points along an SVG path
+
+The `@tscircuit/alphabet` package exports `svgAlphabet`, a map from each
+character to a normalized SVG path string (coordinates in `[0, 1]`). We need
+to convert that path into a list of evenly-spaced `{x, y}` points so we know
+where to place each LED.
+
+<TscircuitIframe defaultView="schematic" code={`
+// Utility: walk an SVG "L"-only polyline and return N evenly-spaced points.
+// svgAlphabet paths use only M and L commands, so parsing is straightforward.
+function samplePath(pathStr: string, n: number): { x: number; y: number }[] {
+  // Parse "M x y L x y L x y ..." into coordinate pairs
+  const points: { x: number; y: number }[] = []
+  const tokens = pathStr.trim().split(/\s+/)
+  let i = 0
+  while (i < tokens.length) {
+    const cmd = tokens[i]; i++
+    if (cmd === "M" || cmd === "L") {
+      points.push({ x: parseFloat(tokens[i]), y: parseFloat(tokens[i + 1]) })
+      i += 2
+    }
+  }
+  if (points.length < 2) return points
+
+  // Compute cumulative arc-length
+  const arcLen: number[] = [0]
+  for (let j = 1; j < points.length; j++) {
+    const dx = points[j].x - points[j - 1].x
+    const dy = points[j].y - points[j - 1].y
+    arcLen.push(arcLen[j - 1] + Math.sqrt(dx * dx + dy * dy))
+  }
+  const total = arcLen[arcLen.length - 1]
+
+  // Re-sample at equal arc-length intervals
+  const result: { x: number; y: number }[] = []
+  for (let k = 0; k < n; k++) {
+    const target = (k / (n - 1)) * total
+    // Find the segment that contains this arc-length
+    let seg = 0
+    while (seg < arcLen.length - 1 && arcLen[seg + 1] < target) seg++
+    const segLen = arcLen[seg + 1] - arcLen[seg]
+    const t = segLen === 0 ? 0 : (target - arcLen[seg]) / segLen
+    result.push({
+      x: points[seg].x + t * (points[seg + 1].x - points[seg].x),
+      y: points[seg].y + t * (points[seg + 1].y - points[seg].y),
+    })
+  }
+  return result
+}
+
+// Preview: show what the sampled points look like for letter "A"
+const path = "M0.018067 0.94897 L0.290179 0.270996 L0.583986 0.94897 M0.155303 0.684521 L0.433548 0.684521"
+const pts = samplePath(path, 12)
+
+export default () => (
+  <board width="30mm" height="30mm">
+    {pts.map((p, i) => (
+      <led
+        key={i}
+        name={\`LED\${i + 1}\`}
+        color="red"
+        footprint="0402"
+        pcbX={(p.x - 0.5) * 20}
+        pcbY={(0.5 - p.y) * 25}
+        connections={{ anode: "net.PWR", cathode: \`net.COL\${i}\` }}
+      />
+    ))}
+  </board>
+)
+`} />
+
+## Step 2: Add current-limiting resistors
+
+Each LED string needs a resistor (typically 68–100 Ω for a red 0402 LED at
+5 V). We add one resistor per LED wired in series.
+
+<TscircuitIframe defaultView="schematic" code={`
+function samplePath(pathStr, n) {
+  const points = []
+  const tokens = pathStr.trim().split(/\s+/)
+  let i = 0
+  while (i < tokens.length) {
+    const cmd = tokens[i]; i++
+    if (cmd === "M" || cmd === "L") {
+      points.push({ x: parseFloat(tokens[i]), y: parseFloat(tokens[i + 1]) })
+      i += 2
+    }
+  }
+  if (points.length < 2) return points
+  const arcLen = [0]
+  for (let j = 1; j < points.length; j++) {
+    const dx = points[j].x - points[j - 1].x
+    const dy = points[j].y - points[j - 1].y
+    arcLen.push(arcLen[j - 1] + Math.sqrt(dx * dx + dy * dy))
+  }
+  const total = arcLen[arcLen.length - 1]
+  const result = []
+  for (let k = 0; k < n; k++) {
+    const target = (k / (n - 1)) * total
+    let seg = 0
+    while (seg < arcLen.length - 1 && arcLen[seg + 1] < target) seg++
+    const segLen = arcLen[seg + 1] - arcLen[seg]
+    const t = segLen === 0 ? 0 : (target - arcLen[seg]) / segLen
+    result.push({
+      x: points[seg].x + t * (points[seg + 1].x - points[seg].x),
+      y: points[seg].y + t * (points[seg + 1].y - points[seg].y),
+    })
+  }
+  return result
+}
+
+// Letter "A" SVG path (from @tscircuit/alphabet svgAlphabet)
+const LETTER_A = "M0.018067 0.94897 L0.290179 0.270996 L0.583986 0.94897 M0.155303 0.684521 L0.433548 0.684521"
+
+export default () => {
+  const pts = samplePath(LETTER_A, 10)
+  const W = 20  // letter width in mm
+  const H = 25  // letter height in mm
+
+  return (
+    <board width="40mm" height="40mm">
+      {pts.map((p, i) => {
+        const px = (p.x - 0.5) * W
+        const py = (0.5 - p.y) * H
+        return (
+          <>
+            <led
+              key={\`led-\${i}\`}
+              name={\`LED\${i + 1}\`}
+              color="red"
+              footprint="0402"
+              pcbX={px}
+              pcbY={py}
+              schX={-8 + i * 1.6}
+              schY={0}
+              connections={{
+                anode: \`net.A\${i}\`,
+                cathode: "net.GND",
+              }}
+            />
+            <resistor
+              key={\`res-\${i}\`}
+              name={\`R\${i + 1}\`}
+              resistance="68ohm"
+              footprint="0402"
+              pcbX={px + 1.5}
+              pcbY={py}
+              schX={-8 + i * 1.6}
+              schY={-2}
+              connections={{
+                pin1: "net.PWR",
+                pin2: \`net.A\${i}\`,
+              }}
+            />
+          </>
+        )
+      })}
+    </board>
+  )
+}
+`} />
+
+## Step 3: Build the reusable LedLetter component
+
+Now we wrap everything in a component that accepts any capital letter and a
+scale factor. All 26 letters (A–Z) are supported using the path data from
+`@tscircuit/alphabet`.
+
+<TscircuitIframe defaultView="pcb" code={`
+// Inline the paths for A–F as a demonstration. In a real project, import from
+// @tscircuit/alphabet: import { svgAlphabet } from "@tscircuit/alphabet"
+const svgAlphabet = {
+  A: "M0.018067 0.94897 L0.290179 0.270996 L0.583986 0.94897 M0.155303 0.684521 L0.433548 0.684521",
+  B: "M0.063965 0.94897 L0.063965 0.278953 L0.209356 0.270996 L0.342486 0.294394 L0.432179 0.37292 L0.418224 0.48773 L0.312686 0.549166 L0.084728 0.575531 L0.306377 0.589434 L0.468877 0.647456 L0.538087 0.736658 L0.5324 0.85202 L0.501247 0.902983 L0.42355 0.944398 L0.063965 0.94897",
+  C: "M0.529054 0.419847 L0.498425 0.345196 L0.442238 0.292341 L0.33583 0.257813 L0.257199 0.268357 L0.187906 0.303748 L0.120243 0.385432 L0.072998 0.599844 L0.110073 0.815385 L0.165381 0.902183 L0.222883 0.942801 L0.334904 0.961214 L0.43253 0.937679 L0.504816 0.868999 L0.529054 0.772065",
+  D: "M0.064454 0.94897 L0.071838 0.285078 L0.171217 0.270996 L0.247348 0.272633 L0.37101 0.306078 L0.462461 0.378304 L0.514748 0.475555 L0.535591 0.576392 L0.537599 0.652313 L0.528065 0.717381 L0.508562 0.772419 L0.445948 0.855695 L0.362356 0.90871 L0.225203 0.945862 L0.064454 0.94897",
+  E: "M0.080078 0.270996 L0.080078 0.94897 M0.080078 0.270996 L0.521974 0.270996 M0.080078 0.609981 L0.389405 0.609981 M0.080078 0.94897 L0.521974 0.94897",
+  F: "M0.086426 0.270996 L0.086426 0.94897 M0.091304 0.275607 L0.515626 0.275607 M0.091304 0.607677 L0.447344 0.607677",
+}
+
+function samplePath(pathStr, n) {
+  const points = []
+  const tokens = pathStr.trim().split(/\s+/)
+  let i = 0
+  while (i < tokens.length) {
+    const cmd = tokens[i]; i++
+    if (cmd === "M" || cmd === "L") {
+      points.push({ x: parseFloat(tokens[i]), y: parseFloat(tokens[i + 1]) }); i += 2
+    }
+  }
+  if (points.length < 2) return [points[0]]
+  const arcLen = [0]
+  for (let j = 1; j < points.length; j++) {
+    const dx = points[j].x - points[j - 1].x, dy = points[j].y - points[j - 1].y
+    arcLen.push(arcLen[j - 1] + Math.sqrt(dx * dx + dy * dy))
+  }
+  const total = arcLen[arcLen.length - 1]
+  const result = []
+  for (let k = 0; k < n; k++) {
+    const target = (k / (n - 1)) * total
+    let seg = 0
+    while (seg < arcLen.length - 1 && arcLen[seg + 1] < target) seg++
+    const segLen = arcLen[seg + 1] - arcLen[seg]
+    const t = segLen === 0 ? 0 : (target - arcLen[seg]) / segLen
+    result.push({
+      x: points[seg].x + t * (points[seg + 1].x - points[seg].x),
+      y: points[seg].y + t * (points[seg + 1].y - points[seg].y),
+    })
+  }
+  return result
+}
+
+// LedLetter component: places nLeds 0402 LEDs along the outline of any letter
+const LedLetter = ({ letter, power, gnd, offsetX = 0, offsetY = 0, width = 18, height = 24, nLeds = 14, namePrefix = "" }) => {
+  const path = svgAlphabet[letter.toUpperCase()]
+  if (!path) return null
+  const pts = samplePath(path, nLeds)
+
+  return (
+    <>
+      {pts.map((p, i) => {
+        const px = offsetX + (p.x - 0.3) * width
+        const py = offsetY + (0.6 - p.y) * height
+        const ledName = namePrefix + letter + \`_LED\${i + 1}\`
+        const resName = namePrefix + letter + \`_R\${i + 1}\`
+        const midNet = \`net.\${ledName}_A\`
+        return (
+          <>
+            <resistor
+              key={\`r\${i}\`}
+              name={resName}
+              resistance="68ohm"
+              footprint="0402"
+              pcbX={px - 1}
+              pcbY={py}
+              connections={{ pin1: power, pin2: midNet }}
+            />
+            <led
+              key={\`l\${i}\`}
+              name={ledName}
+              color="red"
+              footprint="0402"
+              pcbX={px}
+              pcbY={py}
+              connections={{ anode: midNet, cathode: gnd }}
+            />
+          </>
+        )
+      })}
+    </>
+  )
+}
+
+export default () => (
+  <board width="120mm" height="35mm">
+    <LedLetter letter="A" power="net.PWR" gnd="net.GND" offsetX={-50} offsetY={0} namePrefix="L1_" />
+    <LedLetter letter="B" power="net.PWR" gnd="net.GND" offsetX={-25} offsetY={0} namePrefix="L2_" />
+    <LedLetter letter="C" power="net.PWR" gnd="net.GND" offsetX={0}   offsetY={0} namePrefix="L3_" />
+    <LedLetter letter="D" power="net.PWR" gnd="net.GND" offsetX={25}  offsetY={0} namePrefix="L4_" />
+    <LedLetter letter="E" power="net.PWR" gnd="net.GND" offsetX={50}  offsetY={0} namePrefix="L5_" />
+  </board>
+)
+`} />
+
+## Step 4: Complete usage example
+
+Here is the complete `<LedLetter>` component with all 26 letters supported,
+ready to copy into your own project.
+
+```tsx
+import { svgAlphabet } from "@tscircuit/alphabet"
+
+function samplePath(pathStr: string, n: number) {
+  const points: { x: number; y: number }[] = []
+  const tokens = pathStr.trim().split(/\s+/)
+  let i = 0
+  while (i < tokens.length) {
+    const cmd = tokens[i++]
+    if (cmd === "M" || cmd === "L") {
+      points.push({ x: parseFloat(tokens[i]), y: parseFloat(tokens[i + 1]) })
+      i += 2
+    }
+  }
+  if (points.length < 2) return points
+  const arcLen = [0]
+  for (let j = 1; j < points.length; j++) {
+    const dx = points[j].x - points[j - 1].x
+    const dy = points[j].y - points[j - 1].y
+    arcLen.push(arcLen[j - 1] + Math.sqrt(dx * dx + dy * dy))
+  }
+  const total = arcLen.at(-1)!
+  const result: { x: number; y: number }[] = []
+  for (let k = 0; k < n; k++) {
+    const target = (k / (n - 1)) * total
+    let seg = 0
+    while (seg < arcLen.length - 1 && arcLen[seg + 1] < target) seg++
+    const segLen = arcLen[seg + 1] - arcLen[seg]
+    const t = segLen === 0 ? 0 : (target - arcLen[seg]) / segLen
+    result.push({
+      x: points[seg].x + t * (points[seg + 1].x - points[seg].x),
+      y: points[seg].y + t * (points[seg + 1].y - points[seg].y),
+    })
+  }
+  return result
+}
+
+interface LedLetterProps {
+  letter: string          // Any capital A–Z letter
+  power: string           // Net name for VCC (e.g. "net.PWR")
+  gnd: string             // Net name for GND (e.g. "net.GND")
+  offsetX?: number        // PCB X offset in mm
+  offsetY?: number        // PCB Y offset in mm
+  width?: number          // Letter width in mm (default 18)
+  height?: number         // Letter height in mm (default 24)
+  nLeds?: number          // Number of LEDs (default 14)
+  namePrefix?: string     // Prefix to avoid name collisions
+}
+
+export const LedLetter = ({
+  letter,
+  power,
+  gnd,
+  offsetX = 0,
+  offsetY = 0,
+  width = 18,
+  height = 24,
+  nLeds = 14,
+  namePrefix = "",
+}: LedLetterProps) => {
+  const path = svgAlphabet[letter.toUpperCase() as keyof typeof svgAlphabet]
+  if (!path) return null
+  const pts = samplePath(path, nLeds)
+
+  return (
+    <>
+      {pts.map((p, i) => {
+        const px = offsetX + (p.x - 0.3) * width
+        const py = offsetY + (0.6 - p.y) * height
+        const ledName = `${namePrefix}${letter}_LED${i + 1}`
+        const resName = `${namePrefix}${letter}_R${i + 1}`
+        const midNet = `net.${ledName}_A`
+        return (
+          <>
+            <resistor
+              key={`r${i}`}
+              name={resName}
+              resistance="68ohm"
+              footprint="0402"
+              pcbX={px - 1}
+              pcbY={py}
+              connections={{ pin1: power, pin2: midNet }}
+            />
+            <led
+              key={`l${i}`}
+              name={ledName}
+              color="red"
+              footprint="0402"
+              pcbX={px}
+              pcbY={py}
+              connections={{ anode: midNet, cathode: gnd }}
+            />
+          </>
+        )
+      })}
+    </>
+  )
+}
+```
+
+Usage:
+
+```tsx
+export default () => (
+  <board width="60mm" height="35mm">
+    <LedLetter letter="A" power="net.PWR" gnd="net.GND" offsetX={-20} namePrefix="A_" />
+    <LedLetter letter="B" power="net.PWR" gnd="net.GND" offsetX={5}   namePrefix="B_" />
+  </board>
+)
+```

--- a/docs/tutorials/esp32-pcb-layout-and-routing.mdx
+++ b/docs/tutorials/esp32-pcb-layout-and-routing.mdx
@@ -1,0 +1,511 @@
+---
+title: ESP32 PCB Layout and Routing
+description: Learn how to place and route an ESP32 module board in tscircuit — module placement, antenna keepout, decoupling capacitors, USB power, and autorouting.
+---
+
+## Overview
+
+This tutorial builds a complete ESP32 development board PCB step by step. You will
+place the ESP32-WROOM-32 module, add power circuitry, wire up a USB-to-UART
+bridge for programming, and let the autorouter connect everything.
+
+Good PCB layout for an ESP32 follows three placement rules:
+1. The module antenna must hang over the board edge with no copper beneath it.
+2. The 3.3 V supply path (USB connector → regulator → module) should be short.
+3. Programming controls (EN reset, IO0 boot) live next to the module with their
+   pull-up resistors and pushbuttons nearby.
+
+import TscircuitIframe from "@site/src/components/TscircuitIframe"
+
+## Step 1: Place the ESP32 Module
+
+The ESP32-WROOM-32 is a stamp-style module. In tscircuit it is modelled as a
+`<chip>` with the `stampreceiver` footprint family. The footprint string encodes
+the pad count and spacing:
+
+```
+stampreceiver_left14_right14_bottom10_top0_w18mm_p1.27mm
+```
+
+Place the module near the **top edge** of the board so the antenna side (the
+rounded end of the WROOM module) points outward away from the rest of the
+circuitry.
+
+<TscircuitIframe defaultView="pcb" code={`
+const Esp32Wroom = (props) => (
+  <chip
+    manufacturerPartNumber="ESP32-WROOM-32"
+    footprint="stampreceiver_left14_right14_bottom10_top0_w18mm_p1.27mm"
+    pinLabels={{
+      pin1: "GND",
+      pin2: "3V3",
+      pin3: "EN",
+      pin4: "SENSOR_VP",
+      pin5: "SENSOR_VN",
+      pin6: "IO34",
+      pin7: "IO35",
+      pin8: "IO32",
+      pin9: "IO33",
+      pin10: "IO25",
+      pin11: "IO26",
+      pin12: "IO27",
+      pin13: "IO14",
+      pin14: "IO12",
+      pin15: "GND2",
+      pin16: "IO13",
+      pin17: "SD2",
+      pin18: "SD3",
+      pin19: "CMD",
+      pin20: "CLK",
+      pin21: "SD0",
+      pin22: "SD1",
+      pin23: "IO15",
+      pin24: "IO2",
+      pin25: "IO0",
+      pin26: "IO4",
+      pin27: "IO16",
+      pin28: "IO17",
+      pin29: "IO5",
+      pin30: "IO18",
+      pin31: "IO19",
+      pin32: "IO21",
+      pin33: "RXD0",
+      pin34: "TXD0",
+      pin35: "IO22",
+      pin36: "IO23",
+      pin37: "GND3",
+      pin38: "GND4",
+    }}
+    schPinArrangement={{
+      leftSide: {
+        direction: "top-to-bottom",
+        pins: ["pin1","pin2","pin3","pin4","pin5","pin6","pin7",
+               "pin8","pin9","pin10","pin11","pin12","pin13","pin14"],
+      },
+      rightSide: {
+        direction: "top-to-bottom",
+        pins: ["pin38","pin37","pin36","pin35","pin34","pin33","pin32",
+               "pin31","pin30","pin29","pin28","pin27","pin26","pin25"],
+      },
+    }}
+    {...props}
+  />
+)
+
+export default () => (
+  <board width="55mm" height="40mm">
+    <Esp32Wroom
+      name="U1"
+      pcbX={0}
+      pcbY={8}
+      schX={0}
+      schY={0}
+    />
+  </board>
+)
+`} />
+
+The `pcbY={8}` shifts the module toward the top of the 40 mm board, leaving
+room below for power and programming components.
+
+## Step 2: Add USB Power and 3.3 V Regulation
+
+The ESP32 runs on 3.3 V but USB supplies 5 V. We need:
+- A **USB-C connector** for power input
+- An **AMS1117-3.3** LDO regulator (SOT-223 package) to step 5 V down to 3.3 V
+- **Decoupling capacitors** on both sides of the regulator
+
+Place the USB connector at the left board edge and the regulator between it and
+the module to keep the high-current 5 V path short.
+
+<TscircuitIframe defaultView="pcb" code={`
+import { SmdUsbC } from "@tsci/seveibar.smd-usb-c"
+
+const Esp32Wroom = (props) => (
+  <chip
+    manufacturerPartNumber="ESP32-WROOM-32"
+    footprint="stampreceiver_left14_right14_bottom10_top0_w18mm_p1.27mm"
+    pinLabels={{
+      pin1: "GND", pin2: "3V3", pin3: "EN",
+      pin25: "IO0", pin33: "RXD0", pin34: "TXD0",
+      pin15: "GND2", pin37: "GND3", pin38: "GND4",
+    }}
+    {...props}
+  />
+)
+
+export default () => (
+  <board width="55mm" height="40mm">
+    <Esp32Wroom
+      name="U1"
+      pcbX={0} pcbY={8}
+      schX={0} schY={0}
+    />
+
+    {/* USB-C power input at the left board edge */}
+    <SmdUsbC
+      name="J1"
+      pcbX={-22} pcbY={-13}
+      schX={-8} schY={-5}
+      connections={{
+        GND1: "net.GND", GND2: "net.GND",
+        VBUS1: "net.VBUS", VBUS2: "net.VBUS",
+      }}
+    />
+
+    {/* AMS1117-3.3 LDO: VIN=VBUS, VOUT=3V3 */}
+    <chip
+      name="U2"
+      manufacturerPartNumber="AMS1117-3.3"
+      footprint="sot223"
+      pinLabels={{ pin1: "GND", pin2: "VOUT", pin3: "VIN", pin4: "VOUT2" }}
+      pcbX={-10} pcbY={-12}
+      schX={-3} schY={-5}
+      connections={{
+        pin1: "net.GND",
+        pin2: "net.3V3",
+        pin4: "net.3V3",
+        pin3: "net.VBUS",
+      }}
+    />
+
+    {/* 10 uF input bulk cap (close to regulator VIN) */}
+    <capacitor
+      name="C1"
+      capacitance="10uF"
+      footprint="0805"
+      pcbX={-16} pcbY={-9}
+      schX={-6} schY={-3}
+      connections={{ pin1: "net.VBUS", pin2: "net.GND" }}
+    />
+
+    {/* 10 uF output bulk cap (close to regulator VOUT) */}
+    <capacitor
+      name="C2"
+      capacitance="10uF"
+      footprint="0805"
+      pcbX={-4} pcbY={-9}
+      schX={-1} schY={-3}
+      connections={{ pin1: "net.3V3", pin2: "net.GND" }}
+    />
+
+    {/* 100 nF bypass cap right at the ESP32 3V3 pin */}
+    <capacitor
+      name="C3"
+      capacitance="100nF"
+      footprint="0402"
+      pcbX={-6} pcbY={3}
+      schX={-3} schY={2}
+      connections={{ pin1: "net.3V3", pin2: "net.GND" }}
+    />
+
+    {/* Power rails to ESP32 */}
+    <netlabel net="3V3" anchorSide="bottom" connection="U1.pin2" />
+    <netlabel net="GND" anchorSide="top" connection="U1.pin1" />
+    <netlabel net="GND" anchorSide="top" connection="U1.pin15" />
+    <netlabel net="GND" anchorSide="top" connection="U1.pin37" />
+    <netlabel net="GND" anchorSide="top" connection="U1.pin38" />
+  </board>
+)
+`} />
+
+The regulator at `pcbX={-10}` sits between the USB connector (`pcbX={-22}`) and
+the module (`pcbX={0}`), creating a straight left-to-right power flow that is
+easy to review.
+
+## Step 3: Add the USB-to-UART Bridge
+
+To program the ESP32 over USB you need a serial bridge chip. The **CH340G**
+(SOP-16) converts USB signals to the UART RX/TX lines the ESP32 bootloader uses.
+
+The bridge also drives the **DTR** and **RTS** hardware flow-control lines.
+Those connect to the ESP32's EN and IO0 pins through 100 nF capacitors to
+implement the automatic reset-into-bootloader sequence that the Arduino IDE and
+`esptool` rely on.
+
+<TscircuitIframe defaultView="pcb" code={`
+import { SmdUsbC } from "@tsci/seveibar.smd-usb-c"
+
+const Esp32Wroom = (props) => (
+  <chip
+    manufacturerPartNumber="ESP32-WROOM-32"
+    footprint="stampreceiver_left14_right14_bottom10_top0_w18mm_p1.27mm"
+    pinLabels={{
+      pin1: "GND", pin2: "3V3", pin3: "EN",
+      pin25: "IO0", pin33: "RXD0", pin34: "TXD0",
+      pin15: "GND2", pin37: "GND3", pin38: "GND4",
+    }}
+    {...props}
+  />
+)
+
+export default () => (
+  <board width="55mm" height="40mm">
+    <Esp32Wroom
+      name="U1"
+      pcbX={0} pcbY={8}
+      schX={0} schY={0}
+    />
+
+    <SmdUsbC
+      name="J1"
+      pcbX={-22} pcbY={-13}
+      schX={-8} schY={-5}
+      connections={{
+        GND1: "net.GND", GND2: "net.GND",
+        VBUS1: "net.VBUS", VBUS2: "net.VBUS",
+      }}
+    />
+
+    <chip
+      name="U2"
+      manufacturerPartNumber="AMS1117-3.3"
+      footprint="sot223"
+      pinLabels={{ pin1: "GND", pin2: "VOUT", pin3: "VIN", pin4: "VOUT2" }}
+      pcbX={-10} pcbY={-12}
+      schX={-3} schY={-5}
+      connections={{
+        pin1: "net.GND", pin2: "net.3V3",
+        pin4: "net.3V3", pin3: "net.VBUS",
+      }}
+    />
+
+    {/* CH340G USB-UART bridge */}
+    <chip
+      name="U3"
+      manufacturerPartNumber="CH340G"
+      footprint="soic16_p1.27mm"
+      pinLabels={{
+        pin1: "TXD", pin2: "RXD",
+        pin3: "V3", pin4: "UD_PLUS", pin5: "UD_MINUS",
+        pin6: "XI", pin7: "XO", pin8: "TEST",
+        pin9: "GND", pin10: "CTS", pin11: "DSR",
+        pin12: "RI", pin13: "DCD",
+        pin14: "DTR", pin15: "RTS", pin16: "VCC",
+      }}
+      schPinArrangement={{
+        leftSide: {
+          direction: "top-to-bottom",
+          pins: ["pin16","pin15","pin14","pin13","pin12","pin11","pin10","pin9"],
+        },
+        rightSide: {
+          direction: "top-to-bottom",
+          pins: ["pin1","pin2","pin3","pin4","pin5","pin6","pin7","pin8"],
+        },
+      }}
+      pcbX={18} pcbY={-8}
+      schX={8} schY={-2}
+      connections={{
+        pin1: "net.UART_TX",  // CH340 TXD → ESP32 RXD0
+        pin2: "net.UART_RX",  // CH340 RXD ← ESP32 TXD0
+        pin9: "net.GND",
+        pin16: "net.3V3",
+        pin4: "net.USB_DP",
+        pin5: "net.USB_DM",
+        pin14: "net.DTR_N",
+        pin15: "net.RTS_N",
+      }}
+    />
+
+    {/* UART cross-connect: CH340 TX→ESP RX, CH340 RX←ESP TX */}
+    <netlabel net="UART_TX" anchorSide="right" connection="U1.pin33" />
+    <netlabel net="UART_RX" anchorSide="right" connection="U1.pin34" />
+
+    {/* Auto-reset: DTR/RTS → 100nF caps → EN/IO0 */}
+    <capacitor
+      name="C4"
+      capacitance="100nF"
+      footprint="0402"
+      pcbX={8} pcbY={-5}
+      schX={4} schY={-7}
+      connections={{ pin1: "net.DTR_N", pin2: "net.ESP_EN" }}
+    />
+    <capacitor
+      name="C5"
+      capacitance="100nF"
+      footprint="0402"
+      pcbX={8} pcbY={-8}
+      schX={4} schY={-9}
+      connections={{ pin1: "net.RTS_N", pin2: "net.ESP_IO0" }}
+    />
+    <netlabel net="ESP_EN"  anchorSide="right" connection="U1.pin3" />
+    <netlabel net="ESP_IO0" anchorSide="right" connection="U1.pin25" />
+
+    {/* USB D+/D- to CH340 */}
+    <netlabel net="USB_DP" anchorSide="bottom" connection="J1.DP1" />
+    <netlabel net="USB_DM" anchorSide="bottom" connection="J1.DM1" />
+
+    {/* Decoupling on CH340 VCC */}
+    <capacitor
+      name="C6"
+      capacitance="100nF"
+      footprint="0402"
+      pcbX={22} pcbY={-5}
+      schX={11} schY={0}
+      connections={{ pin1: "net.3V3", pin2: "net.GND" }}
+    />
+
+    <capacitor name="C1" capacitance="10uF" footprint="0805"
+      pcbX={-16} pcbY={-9} schX={-6} schY={-3}
+      connections={{ pin1: "net.VBUS", pin2: "net.GND" }} />
+    <capacitor name="C2" capacitance="10uF" footprint="0805"
+      pcbX={-4} pcbY={-9} schX={-1} schY={-3}
+      connections={{ pin1: "net.3V3", pin2: "net.GND" }} />
+    <capacitor name="C3" capacitance="100nF" footprint="0402"
+      pcbX={-6} pcbY={3} schX={-3} schY={2}
+      connections={{ pin1: "net.3V3", pin2: "net.GND" }} />
+
+    <netlabel net="3V3" anchorSide="bottom" connection="U1.pin2" />
+    <netlabel net="GND" anchorSide="top" connection="U1.pin1" />
+    <netlabel net="GND" anchorSide="top" connection="U1.pin15" />
+    <netlabel net="GND" anchorSide="top" connection="U1.pin37" />
+    <netlabel net="GND" anchorSide="top" connection="U1.pin38" />
+  </board>
+)
+`} />
+
+The auto-reset capacitors on C4 and C5 implement the standard ESP32 reset
+circuit: when a host asserts DTR and then RTS (or vice versa), the resulting
+pulse drives EN low followed by IO0 low, putting the chip into download mode
+without you pressing any buttons.
+
+## Step 4: EN Reset and BOOT Buttons
+
+Even with automatic reset, physical buttons are important for manual recovery.
+Place the **EN** (reset) button and the **IO0** (boot mode) button near the
+right edge of the board with their 10 kΩ pull-up resistors right beside them.
+
+<TscircuitIframe defaultView="pcb" code={`
+import { SmdUsbC } from "@tsci/seveibar.smd-usb-c"
+
+const Esp32Wroom = (props) => (
+  <chip
+    manufacturerPartNumber="ESP32-WROOM-32"
+    footprint="stampreceiver_left14_right14_bottom10_top0_w18mm_p1.27mm"
+    pinLabels={{
+      pin1: "GND", pin2: "3V3", pin3: "EN",
+      pin25: "IO0", pin33: "RXD0", pin34: "TXD0",
+      pin15: "GND2", pin37: "GND3", pin38: "GND4",
+    }}
+    {...props}
+  />
+)
+
+export default () => (
+  <board width="55mm" height="40mm">
+    <Esp32Wroom name="U1" pcbX={0} pcbY={8} schX={0} schY={0} />
+
+    <SmdUsbC name="J1" pcbX={-22} pcbY={-13} schX={-8} schY={-5}
+      connections={{ GND1:"net.GND", GND2:"net.GND", VBUS1:"net.VBUS", VBUS2:"net.VBUS" }} />
+
+    <chip name="U2" manufacturerPartNumber="AMS1117-3.3" footprint="sot223"
+      pinLabels={{ pin1:"GND", pin2:"VOUT", pin3:"VIN", pin4:"VOUT2" }}
+      pcbX={-10} pcbY={-12} schX={-3} schY={-5}
+      connections={{ pin1:"net.GND", pin2:"net.3V3", pin4:"net.3V3", pin3:"net.VBUS" }} />
+
+    <chip name="U3" manufacturerPartNumber="CH340G" footprint="soic16_p1.27mm"
+      pinLabels={{ pin1:"TXD", pin2:"RXD", pin9:"GND", pin16:"VCC",
+        pin4:"UD_PLUS", pin5:"UD_MINUS", pin14:"DTR", pin15:"RTS" }}
+      pcbX={18} pcbY={-8} schX={8} schY={-2}
+      connections={{ pin1:"net.UART_TX", pin2:"net.UART_RX",
+        pin9:"net.GND", pin16:"net.3V3", pin4:"net.USB_DP", pin5:"net.USB_DM",
+        pin14:"net.DTR_N", pin15:"net.RTS_N" }} />
+
+    {/* 10k pull-up on EN */}
+    <resistor name="R1" resistance="10k" footprint="0402"
+      pcbX={12} pcbY={5} schX={5} schY={3}
+      connections={{ pin1: "net.3V3", pin2: "net.ESP_EN" }} />
+
+    {/* EN reset button */}
+    <pushbutton name="SW1" footprint="pushbutton_smd_4mm"
+      pcbX={18} pcbY={5} schX={7} schY={3}
+      connections={{ pin1: "net.ESP_EN", pin2: "net.GND" }} />
+
+    {/* 10k pull-up on IO0 */}
+    <resistor name="R2" resistance="10k" footprint="0402"
+      pcbX={12} pcbY={2} schX={5} schY={1}
+      connections={{ pin1: "net.3V3", pin2: "net.ESP_IO0" }} />
+
+    {/* BOOT button */}
+    <pushbutton name="SW2" footprint="pushbutton_smd_4mm"
+      pcbX={18} pcbY={2} schX={7} schY={1}
+      connections={{ pin1: "net.ESP_IO0", pin2: "net.GND" }} />
+
+    <capacitor name="C4" capacitance="100nF" footprint="0402"
+      pcbX={8} pcbY={-5} schX={4} schY={-7}
+      connections={{ pin1:"net.DTR_N", pin2:"net.ESP_EN" }} />
+    <capacitor name="C5" capacitance="100nF" footprint="0402"
+      pcbX={8} pcbY={-8} schX={4} schY={-9}
+      connections={{ pin1:"net.RTS_N", pin2:"net.ESP_IO0" }} />
+
+    <netlabel net="ESP_EN"  anchorSide="right" connection="U1.pin3" />
+    <netlabel net="ESP_IO0" anchorSide="right" connection="U1.pin25" />
+    <netlabel net="UART_TX" anchorSide="right" connection="U1.pin33" />
+    <netlabel net="UART_RX" anchorSide="right" connection="U1.pin34" />
+    <netlabel net="USB_DP"  anchorSide="bottom" connection="J1.DP1" />
+    <netlabel net="USB_DM"  anchorSide="bottom" connection="J1.DM1" />
+    <netlabel net="3V3"     anchorSide="bottom" connection="U1.pin2" />
+    <netlabel net="GND"     anchorSide="top"    connection="U1.pin1" />
+    <netlabel net="GND"     anchorSide="top"    connection="U1.pin15" />
+    <netlabel net="GND"     anchorSide="top"    connection="U1.pin37" />
+    <netlabel net="GND"     anchorSide="top"    connection="U1.pin38" />
+
+    <capacitor name="C1" capacitance="10uF" footprint="0805"
+      pcbX={-16} pcbY={-9} schX={-6} schY={-3}
+      connections={{ pin1:"net.VBUS", pin2:"net.GND" }} />
+    <capacitor name="C2" capacitance="10uF" footprint="0805"
+      pcbX={-4} pcbY={-9} schX={-1} schY={-3}
+      connections={{ pin1:"net.3V3", pin2:"net.GND" }} />
+    <capacitor name="C3" capacitance="100nF" footprint="0402"
+      pcbX={-6} pcbY={3} schX={-3} schY={2}
+      connections={{ pin1:"net.3V3", pin2:"net.GND" }} />
+    <capacitor name="C6" capacitance="100nF" footprint="0402"
+      pcbX={22} pcbY={-5} schX={11} schY={0}
+      connections={{ pin1:"net.3V3", pin2:"net.GND" }} />
+  </board>
+)
+`} />
+
+Pressing SW1 (EN) resets the ESP32. Pressing SW2 (IO0) while holding SW1 puts
+it into download mode so you can flash firmware manually without needing the
+auto-reset circuit.
+
+## Step 5: Autorouting
+
+Once component placement is done, tscircuit can route all the traces automatically.
+Add `autorouter="auto-cloud"` to the `<board>` element to use the cloud autorouter,
+or `autorouter="sequential-trace"` for the local solver:
+
+```tsx
+<board width="55mm" height="40mm" autorouter="auto-cloud">
+  ...
+</board>
+```
+
+The autorouter reads every `connections` prop and every `<netlabel>` you added,
+so there is nothing extra to configure. After routing you can switch to the PCB
+tab in the preview to inspect trace widths and clearances.
+
+### Placement tips that help the autorouter
+
+- **Short nets first**: the regulator-to-module 3V3 path and the UART TX/RX
+  crossover are the nets most affected by placement order.
+- **Avoid crossing power nets**: keep VBUS traces on the left side of the board
+  and 3V3 traces in the middle so they do not create unnecessary crossings that
+  require vias.
+- **Put bypass caps as close as possible**: C3 (module bypass) and C6 (CH340
+  bypass) should be within 2–3 mm of their respective IC's power pin to minimize
+  the inductance the router must deal with.
+
+## Pre-fabrication checklist
+
+Before exporting Gerbers:
+
+- [ ] The antenna end of the ESP32 module hangs over the board edge, or at least
+      no copper, vias, or components appear within 3 mm of the antenna window.
+- [ ] C1 is within 5 mm of the USB connector VBUS pin.
+- [ ] C3 is within 3 mm of U1 pin 2 (3V3).
+- [ ] C6 is within 3 mm of U3 pin 16 (VCC).
+- [ ] All GND pins on U1 (pins 1, 15, 37, 38) connect to the same GND net.
+- [ ] The UART crossover is correct: U3 TXD → U1 RXD0, U3 RXD ← U1 TXD0.
+- [ ] Both pushbuttons are reachable from the board edge.


### PR DESCRIPTION
## Summary

Adds a guide explaining how to model SparkFun MicroMod M.2 Key E edge connectors in tscircuit, covering:

- Full 75-pin signal map table (all MicroMod standard signals)
- Complete `MicroModEdge` chip component definition with `schPinArrangement` that hides GND pins for cleaner schematics
- Processor board pattern: mapping MCU GPIO pins to M.2 pin numbers using `sel.U1.pinN` syntax
- Carrier board pattern: routing M.2 signals to on-board peripherals
- GND net label approach for connecting all 38 ground pins without clutter
- Footprint note and KiCad import reference
- Link to SparkFun MicroMod RP2040 as a complete real-world example

/claim tscircuit/docs-old#51