### PR TITLE
Add JLCPCB footprint docs

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "docs",

--- a/docs/elements/chip.mdx
+++ b/docs/elements/chip.mdx
@@ -788,5 +788,5 @@ guide! This is often much easier and reliable than configuring a chip yourself.
 - [Importing Components from KiCad](../guides/importing-modules-and-chips/importing-from-kicad.md)
 
 :::tip
-If you're only looking to use a standard footprint from KiCad, you can skip importing entirely by referencing the footprint directly with the `kicad:` prefix (e.g. `footprint="kicad:Resistor_SMD/R_0402_1005Metric"`). See [KiCad Footprints](/footprints/kicad-footprints) for details.
+If you're only looking to use an existing PCB footprint, you can skip importing entirely and reference it directly. For KiCad libraries, use the `kicad:` prefix (for example `footprint="kicad:Resistor_SMD/R_0402_1005Metric"`). For JLCPCB/EasyEDA parts, use the `jlcpcb:` prefix (for example `footprint="jlcpcb:C2040"`). See [KiCad Footprints](/footprints/kicad-footprints) and [JLCPCB Footprints](/footprints/jlcpcb-footprints) for details.
 :::

--- a/docs/footprints/jlcpcb-footprints.mdx
+++ b/docs/footprints/jlcpcb-footprints.mdx
@@ -1,0 +1,48 @@
+---
+title: JLCPCB Footprints
+sidebar_position: 2
+description: Use JLCPCB supplier part numbers directly with the `jlcpcb:` footprint prefix
+---
+
+tscircuit can load PCB footprints directly from JLCPCB/EasyEDA part records. Any element that accepts a `footprint` property can reference a JLCPCB part by using the `jlcpcb:` prefix followed by the supplier part number.
+
+import CircuitPreview from "@site/src/components/CircuitPreview"
+
+## Basic Usage
+
+<CircuitPreview
+  defaultView="pcb"
+  hideSchematicTab
+  code={`export default () => (
+  <board width="20mm" height="20mm">
+    <chip
+      name="U1"
+      footprint="jlcpcb:C2040"
+    />
+  </board>
+)`}
+/>
+
+The recommended format is `jlcpcb:C<part-number>`, for example `jlcpcb:C2040`.
+
+For example, the RP2040 can be referenced directly with:
+
+```tsx
+<chip name="U1" manufacturerPartNumber="RP2040" footprint="jlcpcb:C2040" />
+```
+
+## What Gets Loaded
+
+When you use a `jlcpcb:` footprint string, tscircuit fetches the part's PCB footprint data from the configured parts engine. In the default platform, this uses the JLCPCB/EasyEDA part catalog and can also attach 3D model data when it is available.
+
+Use this when you only need the PCB footprint (and optional 3D model). If you also need a generated symbol, port definitions, or a reusable TSX component, use [Importing from JLCPCB](/guides/importing-modules-and-chips/importing-from-jlcpcb) instead.
+
+## Search for Part Numbers
+
+You can discover valid JLCPCB part numbers with:
+
+```bash
+tsci search --jlcpcb RP2040
+```
+
+Search results now include qualified footprint strings like `jlcpcb:C2040`, which can be copied directly into your `footprint` prop.

--- a/docs/guides/importing-modules-and-chips/importing-from-jlcpcb.mdx
+++ b/docs/guides/importing-modules-and-chips/importing-from-jlcpcb.mdx
@@ -10,6 +10,8 @@ import YouTubeEmbed from '../../../src/components/YouTubeEmbed';
 
 JLCPCB maintains a massive component catalog with 3D models and footprints for thousands of parts. You can import these components directly into your tscircuit projects using several methods.
 
+If you only need the PCB footprint, you can skip importing entirely and reference the supplier part number directly with a `jlcpcb:` footprint string, such as `footprint="jlcpcb:C2040"`. See [JLCPCB Footprints](/footprints/jlcpcb-footprints) for the direct-footprint workflow.
+
 ## Import Using Editor Locally
 
 The easiest way to import JLCPCB components is using the editor's built-in import dialog when running `tsci dev`. This provides a modern search interface with real-time stock information.

--- a/docs/guides/running-tscircuit/platform-configuration.md
+++ b/docs/guides/running-tscircuit/platform-configuration.md
@@ -26,7 +26,7 @@ All of the following features of the platform can be configured:
 - **registryApiUrl** - The registry to use, defaults to `https://api.tscircuit.com`. See [Registry API](../../web-apis/the-registry-api.md) for more details
 - **cloudAutorouterUrl** - The cloud autorouter to use, defaults to a tscircuit cloud service that uses freerouting
 - Disable specific circuit outputs to optimize build times, such as disabling autorouting
-- **footprintLibraryMap** - Configure custom prefixes for loading footprint strings from a server. This is how the `kicad:*` footprint strings are loaded!
+- **footprintLibraryMap** - Configure custom prefixes for loading footprint strings from a server. This is how built-in strings like `kicad:*` and `jlcpcb:*` are loaded.
 - **printBoardInformationToSilkscreen** - Print the board information to the silkscreen. This includes standard board and platform information like the board name, version etc.
 
 > See the full specification for the [tscircuit platform configuration](https://github.com/tscircuit/props/blob/main/lib/platformConfig.ts)


### PR DESCRIPTION
## What changed
- added a new JLCPCB footprints doc explaining how to use `jlcpcb:` footprint strings directly
- linked the direct-footprint workflow from the chip docs and the JLCPCB import guide
- clarified that `jlcpcb:*` is a built-in footprint prefix in platform configuration docs
- included the small `bun.lock` metadata update generated in this workspace

## Why
This makes the direct JLCPCB footprint workflow easier to discover without requiring users to go through the full import flow when they only need a footprint.

## Validation
- `bun run build`
