### PR TITLE
Fix docs edit and editor navbar links

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -42,7 +42,7 @@ const config: Config = {
         docs: {
           sidebarPath: "./sidebars.ts",
           routeBasePath: "/", // Serve docs at root
-          editUrl: "https://github.com/tscircuit/docs/tree/main/",
+          editUrl: "https://github.com/tscircuit/docs/edit/main/",
           breadcrumbs: false,
         },
         theme: {
@@ -179,8 +179,8 @@ const config: Config = {
         },
         { to: "https://blog.tscircuit.com", label: "Blog", position: "left" },
         {
-          to: "https://tscircuit.com",
-          label: "Use Online",
+          to: "https://tscircuit.com/editor",
+          label: "Try Online",
           position: "left",
         },
 


### PR DESCRIPTION
/claim #65
/claim #67

This PR addresses two archived docs-old bounty requests against the current live docs repository:

- https://github.com/tscircuit/docs-old/issues/65: generated doc edit links should open GitHub edit mode.
- https://github.com/tscircuit/docs-old/issues/67: the top nav should say "Try Online" and link directly to the editor.

Changes:
- Updates the Docusaurus `editUrl` from `/tree/main/` to `/edit/main/` so docs edit links open the GitHub editor.
- Updates the navbar link from `Use Online` at `https://tscircuit.com` to `Try Online` at `https://tscircuit.com/editor`.

Note: the archived docs-old issues are read-only/locked, so I could not leave `/attempt` comments there before opening this PR.

Verification:
- `bun run format:check`
- `bun run typecheck`
- `bun run docusaurus build`
- `git diff --check`

AI-assisted with Codex; I reviewed the diff and kept the change scoped.