### PR TITLE
feat: add LED letter display tutorial using @tscircuit/alphabet

### DIFF
--- a/docs/tutorials/draw-letters-with-leds.mdx
+++ b/docs/tutorials/draw-letters-with-leds.mdx
@@ -1,0 +1,496 @@
+---
+title: "Draw Letters with LEDs"
+description: "Create LED letter displays using tscircuit and the @tscircuit/alphabet library"
+---
+
+## Overview
+
+This tutorial will walk you through creating a reusable `LedLetter` component that displays any capital letter (A-Z) using LEDs on a PCB. We'll use the `@tscircuit/alphabet` library to get letter shape data and mathematically calculate LED positions along each letter's strokes.
+
+import CircuitPreview from "@site/src/components/CircuitPreview"
+import TscircuitIframe from "@site/src/components/TscircuitIframe"
+
+<TscircuitIframe defaultView="pcb" code={`
+import { lineAlphabet } from "@tscircuit/alphabet"
+
+export const LedLetter = ({
+  letter,
+  power,
+  gnd,
+  pcbX = 0,
+  pcbY = 0,
+  schX = 0,
+  schY = 0,
+  scale = 10,
+  color = "red",
+  namePrefix = "",
+}) => {
+  const lines = lineAlphabet[letter.toUpperCase()]
+  if (!lines) return null
+
+  const positions = []
+  for (const line of lines) {
+    const dx = line.x2 - line.x1
+    const dy = line.y2 - line.y1
+    const segLen = Math.sqrt(dx * dx + dy * dy)
+    const n = Math.max(1, Math.round(segLen * scale / 3))
+    for (let i = 0; i <= n; i++) {
+      const t = n === 0 ? 0.5 : i / n
+      positions.push({
+        px: pcbX + (line.x1 + t * dx - 0.5) * scale,
+        py: pcbY + (0.5 - (line.y1 + t * dy)) * scale,
+      })
+    }
+  }
+
+  return (
+    <group>
+      {positions.map((pos, i) => {
+        const ledName = namePrefix + "LED" + i
+        const resName = namePrefix + "R" + i
+        const sx = schX + (i % 5) * 2
+        const sy = schY + Math.floor(i / 5) * 2
+        return (
+          <group key={i}>
+            <led
+              name={ledName}
+              color={color}
+              footprint="0603"
+              pcbX={pos.px}
+              pcbY={pos.py}
+              schX={sx}
+              schY={sy}
+            />
+            <resistor
+              name={resName}
+              resistance="330"
+              footprint="0402"
+              pcbX={pos.px + 0.8}
+              pcbY={pos.py}
+              schX={sx + 0.8}
+              schY={sy}
+            />
+            <trace from={"." + resName + " .pin1"} to={power} />
+            <trace from={"." + resName + " .pin2"} to={"." + ledName + " .pos"} />
+            <trace from={"." + ledName + " .neg"} to={gnd} />
+          </group>
+        )
+      })}
+    </group>
+  )
+}
+
+export default () => (
+  <board width="60mm" height="30mm" routingDisabled>
+    <LedLetter
+      letter="A"
+      power="net.VCC"
+      gnd="net.GND"
+      pcbX={-15}
+      pcbY={0}
+      schX={-8}
+      schY={-4}
+      namePrefix="A_"
+    />
+    <LedLetter
+      letter="B"
+      power="net.VCC"
+      gnd="net.GND"
+      pcbX={0}
+      pcbY={0}
+      schX={0}
+      schY={-4}
+      namePrefix="B_"
+    />
+    <LedLetter
+      letter="C"
+      power="net.VCC"
+      gnd="net.GND"
+      pcbX={15}
+      pcbY={0}
+      schX={8}
+      schY={-4}
+      namePrefix="C_"
+    />
+  </board>
+)
+`} />
+
+## The @tscircuit/alphabet Library
+
+The `@tscircuit/alphabet` library provides letter shape data as line segments. Each letter is represented as an array of `{x1, y1, x2, y2}` objects, where coordinates are normalized to the [0, 1] range.
+
+```tsx
+import { lineAlphabet } from "@tscircuit/alphabet"
+
+const aLines = lineAlphabet["A"]
+// Array of {x1, y1, x2, y2} - each object is a line segment (stroke) of the letter
+```
+
+The letter "A" typically has three strokes: the left diagonal, the right diagonal, and the horizontal crossbar. Each stroke is a line segment with start and end coordinates. Because the coordinates are normalized, we can scale them to any size on the PCB.
+
+## Placing LEDs Along Letter Strokes
+
+To display a letter with LEDs, we need to convert the normalized line segment coordinates into PCB positions. For each line segment, we calculate how many LEDs to place based on the segment length, then distribute them evenly along the stroke.
+
+The coordinate conversion flips the Y-axis because `lineAlphabet` uses SVG conventions (Y increases downward) while PCB coordinates use standard electronics conventions (Y increases upward).
+
+<CircuitPreview defaultView="pcb" hide3DTab code={`
+import { lineAlphabet } from "@tscircuit/alphabet"
+
+export default () => {
+  const lines = lineAlphabet["A"]
+  const scale = 10
+  const pcbX = 0
+  const pcbY = 0
+
+  const positions = []
+  for (const line of lines) {
+    const dx = line.x2 - line.x1
+    const dy = line.y2 - line.y1
+    const segLen = Math.sqrt(dx * dx + dy * dy)
+    const n = Math.max(1, Math.round(segLen * scale / 3))
+    for (let i = 0; i <= n; i++) {
+      const t = n === 0 ? 0.5 : i / n
+      positions.push({
+        x: pcbX + (line.x1 + t * dx - 0.5) * scale,
+        y: pcbY + (0.5 - (line.y1 + t * dy)) * scale,
+      })
+    }
+  }
+
+  return (
+    <board width="20mm" height="20mm" routingDisabled>
+      {positions.map((pos, i) => (
+        <led
+          key={i}
+          name={"LED" + i}
+          color="red"
+          footprint="0603"
+          pcbX={pos.x}
+          pcbY={pos.y}
+        />
+      ))}
+    </board>
+  )
+}
+`} />
+
+Here we place LEDs along each stroke of the letter "A". Longer strokes get more LEDs — the number is calculated as `Math.max(1, Math.round(segmentLength * scale / 3))`, where `3` is the approximate spacing between LEDs in millimeters.
+
+The position formula centers the letter around `(pcbX, pcbY)`:
+- **X position**: `pcbX + (x - 0.5) * scale` — offsets by -0.5 to center horizontally
+- **Y position**: `pcbY + (0.5 - y) * scale` — flips the Y-axis and centers vertically
+
+## Adding Current-Limiting Resistors
+
+Each LED needs a current-limiting resistor in series. For a 5V supply and a typical red LED with ~2V forward voltage, a 330Ω resistor limits the current to approximately 9mA — a safe operating current for most SMD LEDs.
+
+The wiring for each LED is: **power net → resistor → LED anode → LED cathode → ground net**.
+
+<CircuitPreview defaultView="pcb" hide3DTab code={`
+import { lineAlphabet } from "@tscircuit/alphabet"
+
+export default () => {
+  const lines = lineAlphabet["A"]
+  const scale = 10
+  const pcbX = 0
+  const pcbY = 0
+
+  const positions = []
+  for (const line of lines) {
+    const dx = line.x2 - line.x1
+    const dy = line.y2 - line.y1
+    const segLen = Math.sqrt(dx * dx + dy * dy)
+    const n = Math.max(1, Math.round(segLen * scale / 3))
+    for (let i = 0; i <= n; i++) {
+      const t = n === 0 ? 0.5 : i / n
+      positions.push({
+        x: pcbX + (line.x1 + t * dx - 0.5) * scale,
+        y: pcbY + (0.5 - (line.y1 + t * dy)) * scale,
+      })
+    }
+  }
+
+  return (
+    <board width="20mm" height="20mm" routingDisabled>
+      {positions.map((pos, i) => {
+        const ledName = "LED" + i
+        const resName = "R" + i
+        return (
+          <group key={i}>
+            <led
+              name={ledName}
+              color="red"
+              footprint="0603"
+              pcbX={pos.x}
+              pcbY={pos.y}
+            />
+            <resistor
+              name={resName}
+              resistance="330"
+              footprint="0402"
+              pcbX={pos.x + 0.8}
+              pcbY={pos.y}
+            />
+            <trace from={"." + resName + " .pin1"} to="net.VCC" />
+            <trace from={"." + resName + " .pin2"} to={"." + ledName + " .pos"} />
+            <trace from={"." + ledName + " .neg"} to="net.GND" />
+          </group>
+        )
+      })}
+    </board>
+  )
+}
+`} />
+
+Each resistor is placed 0.8mm to the right of its corresponding LED on the PCB. The 0402 footprint is used for resistors to keep the layout compact, while 0603 LEDs are easier to see and solder.
+
+## The Complete LedLetter Component
+
+Now let's wrap everything into a reusable `LedLetter` component. It accepts a `letter` prop, power and ground nets, position offsets for both PCB and schematic views, a scale factor, LED color, and a name prefix to ensure unique component names when multiple letters are placed on the same board.
+
+<CircuitPreview defaultView="pcb" code={`
+import { lineAlphabet } from "@tscircuit/alphabet"
+
+export const LedLetter = ({
+  letter,
+  power,
+  gnd,
+  pcbX = 0,
+  pcbY = 0,
+  schX = 0,
+  schY = 0,
+  scale = 10,
+  color = "red",
+  namePrefix = "",
+}) => {
+  const lines = lineAlphabet[letter.toUpperCase()]
+  if (!lines) return null
+
+  const positions = []
+  for (const line of lines) {
+    const dx = line.x2 - line.x1
+    const dy = line.y2 - line.y1
+    const segLen = Math.sqrt(dx * dx + dy * dy)
+    const n = Math.max(1, Math.round(segLen * scale / 3))
+    for (let i = 0; i <= n; i++) {
+      const t = n === 0 ? 0.5 : i / n
+      positions.push({
+        px: pcbX + (line.x1 + t * dx - 0.5) * scale,
+        py: pcbY + (0.5 - (line.y1 + t * dy)) * scale,
+      })
+    }
+  }
+
+  return (
+    <group>
+      {positions.map((pos, i) => {
+        const ledName = namePrefix + "LED" + i
+        const resName = namePrefix + "R" + i
+        const sx = schX + (i % 5) * 2
+        const sy = schY + Math.floor(i / 5) * 2
+        return (
+          <group key={i}>
+            <led
+              name={ledName}
+              color={color}
+              footprint="0603"
+              pcbX={pos.px}
+              pcbY={pos.py}
+              schX={sx}
+              schY={sy}
+            />
+            <resistor
+              name={resName}
+              resistance="330"
+              footprint="0402"
+              pcbX={pos.px + 0.8}
+              pcbY={pos.py}
+              schX={sx + 0.8}
+              schY={sy}
+            />
+            <trace from={"." + resName + " .pin1"} to={power} />
+            <trace from={"." + resName + " .pin2"} to={"." + ledName + " .pos"} />
+            <trace from={"." + ledName + " .neg"} to={gnd} />
+          </group>
+        )
+      })}
+    </group>
+  )
+}
+
+export default () => (
+  <board width="20mm" height="20mm" routingDisabled>
+    <LedLetter
+      letter="A"
+      power="net.VCC"
+      gnd="net.GND"
+      pcbX={0}
+      pcbY={0}
+      schX={-4}
+      schY={-4}
+      namePrefix="A_"
+    />
+  </board>
+)
+`} />
+
+The component calculates LED positions along each stroke of the letter, places a resistor next to each LED, and wires them in series. The `namePrefix` prop ensures that component names don't collide when multiple `LedLetter` instances are used on the same board.
+
+### Component Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `letter` | `string` | required | The capital letter to display (A-Z) |
+| `power` | `string` | required | Power net identifier (e.g. `"net.VCC"`) |
+| `gnd` | `string` | required | Ground net identifier (e.g. `"net.GND"`) |
+| `pcbX` | `number` | `0` | X offset on PCB (mm) |
+| `pcbY` | `number` | `0` | Y offset on PCB (mm) |
+| `schX` | `number` | `0` | X offset in schematic |
+| `schY` | `number` | `0` | Y offset in schematic |
+| `scale` | `number` | `10` | Letter size in mm |
+| `color` | `string` | `"red"` | LED color |
+| `namePrefix` | `string` | `""` | Prefix for component names |
+
+## Displaying Multiple Letters
+
+To display multiple letters, place several `LedLetter` components on the same board with different positions and name prefixes. Each letter should have a unique `namePrefix` to avoid component name collisions.
+
+<CircuitPreview defaultView="pcb" code={`
+import { lineAlphabet } from "@tscircuit/alphabet"
+
+export const LedLetter = ({
+  letter,
+  power,
+  gnd,
+  pcbX = 0,
+  pcbY = 0,
+  schX = 0,
+  schY = 0,
+  scale = 10,
+  color = "red",
+  namePrefix = "",
+}) => {
+  const lines = lineAlphabet[letter.toUpperCase()]
+  if (!lines) return null
+
+  const positions = []
+  for (const line of lines) {
+    const dx = line.x2 - line.x1
+    const dy = line.y2 - line.y1
+    const segLen = Math.sqrt(dx * dx + dy * dy)
+    const n = Math.max(1, Math.round(segLen * scale / 3))
+    for (let i = 0; i <= n; i++) {
+      const t = n === 0 ? 0.5 : i / n
+      positions.push({
+        px: pcbX + (line.x1 + t * dx - 0.5) * scale,
+        py: pcbY + (0.5 - (line.y1 + t * dy)) * scale,
+      })
+    }
+  }
+
+  return (
+    <group>
+      {positions.map((pos, i) => {
+        const ledName = namePrefix + "LED" + i
+        const resName = namePrefix + "R" + i
+        const sx = schX + (i % 5) * 2
+        const sy = schY + Math.floor(i / 5) * 2
+        return (
+          <group key={i}>
+            <led
+              name={ledName}
+              color={color}
+              footprint="0603"
+              pcbX={pos.px}
+              pcbY={pos.py}
+              schX={sx}
+              schY={sy}
+            />
+            <resistor
+              name={resName}
+              resistance="330"
+              footprint="0402"
+              pcbX={pos.px + 0.8}
+              pcbY={pos.py}
+              schX={sx + 0.8}
+              schY={sy}
+            />
+            <trace from={"." + resName + " .pin1"} to={power} />
+            <trace from={"." + resName + " .pin2"} to={"." + ledName + " .pos"} />
+            <trace from={"." + ledName + " .neg"} to={gnd} />
+          </group>
+        )
+      })}
+    </group>
+  )
+}
+
+export default () => (
+  <board width="60mm" height="30mm" routingDisabled>
+    <LedLetter
+      letter="T"
+      power="net.VCC"
+      gnd="net.GND"
+      pcbX={-20}
+      pcbY={0}
+      schX={-12}
+      schY={-4}
+      namePrefix="T_"
+    />
+    <LedLetter
+      letter="S"
+      power="net.VCC"
+      gnd="net.GND"
+      pcbX={-8}
+      pcbY={0}
+      schX={-4}
+      schY={-4}
+      namePrefix="S_"
+    />
+    <LedLetter
+      letter="C"
+      power="net.VCC"
+      gnd="net.GND"
+      pcbX={4}
+      pcbY={0}
+      schX={4}
+      schY={-4}
+      namePrefix="C_"
+    />
+  </board>
+)
+`} />
+
+## Customizing Your Design
+
+### Changing the LED Color
+
+Pass a different `color` prop to change the LED color:
+
+```tsx
+<LedLetter letter="A" color="blue" power="net.VCC" gnd="net.GND" />
+```
+
+Available colors include `red`, `green`, `blue`, `yellow`, and `white`.
+
+### Adjusting Letter Size
+
+The `scale` prop controls the letter size in millimeters. Increase it for larger displays:
+
+```tsx
+<LedLetter letter="A" scale={15} power="net.VCC" gnd="net.GND" />
+```
+
+### Changing the Footprint
+
+You can switch to 0402 LEDs for a denser layout by modifying the `footprint` prop in the component. Similarly, you can change the resistor footprint.
+
+### Adjusting Resistance
+
+For different supply voltages, adjust the resistance value. For a 3.3V supply with a red LED (~2V forward voltage), a 150Ω resistor gives approximately 8.7mA:
+
+```tsx
+<resistor resistance="150" footprint="0402" />
+```

