### PR TITLE
[codex] center docs content and update editor link

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -179,8 +179,8 @@ const config: Config = {
         },
         { to: "https://blog.tscircuit.com", label: "Blog", position: "left" },
         {
-          to: "https://tscircuit.com",
-          label: "Use Online",
+          to: "https://tscircuit.com/editor",
+          label: "Try Online",
           position: "left",
         },
 

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -851,11 +851,13 @@ article h4 {
   display: none !important;
 }
 
-/* Force center all documentation content */
+/* Center the documentation column after hiding the table of contents. */
 .col:not(.col--3) {
-  max-width: 1000px !important;
+  width: 100%;
+  max-width: min(100%, 1000px) !important;
   margin-left: auto !important;
   margin-right: auto !important;
+  box-sizing: border-box;
 }
 
 /* Force section overview to center - using stable attribute selector */

--- a/src/theme/DocItem/Layout/styles.module.css
+++ b/src/theme/DocItem/Layout/styles.module.css
@@ -7,6 +7,12 @@
   position: relative;
 }
 
+.docItemContainer {
+  width: 100%;
+  margin-left: auto;
+  margin-right: auto;
+}
+
 .contentHeader {
   position: relative;
   z-index: 10;
@@ -40,6 +46,9 @@
 
 @media (min-width: 997px) {
   .docItemCol {
-    max-width: 75% !important;
+    flex: 0 1 1000px !important;
+    max-width: min(100%, 1000px) !important;
+    margin-left: auto;
+    margin-right: auto;
   }
 }


### PR DESCRIPTION
/claim tscircuit/docs-old#64
/claim tscircuit/docs-old#67

## Summary
- center the docs content column after the table of contents is hidden, matching the archived docs-centering bounty request
- change the navbar CTA from `Use Online` to `Try Online`
- point the CTA directly at `https://tscircuit.com/editor`

## Bounty context
Archived bounty issues:
- https://github.com/tscircuit/docs-old/issues/64
- https://github.com/tscircuit/docs-old/issues/67

`tscircuit/docs-old` is archived/read-only, so I could not comment `/attempt` there before opening this PR.

## Verification
- `npx biome format docusaurus.config.ts src/css/custom.css src/theme/DocItem/Layout/styles.module.css`
- `npm run typecheck`
- `git diff --check HEAD~1..HEAD`
- `npm run docusaurus -- build` after aligning local npm verification to the repo lockfile's `webpack@5.101.3`
- served the built site locally and checked with Puppeteer that the navbar contains `Try Online -> https://tscircuit.com/editor` and the docs column is constrained to 1000px in the main docs area
