### PR TITLE
fix: properly center docs content like Bun docs

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -851,11 +851,18 @@ article h4 {
   display: none !important;
 }
 
-/* Force center all documentation content */
+/* Fix docs centering - properly center content like Bun docs */
+main[class*="docMainContainer"] [class*="container"] {
+  max-width: 100% !important;
+  padding-left: 2rem !important;
+  padding-right: 2rem !important;
+}
+
 .col:not(.col--3) {
-  max-width: 1000px !important;
+  max-width: 800px !important;
   margin-left: auto !important;
   margin-right: auto !important;
+  float: none !important;
 }
 
 /* Force section overview to center - using stable attribute selector */
@@ -1060,7 +1067,7 @@ nav.pagination-nav .pagination-nav__link *:last-child {
 
 article,
 .markdown {
-  max-width: 100% !important;
+  max-width: 800px !important;
   padding-left: 2rem !important;
   padding-right: 2rem !important;
 }


### PR DESCRIPTION
Claims tscircuit/docs-old#64

/claim #64

## Summary
- Set doc content max-width to 800px (matching Bun docs style for better readability)
- Make the container full-width to allow proper centering
- Add auto margins and float:none for reliable centering
- Change article/markdown max-width from 100% to 800px

The docs were previously not properly centered compared to other documentation sites like Bun. The content was too wide and not centered on the page. This fix makes the content area narrower and properly centered, improving readability.