### PR TITLE
[codex] Add edit page action to docs

### DIFF
--- a/src/components/EditPageButton.tsx
+++ b/src/components/EditPageButton.tsx
@@ -1,0 +1,35 @@
+import React from "react"
+import { useDoc } from "@docusaurus/plugin-content-docs/client"
+
+export default function EditPageButton() {
+  const { metadata } = useDoc()
+  const editUrl = metadata.editUrl
+
+  if (!editUrl) return null
+
+  return (
+    <a
+      className="edit-page-button"
+      href={editUrl}
+      target="_blank"
+      rel="noopener noreferrer"
+      aria-label="Edit this page on GitHub"
+    >
+      <svg
+        width="14"
+        height="14"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        aria-hidden="true"
+      >
+        <path d="M12 20h9" />
+        <path d="M16.5 3.5a2.12 2.12 0 0 1 3 3L7 19l-4 1 1-4Z" />
+      </svg>
+      <span>Edit page</span>
+    </a>
+  )
+}

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -49,6 +49,35 @@
   opacity: 0.6;
 }
 
+.edit-page-button {
+  align-items: center;
+  background: var(--ifm-background-color);
+  border: 1px solid var(--ifm-color-emphasis-300);
+  border-radius: 6px;
+  color: var(--ifm-color-emphasis-700);
+  display: inline-flex;
+  font-size: 0.78rem;
+  font-weight: 500;
+  gap: 0.4rem;
+  height: 32px;
+  line-height: 1;
+  padding: 0 0.75rem;
+  text-decoration: none;
+  transition:
+    border-color var(--ifm-transition-fast) ease,
+    color var(--ifm-transition-fast) ease,
+    background var(--ifm-transition-fast) ease;
+  white-space: nowrap;
+}
+
+.edit-page-button:hover,
+.edit-page-button:focus-visible {
+  background: var(--ifm-color-emphasis-100);
+  border-color: var(--ifm-color-primary);
+  color: var(--ifm-color-primary);
+  text-decoration: none;
+}
+
 button {
   all: unset;
   cursor: pointer;

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -63,10 +63,8 @@
   line-height: 1;
   padding: 0 0.75rem;
   text-decoration: none;
-  transition:
-    border-color var(--ifm-transition-fast) ease,
-    color var(--ifm-transition-fast) ease,
-    background var(--ifm-transition-fast) ease;
+  transition: border-color var(--ifm-transition-fast) ease, color
+    var(--ifm-transition-fast) ease, background var(--ifm-transition-fast) ease;
   white-space: nowrap;
 }
 

--- a/src/theme/DocItem/Layout/index.tsx
+++ b/src/theme/DocItem/Layout/index.tsx
@@ -13,6 +13,7 @@ import DocBreadcrumbs from "@theme/DocBreadcrumbs"
 import ContentVisibility from "@theme/ContentVisibility"
 import type { Props } from "@theme/DocItem/Layout"
 import CopyPageButton from "@site/src/components/CopyPageButton"
+import EditPageButton from "@site/src/components/EditPageButton"
 
 import styles from "./styles.module.css"
 
@@ -56,7 +57,10 @@ export default function DocItemLayout({ children }: Props): ReactNode {
             <div className={styles.docItemWithButton}>
               <DocItemContent>
                 <div className={styles.contentHeader}>
-                  <CopyPageButton />
+                  <div className={styles.contentActions}>
+                    <EditPageButton />
+                    <CopyPageButton />
+                  </div>
                 </div>
                 {children}
               </DocItemContent>

--- a/src/theme/DocItem/Layout/styles.module.css
+++ b/src/theme/DocItem/Layout/styles.module.css
@@ -12,7 +12,7 @@
   z-index: 10;
 }
 
-  .contentActions {
+.contentActions {
   position: absolute;
   top: 0;
   right: 0;
@@ -35,7 +35,7 @@
     margin-bottom: 1rem;
   }
 
-.contentActions {
+  .contentActions {
     position: relative;
     flex-wrap: wrap;
   }

--- a/src/theme/DocItem/Layout/styles.module.css
+++ b/src/theme/DocItem/Layout/styles.module.css
@@ -12,7 +12,7 @@
   z-index: 10;
 }
 
-.contentActions {
+  .contentActions {
   position: absolute;
   top: 0;
   right: 0;

--- a/src/theme/DocItem/Layout/styles.module.css
+++ b/src/theme/DocItem/Layout/styles.module.css
@@ -12,14 +12,21 @@
   z-index: 10;
 }
 
-.contentHeader :global(.copy-page-button-container) {
+.contentActions {
   position: absolute;
   top: 0;
   right: 0;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.contentHeader :global(.copy-page-button-container) {
+  position: relative;
 }
 
 .docItemWithButton :global(.markdown) > :global(h1):first-child {
-  padding-right: 180px;
+  padding-right: 290px;
 }
 
 @media (max-width: 800px) {
@@ -28,8 +35,9 @@
     margin-bottom: 1rem;
   }
 
-  .contentHeader :global(.copy-page-button-container) {
+.contentActions {
     position: relative;
+    flex-wrap: wrap;
   }
 
   .docItemWithButton :global(.markdown) > :global(h1):first-child {


### PR DESCRIPTION
## Summary
- add an explicit `Edit page` action to doc pages when Docusaurus provides an edit URL
- place it beside the existing copy-page control and reserve header space on desktop
- style the action so it matches the docs utility controls

## Validation
- Not run: `bun run typecheck` because `bun` is not installed on this machine.

/claim #65