### PR TITLE
docs: expand contribution repo overview

### DIFF
--- a/docs/contributing/overview-of-projects.md
+++ b/docs/contributing/overview-of-projects.md
@@ -1,20 +1,81 @@
 ---
 title: Overview of Projects
 sidebar_position: 2
-description: Explore the key tscircuit repositories including core libraries, tools, and web components that power the ecosystem.
+description: Pick the right tscircuit repository for core libraries, tooling, viewers, converters, docs, and web app contributions.
 ---
 
-| Repo                                                                          | Description                                                                                    | Open Issues                                                                                                                                 |
-| ----------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
-| [tscircuit/core](https://github.com/tscircuit/core)                           | Core library that powers tscircuit, handles conversion of React components into circuit boards | [![GitHub issues](https://img.shields.io/github/issues/tscircuit/core)](https://github.com/tscircuit/core/issues)                           |
-| [tscircuit/schematic-symbols](https://github.com/tscircuit/schematic-symbols) | Library of schematic symbols used across tscircuit                                             | [![GitHub issues](https://img.shields.io/github/issues/tscircuit/schematic-symbols)](https://github.com/tscircuit/schematic-symbols/issues) |
-| [tscircuit/footprinter](https://github.com/tscircuit/footprinter)             | Generates PCB footprints from string descriptions                                              | [![GitHub issues](https://img.shields.io/github/issues/tscircuit/footprinter)](https://github.com/tscircuit/footprinter/issues)             |
-| [tscircuit/circuit-to-svg](https://github.com/tscircuit/circuit-to-svg)       | Converts Circuit JSON into SVG files                                                           | [![GitHub issues](https://img.shields.io/github/issues/tscircuit/circuit-to-svg)](https://github.com/tscircuit/circuit-to-svg/issues)       |
-| [tscircuit/circuit-json](https://github.com/tscircuit/circuit-json)           | Underlying assembly language format that represents tscircuit circuits               | [![GitHub issues](https://img.shields.io/github/issues/tscircuit/circuit-json)](https://github.com/tscircuit/circuit-json/issues)           |
-| [tscircuit/tscircuit.com](https://github.com/tscircuit/tscircuit.com)         | Main website and circuit board editor                                                          | [![GitHub issues](https://img.shields.io/github/issues/tscircuit/tscircuit.com)](https://github.com/tscircuit/tscircuit.com/issues)         |
-| [tscircuit/cli](https://github.com/tscircuit/cli)                             | Main development tool for tscircuit, provides local development server and package management  | [![GitHub issues](https://img.shields.io/github/issues/tscircuit/cli)](https://github.com/tscircuit/cli/issues)                             |
-| [tscircuit/runframe](https://github.com/tscircuit/runframe)                   | React component to preview and run tscircuit circuits                                          | [![GitHub issues](https://img.shields.io/github/issues/tscircuit/runframe)](https://github.com/tscircuit/runframe/issues)                   |
-| [tscircuit/pcb-viewer](https://github.com/tscircuit/pcb-viewer)               | React component for viewing PCBs                                                               | [![GitHub issues](https://img.shields.io/github/issues/tscircuit/pcb-viewer)](https://github.com/tscircuit/pcb-viewer/issues)               |
-| [tscircuit/3d-viewer](https://github.com/tscircuit/3d-viewer)                 | React component for viewing 3D previews                                                        | [![GitHub issues](https://img.shields.io/github/issues/tscircuit/3d-viewer)](https://github.com/tscircuit/3d-viewer/issues)                 |
-| [tscircuit/props](https://github.com/tscircuit/props)                         | Specification for the definitions of every React component supported by tscircuit     | [![GitHub issues](https://img.shields.io/github/issues/tscircuit/props)](https://github.com/tscircuit/props/issues)                         |
-| [tscircuit/easyeda-converter](https://github.com/tscircuit/easyeda-converter) | Command line utility for converting JLCPCB footprints to tscircuit                             | [![GitHub issues](https://img.shields.io/github/issues/tscircuit/easyeda-converter)](https://github.com/tscircuit/easyeda-converter/issues) |
+tscircuit is split into focused repositories. Use this page to route an issue or
+pull request to the repo that owns the behavior you want to change.
+
+## Quick Chooser
+
+| If you want to work on... | Start here |
+| --- | --- |
+| React elements such as `<board />`, `<chip />`, traces, nets, or layout behavior | [tscircuit/core](https://github.com/tscircuit/core) |
+| TypeScript props accepted by tscircuit elements | [tscircuit/props](https://github.com/tscircuit/props) |
+| The shared circuit data format emitted by tscircuit | [tscircuit/circuit-json](https://github.com/tscircuit/circuit-json) |
+| Schematic or PCB SVG rendering | [tscircuit/circuit-to-svg](https://github.com/tscircuit/circuit-to-svg) |
+| Footprint strings and footprint parsing | [tscircuit/footprinter](https://github.com/tscircuit/footprinter) |
+| Schematic symbols | [tscircuit/schematic-symbols](https://github.com/tscircuit/schematic-symbols) |
+| The online editor, package pages, accounts, or dashboard UI | [tscircuit/tscircuit.com](https://github.com/tscircuit/tscircuit.com) |
+| Local commands such as `tsci dev`, `tsci build`, or `tsci export` | [tscircuit/cli](https://github.com/tscircuit/cli) |
+| Embedded previews used in docs and external sites | [tscircuit/runframe](https://github.com/tscircuit/runframe) |
+| PCB viewer interaction or rendering | [tscircuit/pcb-viewer](https://github.com/tscircuit/pcb-viewer) |
+| 3D board previews and model loading | [tscircuit/3d-viewer](https://github.com/tscircuit/3d-viewer) |
+| Autorouting algorithms or routing benchmark cases | [tscircuit/autorouting](https://github.com/tscircuit/autorouting) |
+| The autorouting web interface | [tscircuit/autorouting.com](https://github.com/tscircuit/autorouting.com) |
+| EasyEDA, JLCPCB, KiCad, Eagle, or DSN import/export | The converter repos listed below |
+| Documentation, tutorials, and contribution guides | [tscircuit/docs](https://github.com/tscircuit/docs) |
+
+## Core Libraries
+
+| Repo | What it owns | Good contributions | Open issues |
+| --- | --- | --- | --- |
+| [tscircuit/core](https://github.com/tscircuit/core) | Converts React components into Circuit JSON, schematics, and PCB outputs. | Element behavior, layout logic, routing inputs, regression tests. | [![GitHub issues](https://img.shields.io/github/issues/tscircuit/core)](https://github.com/tscircuit/core/issues) |
+| [tscircuit/props](https://github.com/tscircuit/props) | TypeScript prop definitions for tscircuit elements. | Prop additions, prop docs, stricter element typing. | [![GitHub issues](https://img.shields.io/github/issues/tscircuit/props)](https://github.com/tscircuit/props/issues) |
+| [tscircuit/circuit-json](https://github.com/tscircuit/circuit-json) | The shared data format for circuits, boards, schematic elements, and manufacturing outputs. | Schema changes, validators, fixtures, compatibility notes. | [![GitHub issues](https://img.shields.io/github/issues/tscircuit/circuit-json)](https://github.com/tscircuit/circuit-json/issues) |
+| [tscircuit/circuit-to-svg](https://github.com/tscircuit/circuit-to-svg) | Converts Circuit JSON into schematic and PCB SVGs. | Snapshot fixes, renderer bugs, visual output improvements. | [![GitHub issues](https://img.shields.io/github/issues/tscircuit/circuit-to-svg)](https://github.com/tscircuit/circuit-to-svg/issues) |
+
+## Authoring Tools
+
+| Repo | What it owns | Good contributions | Open issues |
+| --- | --- | --- | --- |
+| [tscircuit/cli](https://github.com/tscircuit/cli) | The `tsci` command line workflow for local development, package commands, exports, and builds. | Command bugs, clearer errors, package workflow fixes, export options. | [![GitHub issues](https://img.shields.io/github/issues/tscircuit/cli)](https://github.com/tscircuit/cli/issues) |
+| [tscircuit/docs](https://github.com/tscircuit/docs) | Documentation, tutorials, guides, API references, and examples. | Missing docs, clearer examples, docs navigation, contribution guides. | [![GitHub issues](https://img.shields.io/github/issues/tscircuit/docs)](https://github.com/tscircuit/docs/issues) |
+| [tscircuit/runframe](https://github.com/tscircuit/runframe) | Embeddable React runtime for previewing and running tscircuit code. | Preview runtime bugs, iframe behavior, editor integration, loading states. | [![GitHub issues](https://img.shields.io/github/issues/tscircuit/runframe)](https://github.com/tscircuit/runframe/issues) |
+
+## Viewers and Web Apps
+
+| Repo | What it owns | Good contributions | Open issues |
+| --- | --- | --- | --- |
+| [tscircuit/tscircuit.com](https://github.com/tscircuit/tscircuit.com) | Main website, online editor, account flows, package pages, and app UI. | Editor bugs, UI polish, dashboard flows, package discovery. | [![GitHub issues](https://img.shields.io/github/issues/tscircuit/tscircuit.com)](https://github.com/tscircuit/tscircuit.com/issues) |
+| [tscircuit/pcb-viewer](https://github.com/tscircuit/pcb-viewer) | React PCB viewer used by docs, previews, and apps. | Layer controls, interaction bugs, board rendering, viewer performance. | [![GitHub issues](https://img.shields.io/github/issues/tscircuit/pcb-viewer)](https://github.com/tscircuit/pcb-viewer/issues) |
+| [tscircuit/3d-viewer](https://github.com/tscircuit/3d-viewer) | 3D board and component previews. | Model loading, camera behavior, 3D rendering, lighting, performance. | [![GitHub issues](https://img.shields.io/github/issues/tscircuit/3d-viewer)](https://github.com/tscircuit/3d-viewer/issues) |
+| [tscircuit/autorouting.com](https://github.com/tscircuit/autorouting.com) | Web interface for autorouting experiments and debugging. | Route visualization, job status UX, debug views, integration fixes. | [![GitHub issues](https://img.shields.io/github/issues/tscircuit/autorouting.com)](https://github.com/tscircuit/autorouting.com/issues) |
+
+## Symbols, Footprints, and Converters
+
+| Repo | What it owns | Good contributions | Open issues |
+| --- | --- | --- | --- |
+| [tscircuit/schematic-symbols](https://github.com/tscircuit/schematic-symbols) | Reusable schematic symbols. | Missing symbols, symbol metadata, test fixtures, examples. | [![GitHub issues](https://img.shields.io/github/issues/tscircuit/schematic-symbols)](https://github.com/tscircuit/schematic-symbols/issues) |
+| [tscircuit/footprinter](https://github.com/tscircuit/footprinter) | Generates PCB footprints from footprint strings. | New footprints, parser fixes, footprint snapshots. | [![GitHub issues](https://img.shields.io/github/issues/tscircuit/footprinter)](https://github.com/tscircuit/footprinter/issues) |
+| [tscircuit/easyeda-converter](https://github.com/tscircuit/easyeda-converter) | Converts EasyEDA and JLCPCB data into tscircuit-compatible output. | Import bugs, part mapping, footprint conversion. | [![GitHub issues](https://img.shields.io/github/issues/tscircuit/easyeda-converter)](https://github.com/tscircuit/easyeda-converter/issues) |
+| [tscircuit/kicad-converter](https://github.com/tscircuit/kicad-converter) | Converts KiCad data for tscircuit workflows. | KiCad import/export fixes, library conversion coverage. | [![GitHub issues](https://img.shields.io/github/issues/tscircuit/kicad-converter)](https://github.com/tscircuit/kicad-converter/issues) |
+| [tscircuit/eagle-xml-converter](https://github.com/tscircuit/eagle-xml-converter) | Converts Eagle XML files into tscircuit-compatible data. | Eagle import coverage, converter bugs, fixture tests. | [![GitHub issues](https://img.shields.io/github/issues/tscircuit/eagle-xml-converter)](https://github.com/tscircuit/eagle-xml-converter/issues) |
+| [tscircuit/dsn-converter](https://github.com/tscircuit/dsn-converter) | Converts Specctra DSN files into Circuit JSON. | DSN parsing, autorouter import/export compatibility, fixtures. | [![GitHub issues](https://img.shields.io/github/issues/tscircuit/dsn-converter)](https://github.com/tscircuit/dsn-converter/issues) |
+
+## Autorouting and Community Infrastructure
+
+| Repo | What it owns | Good contributions | Open issues |
+| --- | --- | --- | --- |
+| [tscircuit/autorouting](https://github.com/tscircuit/autorouting) | Autorouting algorithms, datasets, benchmarks, and route problem definitions. | Algorithm improvements, reduced route failures, benchmark cases. | [![GitHub issues](https://img.shields.io/github/issues/tscircuit/autorouting)](https://github.com/tscircuit/autorouting/issues) |
+| [tscircuit/contribution-tracker](https://github.com/tscircuit/contribution-tracker) | Contribution summaries and sponsorship signals. | Scoring logic, contribution ingestion, dashboard data fixes. | [![GitHub issues](https://img.shields.io/github/issues/tscircuit/contribution-tracker)](https://github.com/tscircuit/contribution-tracker/issues) |
+
+## Before Opening a PR
+
+- Search the target repo's open issues first, then link the issue in your PR.
+- Include a small reproduction, fixture, or screenshot when changing visual output.
+- Put type or schema changes in `props` or `circuit-json` before wiring them into `core`.
+- Keep docs examples aligned with current element names and props.
+- If a bug crosses repos, open the PR in the repo that owns the failing behavior
+  and mention any follow-up repos in the description.


### PR DESCRIPTION
Claims tscircuit/docs-old#61.

/claim #61

## Summary
- replace the flat repo list with a contribution routing guide
- add a quick chooser mapping common contribution types to the owning repo
- group core libraries, authoring tools, viewers, converters, autorouting, and community infrastructure
- keep issue badges while adding practical guidance for what each repo owns and what contributions fit there

## Verification
- Checked frontmatter delimiters locally.
- Checked the overview file is ASCII-only.
- Not run: Docusaurus build, because this workspace does not have repo dependencies installed.

References:
- https://github.com/tscircuit/docs-old/issues/61