### PR TITLE
Use Try Online navbar link for editor

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -179,8 +179,8 @@ const config: Config = {
         },
         { to: "https://blog.tscircuit.com", label: "Blog", position: "left" },
         {
-          to: "https://tscircuit.com",
-          label: "Use Online",
+          to: "https://tscircuit.com/editor",
+          label: "Try Online",
           position: "left",
         },
 


### PR DESCRIPTION
/claim tscircuit/docs-old#67

Tiny docs navbar update: the left CTA now says "Try Online" and opens the editor directly.

Checked with `git diff --check`. I did not install or update dependencies for this.
