### PR TITLE
[codex] Align docs content layout

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -754,6 +754,14 @@ body {
   box-sizing: border-box;
 }
 
+@media (min-width: 997px) {
+  .doc-section-subtitle {
+    max-width: 1000px;
+    margin-left: clamp(2rem, 5vw, 5rem);
+    margin-right: auto;
+  }
+}
+
 @media (max-width: 768px) {
   .doc-section-subtitle {
     padding-left: 2rem;
@@ -851,11 +859,14 @@ article h4 {
   display: none !important;
 }
 
-/* Force center all documentation content */
-.col:not(.col--3) {
-  max-width: 1000px !important;
-  margin-left: auto !important;
-  margin-right: auto !important;
+@media (min-width: 997px) {
+  main[class*="docMainContainer"]
+    > .container.padding-top--md.padding-bottom--lg {
+    width: 100% !important;
+    max-width: none !important;
+    margin-left: 0 !important;
+    margin-right: 0 !important;
+  }
 }
 
 /* Force section overview to center - using stable attribute selector */
@@ -899,7 +910,7 @@ article h4 {
       article
     )[class*="generatedIndexPage"] {
     max-width: 1000px !important;
-    margin-left: auto !important;
+    margin-left: clamp(2rem, 5vw, 5rem) !important;
     margin-right: auto !important;
     width: 1000px !important;
   }

--- a/src/theme/DocItem/Layout/index.tsx
+++ b/src/theme/DocItem/Layout/index.tsx
@@ -45,7 +45,7 @@ export default function DocItemLayout({ children }: Props): ReactNode {
   const { metadata } = useDoc()
   return (
     <div className="row">
-      <div className={clsx("col", !docTOC.hidden && styles.docItemCol)}>
+      <div className={clsx("col", styles.docItemCol)}>
         <ContentVisibility metadata={metadata} />
         <DocVersionBanner />
         <div className={styles.docItemContainer}>

--- a/src/theme/DocItem/Layout/styles.module.css
+++ b/src/theme/DocItem/Layout/styles.module.css
@@ -3,6 +3,17 @@
   margin-top: 0;
 }
 
+:global(.col).docItemCol {
+  max-width: 100% !important;
+  margin-left: 0 !important;
+  margin-right: 0 !important;
+}
+
+.docItemContainer {
+  width: 100%;
+  max-width: 1000px;
+}
+
 .docItemWithButton {
   position: relative;
 }
@@ -40,6 +51,11 @@
 
 @media (min-width: 997px) {
   .docItemCol {
-    max-width: 75% !important;
+    flex: 1 1 auto;
+  }
+
+  .docItemContainer {
+    margin-left: clamp(2rem, 5vw, 5rem);
+    margin-right: auto;
   }
 }


### PR DESCRIPTION
/claim tscircuit/docs-old#64

Fixes tscircuit/docs-old#64.

## Summary
- Stop centering the whole docs wrapper in the desktop viewport.
- Align docs content, generated index pages, and section subtitles closer to the left docs sidebar while keeping a 1000px content width.
- Keep mobile layouts unchanged.

## Validation
- `bunx biome format src/theme/DocItem/Layout/index.tsx src/theme/DocItem/Layout/styles.module.css src/css/custom.css`
- `bun run typecheck`
- `bun run build`
- Playwright viewport checks at 2048x1152 and 390x844 for docs article and generated category pages.