### PR TITLE
Update docs navbar to Try Online

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -179,8 +179,8 @@ const config: Config = {
         },
         { to: "https://blog.tscircuit.com", label: "Blog", position: "left" },
         {
-          to: "https://tscircuit.com",
-          label: "Use Online",
+          to: "https://tscircuit.com/editor",
+          label: "Try Online",
           position: "left",
         },
 


### PR DESCRIPTION
## Summary
- Rename the navbar item from "Use Online" to "Try Online"
- Link directly to the online editor at https://tscircuit.com/editor

## Context
- This carries the intent of tscircuit/docs-old#67 into the active docs repository because tscircuit/docs-old is archived and GitHub rejects new PRs there.

## Verification
- git diff --check
- npm run typecheck (blocked locally: dependencies are not installed, tsc is unavailable)

Addresses tscircuit/docs-old#67
