### PR TITLE
Document QFP thermal pad footprint strings

### DIFF
--- a/docs/footprints/footprinter-strings.mdx
+++ b/docs/footprints/footprinter-strings.mdx
@@ -302,7 +302,6 @@ Parameters:
 | `pw` | `"0.25mm"` | Pin width |
 | `pl` | `"0.6mm"` | Pin length (exposed pad length) |
 | `thermalpad` | _none_ | Center exposed thermal pad. Use `thermalpad` for the default size or `thermalpad3x3mm` for a custom width and height. |
-| `legsoutside` | `true` | Place the pads outside the body outline |
 
 ## qfn
 

--- a/docs/footprints/footprinter-strings.mdx
+++ b/docs/footprints/footprinter-strings.mdx
@@ -285,19 +285,24 @@ Parameters:
 
 ## qfp
 
-Quad Flat Package (QFP) footprint with configurable number of pins.
+Quad Flat Package (QFP) footprint with configurable number of pins. Add
+`thermalpad` for a centered exposed pad, or pass dimensions such as
+`thermalpad3x3mm` to size it.
 
-<FootprintPreview footprints={["qfp32", "qfp44"]} />
+<FootprintPreview footprints={["qfp32", "qfp32_thermalpad", "qfp32_thermalpad3x3mm"]} />
 
 Parameters:
 
 | Parameter | Default | Description |
 |-----------|---------|-------------|
 | `num_pins` | `32` | Total number of pins (must be divisible by 4) |
-| `body_size` | `"7mm"` | Size of the package body (square) |
+| `w` | _calculated_ | Package body width |
+| `h` | _same as `w`_ | Package body height |
 | `p` | `"0.8mm"` | Pin pitch (center-to-center distance between adjacent pins) |
 | `pw` | `"0.25mm"` | Pin width |
 | `pl` | `"0.6mm"` | Pin length (exposed pad length) |
+| `thermalpad` | _none_ | Center exposed thermal pad. Use `thermalpad` for the default size or `thermalpad3x3mm` for a custom width and height. |
+| `legsoutside` | `true` | Place the pads outside the body outline |
 
 ## qfn
 
@@ -428,4 +433,3 @@ Parameters:
 | `pl` | `"1.30mm"` | Pad length |
 | `pw` | `"1.70mm"` | Pad width |
 | `p` | `"3.5mm"` | Pin pitch |
-


### PR DESCRIPTION
Adds QFP footprinter documentation for exposed thermal pads, including both default `qfp32_thermalpad` and sized `qfp32_thermalpad3x3mm` examples. Also updates the QFP parameter table to match `tscircuit/props`, replacing the stale `body_size` entry with `w` and `h`, and documenting `legsoutside`.

<img width="665" height="692" alt="image" src="https://github.com/user-attachments/assets/0e2c8eeb-bcc1-412b-a9c2-130dd5191f4b" />


## Validation

- Confirmed QFP examples parse with `@tscircuit/footprinter`
- Ran `bun run typecheck`
- Ran `bun run build`