### PR TITLE
docs: add QFP thermal-pad variants to preview and document `thermalpad` parameter

### DIFF
--- a/docs/footprints/footprinter-strings.mdx
+++ b/docs/footprints/footprinter-strings.mdx
@@ -287,7 +287,7 @@ Parameters:
 
 Quad Flat Package (QFP) footprint with configurable number of pins.
 
-<FootprintPreview footprints={["qfp32", "qfp44"]} />
+<FootprintPreview footprints={["qfp32", "qfp44", "qfp32_thermalpad", "qfp32_thermalpad1.5mmx1mm"]} />
 
 Parameters:
 
@@ -298,6 +298,8 @@ Parameters:
 | `p` | `"0.8mm"` | Pin pitch (center-to-center distance between adjacent pins) |
 | `pw` | `"0.25mm"` | Pin width |
 | `pl` | `"0.6mm"` | Pin length (exposed pad length) |
+| `thermalpad` | `false` | Add `_thermalpad` to include a centered exposed thermal pad (for example, `qfp32_thermalpad`). |
+| `thermalpad{width}x{height}` | n/a | Thermal pad sizing suffix used to set both thermal pad width and height (e.g. `qfp32_thermalpad1.5mmx1mm`). |
 
 ## qfn
 


### PR DESCRIPTION
### Motivation

- Clarify and document newly supported QFP footprint variants that include a centered exposed thermal pad and allow explicit sizing via the footprint name.

### Description

- Updated the `<FootprintPreview>` for `qfp` to include `qfp32_thermalpad` and `qfp32_thermalpad1.5mmx1mm` preview entries. 
- Added documentation entries for the `thermalpad` parameter and the `thermalpad{width}x{height}` sizing suffix to explain how to request a thermal pad and specify its size. 
- Changes are confined to `docs/footprints/footprinter-strings.mdx` and do not modify footprint generation logic.

### Testing

- Built the documentation site with `yarn docs:build` and confirmed the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a1348cdefc4832e8b2c274fa2f9061a)