### PR TITLE
[codex] Update online editor navbar link

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -179,8 +179,8 @@ const config: Config = {
         },
         { to: "https://blog.tscircuit.com", label: "Blog", position: "left" },
         {
-          to: "https://tscircuit.com",
-          label: "Use Online",
+          to: "https://tscircuit.com/editor",
+          label: "Try Online",
           position: "left",
         },
 


### PR DESCRIPTION
## Summary
- rename the docs navbar item from `Use Online` to `Try Online`
- point it directly at `https://tscircuit.com/editor`

## Validation
- Not run: `bun run typecheck` because `bun` is not installed on this machine.

/claim #67