### PR TITLE
fix: rename 'Use Online' to 'Try Online' and point to editor

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -179,8 +179,8 @@ const config: Config = {
         },
         { to: "https://blog.tscircuit.com", label: "Blog", position: "left" },
         {
-          to: "https://tscircuit.com",
-          label: "Use Online",
+          to: "https://tscircuit.com/editor",
+          label: "Try Online",
           position: "left",
         },
 


### PR DESCRIPTION
Claims tscircuit/docs-old#67

/claim #67

## Summary
- Renamed the navbar link from "Use Online" to "Try Online"
- Changed the URL from `tscircuit.com` to `tscircuit.com/editor` so users land directly in the editor

This addresses the bounty request to update the "Find Packages" link to say "Try Online" and navigate to the tscircuit editor.