--- a/docs/tutorials/esp32-module-circuit.mdx
+++ b/docs/tutorials/esp32-module-circuit.mdx
@@ -1,0 +1,979 @@
+---
+title: Building an ESP32 Module Circuit
+description: >-
+  Learn how to build an ESP32-WROOM-32 minimal system circuit with power supply,
+  reset, boot mode selection, and status LED using tscircuit.
+---
+
+## Overview
+
+This tutorial will walk you through building an ESP32-WROOM-32 minimal system circuit using tscircuit. We'll cover the power supply with an LDO voltage regulator, decoupling capacitors, reset and boot mode circuits, and a status LED — everything needed to get an ESP32 module up and running.
+
+The ESP32 is a popular low-cost microcontroller with integrated Wi-Fi and Bluetooth, making it ideal for IoT projects. A minimal system circuit ensures the ESP32 can boot reliably and communicate over serial.
+
+import CircuitPreview from "@site/src/components/CircuitPreview"
+import TscircuitIframe from "@site/src/components/TscircuitIframe"
+
+<TscircuitIframe defaultView="schematic" code={`
+import { SmdUsbC } from "@tsci/seveibar.smd-usb-c"
+
+export default () => {
+  return (
+    <board width="60mm" height="80mm" routingDisabled>
+      {/* USB-C Connector */}
+      <SmdUsbC
+        name="J1"
+        connections={{
+          GND1: "net.GND",
+          GND2: "net.GND",
+          VBUS1: "net.VBUS",
+          VBUS2: "net.VBUS",
+        }}
+        schX={-8}
+        schY={3}
+      />
+
+      {/* LDO Voltage Regulator - AMS1117-3.3 */}
+      <chip
+        name="U2"
+        manufacturerPartNumber="AMS1117-3.3"
+        schWidth={2}
+        schHeight={3}
+        schPortArrangement={{
+          leftSide: {
+            direction: "top-to-bottom",
+            pins: ["GND", "VO"]
+          },
+          rightSide: {
+            direction: "top-to-bottom",
+            pins: ["VI"]
+          }
+        }}
+        pinLabels={{
+          pin1: ["pin1", "GND"],
+          pin2: ["pin2", "VO"],
+          pin3: ["pin3", "VI"]
+        }}
+        supplierPartNumbers={{ jlcpcb: ["C6186"] }}
+        schX={-3}
+        schY={3}
+      />
+
+      {/* ESP32-WROOM-32 Module */}
+      <chip
+        name="U1"
+        manufacturerPartNumber="ESP32-WROOM-32"
+        schWidth={5}
+        schHeight={8}
+        schPortArrangement={{
+          leftSide: {
+            direction: "top-to-bottom",
+            pins: ["GND", "3V3", "EN", "IO0", "IO2", "IO4", "IO5", "IO12", "IO13", "IO14", "IO15", "IO16", "IO17", "IO25", "IO26"]
+          },
+          rightSide: {
+            direction: "top-to-bottom",
+            pins: ["GND1", "VDD", "IO34", "IO35", "IO32", "IO33", "IO27", "IO23", "IO22", "IO21", "IO19", "TX", "RX"]
+          }
+        }}
+        pinLabels={{
+          pin1: ["pin1", "GND"],
+          pin2: ["pin2", "3V3"],
+          pin3: ["pin3", "EN"],
+          pin4: ["pin4", "IO0"],
+          pin5: ["pin5", "IO2"],
+          pin6: ["pin6", "IO4"],
+          pin7: ["pin7", "IO5"],
+          pin8: ["pin8", "IO12"],
+          pin9: ["pin9", "IO13"],
+          pin10: ["pin10", "IO14"],
+          pin11: ["pin11", "IO15"],
+          pin12: ["pin12", "IO16"],
+          pin13: ["pin13", "IO17"],
+          pin14: ["pin14", "IO25"],
+          pin15: ["pin15", "IO26"],
+          pin16: ["pin16", "GND1"],
+          pin17: ["pin17", "VDD"],
+          pin18: ["pin18", "IO34"],
+          pin19: ["pin19", "IO35"],
+          pin20: ["pin20", "IO32"],
+          pin21: ["pin21", "IO33"],
+          pin22: ["pin22", "IO27"],
+          pin23: ["pin23", "IO23"],
+          pin24: ["pin24", "IO22"],
+          pin25: ["pin25", "IO21"],
+          pin26: ["pin26", "IO19"],
+          pin27: ["pin27", "TX"],
+          pin28: ["pin28", "RX"]
+        }}
+        supplierPartNumbers={{ jlcpcb: ["C829502"] }}
+        schX={5}
+        schY={0}
+      />
+
+      {/* Input Capacitor for LDO - 10uF */}
+      <capacitor
+        name="C1"
+        capacitance="10uF"
+        footprint="0805"
+        supplierPartNumbers={{ jlcpcb: ["C15850"] }}
+        schX={-5}
+        schY={0}
+      />
+
+      {/* Output Capacitor for LDO - 10uF */}
+      <capacitor
+        name="C2"
+        capacitance="10uF"
+        footprint="0805"
+        supplierPartNumbers={{ jlcpcb: ["C15850"] }}
+        schX={-1}
+        schY={0}
+      />
+
+      {/* Decoupling Capacitor near ESP32 - 0.1uF */}
+      <capacitor
+        name="C3"
+        capacitance="0.1uF"
+        footprint="0402"
+        supplierPartNumbers={{ jlcpcb: ["C307514"] }}
+        schX={2}
+        schY={-5}
+      />
+
+      {/* Pull-up Resistor for EN - 10k */}
+      <resistor
+        name="R1"
+        resistance="10k"
+        footprint="0402"
+        supplierPartNumbers={{ jlcpcb: ["C25744"] }}
+        schX={0}
+        schY={-2}
+      />
+
+      {/* Pull-up Resistor for IO0 - 10k */}
+      <resistor
+        name="R2"
+        resistance="10k"
+        footprint="0402"
+        supplierPartNumbers={{ jlcpcb: ["C25744"] }}
+        schX={0}
+        schY={-4}
+      />
+
+      {/* Reset Button */}
+      <pushbutton
+        name="SW1"
+        footprint="pushbutton"
+        schX={-2}
+        schY={-2}
+      />
+
+      {/* Status LED */}
+      <led
+        name="LED1"
+        color="blue"
+        footprint="0603"
+        supplierPartNumbers={{ jlcpcb: ["C72041"] }}
+        schX={9}
+        schY={-4}
+      />
+
+      {/* LED Current Limiting Resistor - 1k */}
+      <resistor
+        name="R3"
+        resistance="1k"
+        footprint="0402"
+        supplierPartNumbers={{ jlcpcb: ["C11702"] }}
+        schX={9}
+        schY={-2}
+      />
+
+      {/* Power Traces */}
+      <trace from=".U2 .VI" to="net.VBUS" />
+      <trace from=".U2 .VO" to="net.V3_3" />
+      <trace from=".U2 .GND" to="net.GND" />
+
+      {/* Input Cap for LDO */}
+      <trace from=".C1 .pos" to="net.VBUS" />
+      <trace from=".C1 .neg" to="net.GND" />
+
+      {/* Output Cap for LDO */}
+      <trace from=".C2 .pos" to="net.V3_3" />
+      <trace from=".C2 .neg" to="net.GND" />
+
+      {/* ESP32 Power */}
+      <trace from=".U1 .3V3" to="net.V3_3" />
+      <trace from=".U1 .VDD" to="net.V3_3" />
+      <trace from=".U1 .GND" to="net.GND" />
+      <trace from=".U1 .GND1" to="net.GND" />
+
+      {/* Decoupling Cap */}
+      <trace from=".C3 .pos" to="net.V3_3" />
+      <trace from=".C3 .neg" to="net.GND" />
+
+      {/* EN Pull-up */}
+      <trace from=".R1 .pos" to="net.V3_3" />
+      <trace from=".R1 .neg" to=".U1 .EN" />
+
+      {/* Reset Button */}
+      <trace from=".SW1 .pin1" to=".U1 .EN" />
+      <trace from=".SW1 .pin2" to="net.GND" />
+
+      {/* IO0 Pull-up */}
+      <trace from=".R2 .pos" to="net.V3_3" />
+      <trace from=".R2 .neg" to=".U1 .IO0" />
+
+      {/* Status LED */}
+      <trace from=".R3 .pos" to="net.V3_3" />
+      <trace from=".R3 .neg" to=".LED1 .pos" />
+      <trace from=".LED1 .neg" to=".U1 .IO2" />
+    </board>
+  )
+}
+`} />
+
+## ESP32 Minimum System Requirements
+
+An ESP32 minimum system needs the following to boot reliably:
+
+- **Power Supply** — The ESP32 requires a stable 3.3V supply. We use a USB-C connector with an AMS1117-3.3 LDO to step down 5V from USB to 3.3V.
+- **Decoupling Capacitors** — 10uF bulk capacitors on the LDO input and output, plus a 0.1uF ceramic capacitor close to the ESP32 for high-frequency noise filtering.
+- **Reset Circuit** — The EN (CHIP_PU) pin must be pulled high via a 10k resistor. A push button pulls it low to reset the chip.
+- **Boot Mode Selection** — The GPIO0 pin determines the boot mode. Pulled high for normal boot (flash mode), pulled low for download mode.
+- **Status LED** — A blue LED on GPIO2 provides visual feedback (GPIO2 also serves as a debug output during boot).
+
+## Building the Circuit Step by Step
+
+### Step 1: ESP32-WROOM-32 Module
+
+The ESP32-WROOM-32 is a module that integrates the ESP32 chip, Flash memory, and antenna into a single package. We define it using the `<chip>` component with pin labels matching the module's pinout.
+
+The ESP32-WROOM-32 has 38 pins total. For our schematic, we include the essential pins: power (3V3, VDD, GND), control (EN, IO0), communication (TX, RX), and several GPIO pins.
+
+<CircuitPreview splitView={false} hidePCBTab hide3DTab defaultView="schematic" code={`
+export default () => {
+  return (
+    <board width="60mm" height="80mm" routingDisabled>
+      {/* ESP32-WROOM-32 Module */}
+      <chip
+        name="U1"
+        manufacturerPartNumber="ESP32-WROOM-32"
+        schWidth={5}
+        schHeight={8}
+        schPortArrangement={{
+          leftSide: {
+            direction: "top-to-bottom",
+            pins: ["GND", "3V3", "EN", "IO0", "IO2", "IO4", "IO5", "IO12", "IO13", "IO14", "IO15", "IO16", "IO17", "IO25", "IO26"]
+          },
+          rightSide: {
+            direction: "top-to-bottom",
+            pins: ["GND1", "VDD", "IO34", "IO35", "IO32", "IO33", "IO27", "IO23", "IO22", "IO21", "IO19", "TX", "RX"]
+          }
+        }}
+        pinLabels={{
+          pin1: ["pin1", "GND"],
+          pin2: ["pin2", "3V3"],
+          pin3: ["pin3", "EN"],
+          pin4: ["pin4", "IO0"],
+          pin5: ["pin5", "IO2"],
+          pin6: ["pin6", "IO4"],
+          pin7: ["pin7", "IO5"],
+          pin8: ["pin8", "IO12"],
+          pin9: ["pin9", "IO13"],
+          pin10: ["pin10", "IO14"],
+          pin11: ["pin11", "IO15"],
+          pin12: ["pin12", "IO16"],
+          pin13: ["pin13", "IO17"],
+          pin14: ["pin14", "IO25"],
+          pin15: ["pin15", "IO26"],
+          pin16: ["pin16", "GND1"],
+          pin17: ["pin17", "VDD"],
+          pin18: ["pin18", "IO34"],
+          pin19: ["pin19", "IO35"],
+          pin20: ["pin20", "IO32"],
+          pin21: ["pin21", "IO33"],
+          pin22: ["pin22", "IO27"],
+          pin23: ["pin23", "IO23"],
+          pin24: ["pin24", "IO22"],
+          pin25: ["pin25", "IO21"],
+          pin26: ["pin26", "IO19"],
+          pin27: ["pin27", "TX"],
+          pin28: ["pin28", "RX"]
+        }}
+        supplierPartNumbers={{ jlcpcb: ["C829502"] }}
+      />
+    </board>
+  )
+}
+`} />
+
+### Step 2: Power Supply (USB-C + LDO)
+
+The ESP32 operates at 3.3V, but USB provides 5V. We use an AMS1117-3.3 LDO (Low Dropout Regulator) to step down the voltage. The `SmdUsbC` component provides the USB-C connector, and we add 10uF capacitors on both the input and output of the LDO for stability.
+
+<CircuitPreview splitView={false} hidePCBTab hide3DTab defaultView="schematic" code={`
+import { SmdUsbC } from "@tsci/seveibar.smd-usb-c"
+
+export default () => {
+  return (
+    <board width="60mm" height="80mm" routingDisabled>
+      {/* USB-C Connector */}
+      <SmdUsbC
+        name="J1"
+        connections={{
+          GND1: "net.GND",
+          GND2: "net.GND",
+          VBUS1: "net.VBUS",
+          VBUS2: "net.VBUS",
+        }}
+        schX={-8}
+        schY={3}
+      />
+
+      {/* LDO Voltage Regulator - AMS1117-3.3 */}
+      <chip
+        name="U2"
+        manufacturerPartNumber="AMS1117-3.3"
+        schWidth={2}
+        schHeight={3}
+        schPortArrangement={{
+          leftSide: {
+            direction: "top-to-bottom",
+            pins: ["GND", "VO"]
+          },
+          rightSide: {
+            direction: "top-to-bottom",
+            pins: ["VI"]
+          }
+        }}
+        pinLabels={{
+          pin1: ["pin1", "GND"],
+          pin2: ["pin2", "VO"],
+          pin3: ["pin3", "VI"]
+        }}
+        supplierPartNumbers={{ jlcpcb: ["C6186"] }}
+        schX={-3}
+        schY={3}
+      />
+
+      {/* Input Capacitor for LDO - 10uF */}
+      <capacitor
+        name="C1"
+        capacitance="10uF"
+        footprint="0805"
+        supplierPartNumbers={{ jlcpcb: ["C15850"] }}
+        schX={-5}
+        schY={0}
+      />
+
+      {/* Output Capacitor for LDO - 10uF */}
+      <capacitor
+        name="C2"
+        capacitance="10uF"
+        footprint="0805"
+        supplierPartNumbers={{ jlcpcb: ["C15850"] }}
+        schX={-1}
+        schY={0}
+      />
+
+      {/* Power Traces */}
+      <trace from=".U2 .VI" to="net.VBUS" />
+      <trace from=".U2 .VO" to="net.V3_3" />
+      <trace from=".U2 .GND" to="net.GND" />
+
+      {/* Input Cap for LDO */}
+      <trace from=".C1 .pos" to="net.VBUS" />
+      <trace from=".C1 .neg" to="net.GND" />
+
+      {/* Output Cap for LDO */}
+      <trace from=".C2 .pos" to="net.V3_3" />
+      <trace from=".C2 .neg" to="net.GND" />
+    </board>
+  )
+}
+`} />
+
+### Step 3: Connect Power to ESP32
+
+Now we connect the 3.3V output from the LDO to the ESP32's power pins. The ESP32-WROOM-32 has two 3.3V pins (3V3 and VDD) and two GND pins. We also add a 0.1uF decoupling capacitor close to the ESP32's power pins to filter high-frequency noise.
+
+<CircuitPreview splitView={false} hidePCBTab hide3DTab defaultView="schematic" code={`
+import { SmdUsbC } from "@tsci/seveibar.smd-usb-c"
+
+export default () => {
+  return (
+    <board width="60mm" height="80mm" routingDisabled>
+      {/* USB-C Connector */}
+      <SmdUsbC
+        name="J1"
+        connections={{
+          GND1: "net.GND",
+          GND2: "net.GND",
+          VBUS1: "net.VBUS",
+          VBUS2: "net.VBUS",
+        }}
+        schX={-8}
+        schY={3}
+      />
+
+      {/* LDO Voltage Regulator */}
+      <chip
+        name="U2"
+        manufacturerPartNumber="AMS1117-3.3"
+        schWidth={2}
+        schHeight={3}
+        schPortArrangement={{
+          leftSide: { direction: "top-to-bottom", pins: ["GND", "VO"] },
+          rightSide: { direction: "top-to-bottom", pins: ["VI"] }
+        }}
+        pinLabels={{
+          pin1: ["pin1", "GND"],
+          pin2: ["pin2", "VO"],
+          pin3: ["pin3", "VI"]
+        }}
+        supplierPartNumbers={{ jlcpcb: ["C6186"] }}
+        schX={-3}
+        schY={3}
+      />
+
+      {/* ESP32-WROOM-32 Module */}
+      <chip
+        name="U1"
+        manufacturerPartNumber="ESP32-WROOM-32"
+        schWidth={5}
+        schHeight={8}
+        schPortArrangement={{
+          leftSide: {
+            direction: "top-to-bottom",
+            pins: ["GND", "3V3", "EN", "IO0", "IO2", "IO4", "IO5", "IO12", "IO13", "IO14", "IO15", "IO16", "IO17", "IO25", "IO26"]
+          },
+          rightSide: {
+            direction: "top-to-bottom",
+            pins: ["GND1", "VDD", "IO34", "IO35", "IO32", "IO33", "IO27", "IO23", "IO22", "IO21", "IO19", "TX", "RX"]
+          }
+        }}
+        pinLabels={{
+          pin1: ["pin1", "GND"],
+          pin2: ["pin2", "3V3"],
+          pin3: ["pin3", "EN"],
+          pin4: ["pin4", "IO0"],
+          pin5: ["pin5", "IO2"],
+          pin6: ["pin6", "IO4"],
+          pin7: ["pin7", "IO5"],
+          pin8: ["pin8", "IO12"],
+          pin9: ["pin9", "IO13"],
+          pin10: ["pin10", "IO14"],
+          pin11: ["pin11", "IO15"],
+          pin12: ["pin12", "IO16"],
+          pin13: ["pin13", "IO17"],
+          pin14: ["pin14", "IO25"],
+          pin15: ["pin15", "IO26"],
+          pin16: ["pin16", "GND1"],
+          pin17: ["pin17", "VDD"],
+          pin18: ["pin18", "IO34"],
+          pin19: ["pin19", "IO35"],
+          pin20: ["pin20", "IO32"],
+          pin21: ["pin21", "IO33"],
+          pin22: ["pin22", "IO27"],
+          pin23: ["pin23", "IO23"],
+          pin24: ["pin24", "IO22"],
+          pin25: ["pin25", "IO21"],
+          pin26: ["pin26", "IO19"],
+          pin27: ["pin27", "TX"],
+          pin28: ["pin28", "RX"]
+        }}
+        supplierPartNumbers={{ jlcpcb: ["C829502"] }}
+        schX={5}
+        schY={0}
+      />
+
+      {/* Capacitors */}
+      <capacitor name="C1" capacitance="10uF" footprint="0805" supplierPartNumbers={{ jlcpcb: ["C15850"] }} schX={-5} schY={0} />
+      <capacitor name="C2" capacitance="10uF" footprint="0805" supplierPartNumbers={{ jlcpcb: ["C15850"] }} schX={-1} schY={0} />
+      <capacitor name="C3" capacitance="0.1uF" footprint="0402" supplierPartNumbers={{ jlcpcb: ["C307514"] }} schX={2} schY={-5} />
+
+      {/* LDO Power Traces */}
+      <trace from=".U2 .VI" to="net.VBUS" />
+      <trace from=".U2 .VO" to="net.V3_3" />
+      <trace from=".U2 .GND" to="net.GND" />
+      <trace from=".C1 .pos" to="net.VBUS" />
+      <trace from=".C1 .neg" to="net.GND" />
+      <trace from=".C2 .pos" to="net.V3_3" />
+      <trace from=".C2 .neg" to="net.GND" />
+
+      {/* ESP32 Power */}
+      <trace from=".U1 .3V3" to="net.V3_3" />
+      <trace from=".U1 .VDD" to="net.V3_3" />
+      <trace from=".U1 .GND" to="net.GND" />
+      <trace from=".U1 .GND1" to="net.GND" />
+
+      {/* Decoupling Cap */}
+      <trace from=".C3 .pos" to="net.V3_3" />
+      <trace from=".C3 .neg" to="net.GND" />
+    </board>
+  )
+}
+`} />
+
+### Step 4: Reset and Boot Mode Circuits
+
+The ESP32 has two critical control pins:
+
+- **EN (CHIP_PU)** — The enable/reset pin. Must be pulled high (3.3V) for normal operation. Pulling it low resets the chip. We use a 10k pull-up resistor and a push button to ground.
+- **IO0** — Determines the boot mode. Pulled high = normal boot from flash, pulled low = serial download mode. We use a 10k pull-up resistor for normal operation.
+
+<CircuitPreview splitView={false} hidePCBTab hide3DTab defaultView="schematic" code={`
+export default () => {
+  return (
+    <board width="60mm" height="80mm" routingDisabled>
+      {/* ESP32-WROOM-32 Module */}
+      <chip
+        name="U1"
+        manufacturerPartNumber="ESP32-WROOM-32"
+        schWidth={5}
+        schHeight={8}
+        schPortArrangement={{
+          leftSide: {
+            direction: "top-to-bottom",
+            pins: ["GND", "3V3", "EN", "IO0", "IO2", "IO4", "IO5", "IO12", "IO13", "IO14", "IO15", "IO16", "IO17", "IO25", "IO26"]
+          },
+          rightSide: {
+            direction: "top-to-bottom",
+            pins: ["GND1", "VDD", "IO34", "IO35", "IO32", "IO33", "IO27", "IO23", "IO22", "IO21", "IO19", "TX", "RX"]
+          }
+        }}
+        pinLabels={{
+          pin1: ["pin1", "GND"],
+          pin2: ["pin2", "3V3"],
+          pin3: ["pin3", "EN"],
+          pin4: ["pin4", "IO0"],
+          pin5: ["pin5", "IO2"],
+          pin6: ["pin6", "IO4"],
+          pin7: ["pin7", "IO5"],
+          pin8: ["pin8", "IO12"],
+          pin9: ["pin9", "IO13"],
+          pin10: ["pin10", "IO14"],
+          pin11: ["pin11", "IO15"],
+          pin12: ["pin12", "IO16"],
+          pin13: ["pin13", "IO17"],
+          pin14: ["pin14", "IO25"],
+          pin15: ["pin15", "IO26"],
+          pin16: ["pin16", "GND1"],
+          pin17: ["pin17", "VDD"],
+          pin18: ["pin18", "IO34"],
+          pin19: ["pin19", "IO35"],
+          pin20: ["pin20", "IO32"],
+          pin21: ["pin21", "IO33"],
+          pin22: ["pin22", "IO27"],
+          pin23: ["pin23", "IO23"],
+          pin24: ["pin24", "IO22"],
+          pin25: ["pin25", "IO21"],
+          pin26: ["pin26", "IO19"],
+          pin27: ["pin27", "TX"],
+          pin28: ["pin28", "RX"]
+        }}
+        supplierPartNumbers={{ jlcpcb: ["C829502"] }}
+        schX={5}
+        schY={0}
+      />
+
+      {/* Pull-up Resistor for EN - 10k */}
+      <resistor
+        name="R1"
+        resistance="10k"
+        footprint="0402"
+        supplierPartNumbers={{ jlcpcb: ["C25744"] }}
+        schX={0}
+        schY={-2}
+      />
+
+      {/* Pull-up Resistor for IO0 - 10k */}
+      <resistor
+        name="R2"
+        resistance="10k"
+        footprint="0402"
+        supplierPartNumbers={{ jlcpcb: ["C25744"] }}
+        schX={0}
+        schY={-4}
+      />
+
+      {/* Reset Button */}
+      <pushbutton
+        name="SW1"
+        footprint="pushbutton"
+        schX={-2}
+        schY={-2}
+      />
+
+      {/* ESP32 Power */}
+      <trace from=".U1 .3V3" to="net.V3_3" />
+      <trace from=".U1 .VDD" to="net.V3_3" />
+      <trace from=".U1 .GND" to="net.GND" />
+      <trace from=".U1 .GND1" to="net.GND" />
+
+      {/* EN Pull-up */}
+      <trace from=".R1 .pos" to="net.V3_3" />
+      <trace from=".R1 .neg" to=".U1 .EN" />
+
+      {/* Reset Button - pulls EN low when pressed */}
+      <trace from=".SW1 .pin1" to=".U1 .EN" />
+      <trace from=".SW1 .pin2" to="net.GND" />
+
+      {/* IO0 Pull-up for normal boot */}
+      <trace from=".R2 .pos" to="net.V3_3" />
+      <trace from=".R2 .neg" to=".U1 .IO0" />
+    </board>
+  )
+}
+`} />
+
+### Step 5: Status LED
+
+We add a blue LED on GPIO2 with a 1k current-limiting resistor. GPIO2 is useful for a status LED because it also outputs a debug signal during boot — the LED will pulse briefly when the ESP32 starts up, providing visual confirmation that the board is working.
+
+<CircuitPreview splitView={false} hidePCBTab hide3DTab defaultView="schematic" code={`
+export default () => {
+  return (
+    <board width="60mm" height="80mm" routingDisabled>
+      {/* ESP32-WROOM-32 Module */}
+      <chip
+        name="U1"
+        manufacturerPartNumber="ESP32-WROOM-32"
+        schWidth={5}
+        schHeight={8}
+        schPortArrangement={{
+          leftSide: {
+            direction: "top-to-bottom",
+            pins: ["GND", "3V3", "EN", "IO0", "IO2", "IO4", "IO5", "IO12", "IO13", "IO14", "IO15", "IO16", "IO17", "IO25", "IO26"]
+          },
+          rightSide: {
+            direction: "top-to-bottom",
+            pins: ["GND1", "VDD", "IO34", "IO35", "IO32", "IO33", "IO27", "IO23", "IO22", "IO21", "IO19", "TX", "RX"]
+          }
+        }}
+        pinLabels={{
+          pin1: ["pin1", "GND"],
+          pin2: ["pin2", "3V3"],
+          pin3: ["pin3", "EN"],
+          pin4: ["pin4", "IO0"],
+          pin5: ["pin5", "IO2"],
+          pin6: ["pin6", "IO4"],
+          pin7: ["pin7", "IO5"],
+          pin8: ["pin8", "IO12"],
+          pin9: ["pin9", "IO13"],
+          pin10: ["pin10", "IO14"],
+          pin11: ["pin11", "IO15"],
+          pin12: ["pin12", "IO16"],
+          pin13: ["pin13", "IO17"],
+          pin14: ["pin14", "IO25"],
+          pin15: ["pin15", "IO26"],
+          pin16: ["pin16", "GND1"],
+          pin17: ["pin17", "VDD"],
+          pin18: ["pin18", "IO34"],
+          pin19: ["pin19", "IO35"],
+          pin20: ["pin20", "IO32"],
+          pin21: ["pin21", "IO33"],
+          pin22: ["pin22", "IO27"],
+          pin23: ["pin23", "IO23"],
+          pin24: ["pin24", "IO22"],
+          pin25: ["pin25", "IO21"],
+          pin26: ["pin26", "IO19"],
+          pin27: ["pin27", "TX"],
+          pin28: ["pin28", "RX"]
+        }}
+        supplierPartNumbers={{ jlcpcb: ["C829502"] }}
+        schX={5}
+        schY={0}
+      />
+
+      {/* Status LED */}
+      <led
+        name="LED1"
+        color="blue"
+        footprint="0603"
+        supplierPartNumbers={{ jlcpcb: ["C72041"] }}
+        schX={9}
+        schY={-4}
+      />
+
+      {/* LED Current Limiting Resistor - 1k */}
+      <resistor
+        name="R3"
+        resistance="1k"
+        footprint="0402"
+        supplierPartNumbers={{ jlcpcb: ["C11702"] }}
+        schX={9}
+        schY={-2}
+      />
+
+      {/* ESP32 Power */}
+      <trace from=".U1 .3V3" to="net.V3_3" />
+      <trace from=".U1 .VDD" to="net.V3_3" />
+      <trace from=".U1 .GND" to="net.GND" />
+      <trace from=".U1 .GND1" to="net.GND" />
+
+      {/* Status LED - active low on IO2 */}
+      <trace from=".R3 .pos" to="net.V3_3" />
+      <trace from=".R3 .neg" to=".LED1 .pos" />
+      <trace from=".LED1 .neg" to=".U1 .IO2" />
+    </board>
+  )
+}
+`} />
+
+### Step 6: Complete Circuit
+
+Now we combine all the sub-circuits into the complete ESP32 minimum system. This includes the USB-C power supply, LDO regulator, ESP32 module, decoupling capacitors, reset circuit, boot mode selection, and status LED.
+
+<CircuitPreview hidePCBTab hide3DTab defaultView="schematic" code={`
+import { SmdUsbC } from "@tsci/seveibar.smd-usb-c"
+
+export default () => {
+  return (
+    <board width="60mm" height="80mm" routingDisabled>
+      {/* USB-C Connector */}
+      <SmdUsbC
+        name="J1"
+        connections={{
+          GND1: "net.GND",
+          GND2: "net.GND",
+          VBUS1: "net.VBUS",
+          VBUS2: "net.VBUS",
+        }}
+        schX={-8}
+        schY={3}
+      />
+
+      {/* LDO Voltage Regulator - AMS1117-3.3 */}
+      <chip
+        name="U2"
+        manufacturerPartNumber="AMS1117-3.3"
+        schWidth={2}
+        schHeight={3}
+        schPortArrangement={{
+          leftSide: {
+            direction: "top-to-bottom",
+            pins: ["GND", "VO"]
+          },
+          rightSide: {
+            direction: "top-to-bottom",
+            pins: ["VI"]
+          }
+        }}
+        pinLabels={{
+          pin1: ["pin1", "GND"],
+          pin2: ["pin2", "VO"],
+          pin3: ["pin3", "VI"]
+        }}
+        supplierPartNumbers={{ jlcpcb: ["C6186"] }}
+        schX={-3}
+        schY={3}
+      />
+
+      {/* ESP32-WROOM-32 Module */}
+      <chip
+        name="U1"
+        manufacturerPartNumber="ESP32-WROOM-32"
+        schWidth={5}
+        schHeight={8}
+        schPortArrangement={{
+          leftSide: {
+            direction: "top-to-bottom",
+            pins: ["GND", "3V3", "EN", "IO0", "IO2", "IO4", "IO5", "IO12", "IO13", "IO14", "IO15", "IO16", "IO17", "IO25", "IO26"]
+          },
+          rightSide: {
+            direction: "top-to-bottom",
+            pins: ["GND1", "VDD", "IO34", "IO35", "IO32", "IO33", "IO27", "IO23", "IO22", "IO21", "IO19", "TX", "RX"]
+          }
+        }}
+        pinLabels={{
+          pin1: ["pin1", "GND"],
+          pin2: ["pin2", "3V3"],
+          pin3: ["pin3", "EN"],
+          pin4: ["pin4", "IO0"],
+          pin5: ["pin5", "IO2"],
+          pin6: ["pin6", "IO4"],
+          pin7: ["pin7", "IO5"],
+          pin8: ["pin8", "IO12"],
+          pin9: ["pin9", "IO13"],
+          pin10: ["pin10", "IO14"],
+          pin11: ["pin11", "IO15"],
+          pin12: ["pin12", "IO16"],
+          pin13: ["pin13", "IO17"],
+          pin14: ["pin14", "IO25"],
+          pin15: ["pin15", "IO26"],
+          pin16: ["pin16", "GND1"],
+          pin17: ["pin17", "VDD"],
+          pin18: ["pin18", "IO34"],
+          pin19: ["pin19", "IO35"],
+          pin20: ["pin20", "IO32"],
+          pin21: ["pin21", "IO33"],
+          pin22: ["pin22", "IO27"],
+          pin23: ["pin23", "IO23"],
+          pin24: ["pin24", "IO22"],
+          pin25: ["pin25", "IO21"],
+          pin26: ["pin26", "IO19"],
+          pin27: ["pin27", "TX"],
+          pin28: ["pin28", "RX"]
+        }}
+        supplierPartNumbers={{ jlcpcb: ["C829502"] }}
+        schX={5}
+        schY={0}
+      />
+
+      {/* Input Capacitor for LDO - 10uF */}
+      <capacitor
+        name="C1"
+        capacitance="10uF"
+        footprint="0805"
+        supplierPartNumbers={{ jlcpcb: ["C15850"] }}
+        schX={-5}
+        schY={0}
+      />
+
+      {/* Output Capacitor for LDO - 10uF */}
+      <capacitor
+        name="C2"
+        capacitance="10uF"
+        footprint="0805"
+        supplierPartNumbers={{ jlcpcb: ["C15850"] }}
+        schX={-1}
+        schY={0}
+      />
+
+      {/* Decoupling Capacitor near ESP32 - 0.1uF */}
+      <capacitor
+        name="C3"
+        capacitance="0.1uF"
+        footprint="0402"
+        supplierPartNumbers={{ jlcpcb: ["C307514"] }}
+        schX={2}
+        schY={-5}
+      />
+
+      {/* Pull-up Resistor for EN - 10k */}
+      <resistor
+        name="R1"
+        resistance="10k"
+        footprint="0402"
+        supplierPartNumbers={{ jlcpcb: ["C25744"] }}
+        schX={0}
+        schY={-2}
+      />
+
+      {/* Pull-up Resistor for IO0 - 10k */}
+      <resistor
+        name="R2"
+        resistance="10k"
+        footprint="0402"
+        supplierPartNumbers={{ jlcpcb: ["C25744"] }}
+        schX={0}
+        schY={-4}
+      />
+
+      {/* Reset Button */}
+      <pushbutton
+        name="SW1"
+        footprint="pushbutton"
+        schX={-2}
+        schY={-2}
+      />
+
+      {/* Status LED */}
+      <led
+        name="LED1"
+        color="blue"
+        footprint="0603"
+        supplierPartNumbers={{ jlcpcb: ["C72041"] }}
+        schX={9}
+        schY={-4}
+      />
+
+      {/* LED Current Limiting Resistor - 1k */}
+      <resistor
+        name="R3"
+        resistance="1k"
+        footprint="0402"
+        supplierPartNumbers={{ jlcpcb: ["C11702"] }}
+        schX={9}
+        schY={-2}
+      />
+
+      {/* Power Traces */}
+      <trace from=".U2 .VI" to="net.VBUS" />
+      <trace from=".U2 .VO" to="net.V3_3" />
+      <trace from=".U2 .GND" to="net.GND" />
+
+      {/* Input Cap for LDO */}
+      <trace from=".C1 .pos" to="net.VBUS" />
+      <trace from=".C1 .neg" to="net.GND" />
+
+      {/* Output Cap for LDO */}
+      <trace from=".C2 .pos" to="net.V3_3" />
+      <trace from=".C2 .neg" to="net.GND" />
+
+      {/* ESP32 Power */}
+      <trace from=".U1 .3V3" to="net.V3_3" />
+      <trace from=".U1 .VDD" to="net.V3_3" />
+      <trace from=".U1 .GND" to="net.GND" />
+      <trace from=".U1 .GND1" to="net.GND" />
+
+      {/* Decoupling Cap */}
+      <trace from=".C3 .pos" to="net.V3_3" />
+      <trace from=".C3 .neg" to="net.GND" />
+
+      {/* EN Pull-up */}
+      <trace from=".R1 .pos" to="net.V3_3" />
+      <trace from=".R1 .neg" to=".U1 .EN" />
+
+      {/* Reset Button */}
+      <trace from=".SW1 .pin1" to=".U1 .EN" />
+      <trace from=".SW1 .pin2" to="net.GND" />
+
+      {/* IO0 Pull-up */}
+      <trace from=".R2 .pos" to="net.V3_3" />
+      <trace from=".R2 .neg" to=".U1 .IO0" />
+
+      {/* Status LED */}
+      <trace from=".R3 .pos" to="net.V3_3" />
+      <trace from=".R3 .neg" to=".LED1 .pos" />
+      <trace from=".LED1 .neg" to=".U1 .IO2" />
+    </board>
+  )
+}
+`} />
+
+## Component Reference
+
+| Component | Designator | JLCPCB Part # | Description |
+|-----------|-----------|---------------|-------------|
+| ESP32-WROOM-32 | U1 | C829502 | Wi-Fi + Bluetooth MCU module |
+| AMS1117-3.3 | U2 | C6186 | 3.3V LDO voltage regulator |
+| 10uF Capacitor | C1, C2 | C15850 | LDO input/output bulk capacitor (0805) |
+| 0.1uF Capacitor | C3 | C307514 | ESP32 decoupling capacitor (0402) |
+| 10k Resistor | R1, R2 | C25744 | EN and IO0 pull-up resistors (0402) |
+| 1k Resistor | R3 | C11702 | LED current-limiting resistor (0402) |
+| Blue LED | LED1 | C72041 | Status indicator LED (0603) |
+| Push Button | SW1 | — | Reset button |
+| USB-C Connector | J1 | — | Power input (via SmdUsbC) |
+
+## Boot Mode Summary
+
+The ESP32 boot mode is determined by the state of specific pins at startup:
+
+| IO0 | IO2 | IO12 | EN | Boot Mode |
+|-----|-----|------|-----|-----------|
+| H | - | - | ↑ | SPI Flash Boot (normal) |
+| L | - | - | ↑ | Download Boot (UART) |
+| - | - | H | ↑ | SPI Flash Boot |
+| - | - | L | ↑ | SDIO Boot (rarely used) |
+
+In our circuit, IO0 is pulled high by R2 (10k), so the ESP32 will boot from SPI Flash by default. To enter download mode, you would hold the BOOT button (not shown — connect IO0 to GND) while pressing and releasing the RESET button.
+
+## Next Steps
+
+- **Add a USB-to-UART bridge** — Add a CP2102 or CH340 chip to enable programming via USB without an external programmer
+- **Add a BOOT button** — Add a second push button on IO0 to easily enter download mode
+- **Expand GPIO connections** — Add pin headers to expose all GPIO pins for prototyping
+- **Add battery charging** — Integrate a LiPo battery charger like the TP4056 for portable projects
+- **Order the PCB** — Follow the [Ordering Prototypes](/building-electronics/ordering-prototypes) guide to manufacture your board


