### PR TITLE
Fix Try Online navbar link

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -179,8 +179,8 @@ const config: Config = {
         },
         { to: "https://blog.tscircuit.com", label: "Blog", position: "left" },
         {
-          to: "https://tscircuit.com",
-          label: "Use Online",
+          to: "https://tscircuit.com/editor",
+          label: "Try Online",
           position: "left",
         },
 


### PR DESCRIPTION
## Summary
- rename the top nav link from "Use Online" to "Try Online"
- point the link directly to `https://tscircuit.com/editor` as requested in #67

/claim #67

## Testing
- `bun run typecheck`
- `bun run build`