### PR TITLE
docs(footprints): document QFP thermal pad option and update preview examples

### DIFF
--- a/docs/footprints/footprinter-strings.mdx
+++ b/docs/footprints/footprinter-strings.mdx
@@ -287,7 +287,7 @@ Parameters:
 
 Quad Flat Package (QFP) footprint with configurable number of pins.
 
-<FootprintPreview footprints={["qfp32", "qfp44"]} />
+<FootprintPreview footprints={["qfp32_thermalpad", "qfp32_w7_l7_p0.5_pw0.3_pl0.6_thermalpad1.5mmx1mm"]} />
 
 Parameters:
 
@@ -298,6 +298,8 @@ Parameters:
 | `p` | `"0.8mm"` | Pin pitch (center-to-center distance between adjacent pins) |
 | `pw` | `"0.25mm"` | Pin width |
 | `pl` | `"0.6mm"` | Pin length (exposed pad length) |
+| `thermalpad` | `false` | Set to `true` to add a centered exposed thermal pad (`_thermalpad`). |
+| `thermalpad{width}x{height}` | n/a | Thermal pad sizing suffix (e.g. `_thermalpad1.5mmx1mm`) used to set both thermal pad width and height. |
 
 ## qfn
 

--- a/docs/footprints/footprinter-strings.mdx
+++ b/docs/footprints/footprinter-strings.mdx
@@ -287,7 +287,7 @@ Parameters:
 
 Quad Flat Package (QFP) footprint with configurable number of pins.
 
-<FootprintPreview footprints={["qfp32_thermalpad", "qfp32_w7_l7_p0.5_pw0.3_pl0.6_thermalpad1.5mmx1mm"]} />
+<FootprintPreview footprints={["qfp32", "qfp44", "qfp32_thermalpad", "qfp32_thermalpad1.5mmx1mm"]} />
 
 Parameters:
 
@@ -299,7 +299,7 @@ Parameters:
 | `pw` | `"0.25mm"` | Pin width |
 | `pl` | `"0.6mm"` | Pin length (exposed pad length) |
 | `thermalpad` | `false` | Set to `true` to add a centered exposed thermal pad (`_thermalpad`). |
-| `thermalpad{width}x{height}` | n/a | Thermal pad sizing suffix (e.g. `_thermalpad1.5mmx1mm`) used to set both thermal pad width and height. |
+| `thermalpad{width}x{height}` | n/a | Thermal pad sizing suffix used to set both thermal pad width and height (e.g. `qfp32_thermalpad1.5mmx1mm`). |
 
 ## qfn
 

--- a/docs/footprints/footprinter-strings.mdx
+++ b/docs/footprints/footprinter-strings.mdx
@@ -287,7 +287,7 @@ Parameters:
 
 Quad Flat Package (QFP) footprint with configurable number of pins.
 
-<FootprintPreview footprints={["qfp32", "qfp44", "qfp32_thermalpad", "qfp32_thermalpad1.5mmx1mm"]} />
+<FootprintPreview footprints={["qfp32", "qfp44"]} />
 
 Parameters:
 
@@ -298,7 +298,7 @@ Parameters:
 | `p` | `"0.8mm"` | Pin pitch (center-to-center distance between adjacent pins) |
 | `pw` | `"0.25mm"` | Pin width |
 | `pl` | `"0.6mm"` | Pin length (exposed pad length) |
-| `thermalpad` | `false` | Set to `true` to add a centered exposed thermal pad (`_thermalpad`). |
+| `thermalpad` | `false` | Add `_thermalpad` to include a centered exposed thermal pad (for example, `qfp32_thermalpad`). |
 | `thermalpad{width}x{height}` | n/a | Thermal pad sizing suffix used to set both thermal pad width and height (e.g. `qfp32_thermalpad1.5mmx1mm`). |
 
 ## qfn

--- a/docs/footprints/footprinter-strings.mdx
+++ b/docs/footprints/footprinter-strings.mdx
@@ -287,7 +287,7 @@ Parameters:
 
 Quad Flat Package (QFP) footprint with configurable number of pins.
 
-<FootprintPreview footprints={["qfp32", "qfp44"]} />
+<FootprintPreview footprints={["qfp32", "qfp44", "qfp32_thermalpad", "qfp32_thermalpad1.5mmx1mm"]} />
 
 Parameters:
 


### PR DESCRIPTION
### Motivation
- Clarify that QFP footprints can include a centered exposed thermal pad and show examples of thermal-pad variants in the preview. 

### Description
- Updated `docs/footprints/footprinter-strings.mdx` to change the `FootprintPreview` for `qfp` to include thermal pad variants and added parameter descriptions for `thermalpad` and the `thermalpad{width}x{height}` sizing suffix.

### Testing
- No automated tests were run for this documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a1348cdefc4832e8b2c274fa2f9061a)