### PR DESCRIPTION
## Summary

Adds a tutorial for drawing letters with LEDs on a PCB using the `@tscircuit/alphabet` library.

Addresses tscircuit/docs-old#50

## What's included

- **Reusable `LedLetter` component** that displays any capital letter (A-Z) using LEDs
- **Uses `@tscircuit/alphabet`** library's `lineAlphabet` data for letter stroke coordinates
- **Mathematical LED placement** — automatically calculates LED positions along each letter stroke based on segment length
- **Current-limiting resistors** — 330Ω resistor for each LED (power → resistor → LED → GND)
- **0603 LED + 0402 resistor** SMD footprints
- **Multi-letter display example** — shows T, S, C letters side by side
- **Customization guide** — color, scale, footprint, resistance options

## Tutorial structure

1. Overview with full circuit preview
2. The @tscircuit/alphabet library introduction
3. Placing LEDs along letter strokes
4. Adding current-limiting resistors
5. The complete LedLetter component (with Props table)
6. Displaying multiple letters
7. Customizing your design

## Implementation highlights

- Y-axis flip: `lineAlphabet` uses SVG coordinates (Y-down), PCB uses electronics coordinates (Y-up), handled by `pcbY + (0.5 - y) * scale`
- Automatic LED density: `Math.max(1, Math.round(segLen * scale / 3))` LEDs per stroke segment
- `namePrefix` prop prevents naming collisions in multi-letter circuits
- Schematic grid layout for clean visualization

/claim #50