### PR TITLE
Add tutorials: USB PD Trigger HAT, I2C Environmental Sensor, Class D Audio Amplifier HAT

### DIFF
--- a/docs/guides/class-d-audio-amplifier-hat.mdx
+++ b/docs/guides/class-d-audio-amplifier-hat.mdx
@@ -1,0 +1,572 @@
+---
+title: Class D Audio Amplifier HAT
+description: >-
+  Design a Class D audio amplifier HAT using tscircuit with a PAM8403 stereo
+  amplifier IC. Learn how Class D amplification achieves high efficiency and
+  build a compact speaker driver module perfect for portable audio projects.
+---
+
+import CircuitPreview from "@site/src/components/CircuitPreview"
+import TscircuitIframe from "@site/src/components/TscircuitIframe"
+
+## Overview
+
+This tutorial walks through designing a Class D audio amplifier HAT using tscircuit. We'll use the PAM8403 — a popular 3W+3W stereo Class D amplifier — to drive a pair of speakers from a line-level audio input. Class D amplifiers are perfect for battery-powered and portable audio projects because of their high efficiency (often above 90%).
+
+<TscircuitIframe defaultView="3d" code={`
+export default () => (
+  <board width="50mm" height="35mm">
+    <chip
+      name="U1"
+      manufacturerPartNumber="PAM8403"
+      footprint="sop16"
+      pinLabels={{
+        pin1: ["LOUT-"],
+        pin2: ["PGNDL"],
+        pin3: ["LOUT+"],
+        pin4: ["VDD"],
+        pin5: ["LIN+"],
+        pin6: ["LIN-"],
+        pin7: ["BYPASS"],
+        pin8: ["SHUTDOWN"],
+        pin9: ["MUTE"],
+        pin10: ["VREF"],
+        pin11: ["RIN+"],
+        pin12: ["RIN-"],
+        pin13: ["VDD"],
+        pin14: ["ROUT+"],
+        pin15: ["PGNDR"],
+        pin16: ["ROUT-"],
+      }}
+      schPortArrangement={{
+        leftSide: { pins: ["LOUT-", "PGNDL", "LOUT+", "VDD", "LIN+", "LIN-", "BYPASS", "SHUTDOWN"], direction: "top-to-bottom" },
+        rightSide: { pins: ["ROUT-", "PGNDR", "ROUT+", "VDD", "RIN+", "RIN-", "VREF", "MUTE"], direction: "top-to-bottom" },
+      }}
+      pcbX={0}
+      pcbY={0}
+    />
+
+    <capacitor name="C1" capacitance="100uF" footprint="0805" pcbX={-8} pcbY={-8} />
+    <capacitor name="C2" capacitance="100uF" footprint="0805" pcbX={0} pcbY={-8} />
+    <capacitor name="C3" capacitance="1uF" footprint="0603" pcbX={-8} pcbY={8} />
+    <capacitor name="C4" capacitance="1uF" footprint="0603" pcbX={0} pcbY={8} />
+
+    <capacitor name="C_BYPASS" capacitance="1uF" footprint="0402" pcbX={-5} pcbY={-12} />
+
+    <resistor name="R1" resistance="10k" footprint="0402" pcbX={-10} pcbY={3} />
+    <resistor name="R2" resistance="10k" footprint="0402" pcbX={-6} pcbY={3} />
+    <resistor name="R3" resistance="10k" footprint="0402" pcbX={6} pcbY={3} />
+    <resistor name="R4" resistance="10k" footprint="0402" pcbX={10} pcbY={3} />
+
+    <pinheader name="J1" pinCount={4} pcbX={-15} pcbY={0} />
+    <pinheader name="J2" pinCount={2} pcbX={15} pcbY={-5} />
+    <pinheader name="J3" pinCount={2} pcbX={15} pcbY={5} />
+
+    <trace from=".J1 .pin1" to="net.V5" />
+    <trace from=".J1 .pin2" to="net.GND" />
+    <trace from=".J1 .pin3" to=".R1 .pos" />
+    <trace from=".J1 .pin4" to=".R3 .pos" />
+
+    <trace from=".R1 .neg" to=".U1 .LIN+" />
+    <trace from=".R2 .pos" to=".U1 .LIN+" />
+    <trace from=".R2 .neg" to="net.GND" />
+
+    <trace from=".R3 .neg" to=".U1 .RIN+" />
+    <trace from=".R4 .pos" to=".U1 .RIN+" />
+    <trace from=".R4 .neg" to="net.GND" />
+
+    <trace from=".C3 .pos" to=".U1 .LIN+" />
+    <trace from=".C3 .neg" to=".R1 .neg" />
+    <trace from=".C4 .pos" to=".U1 .RIN+" />
+    <trace from=".C4 .neg" to=".R3 .neg" />
+
+    <trace from=".U1 .LIN-" to="net.GND" />
+    <trace from=".U1 .RIN-" to="net.GND" />
+
+    <trace from=".U1 .VDD" to="net.V5" />
+    <trace from=".U1 .PGNDL" to="net.GND" />
+    <trace from=".U1 .PGNDR" to="net.GND" />
+
+    <trace from=".U1 .SHUTDOWN" to="net.V5" />
+    <trace from=".U1 .MUTE" to="net.GND" />
+
+    <trace from=".C_BYPASS .pos" to=".U1 .BYPASS" />
+    <trace from=".C_BYPASS .neg" to="net.GND" />
+
+    <trace from=".C1 .pos" to="net.V5" />
+    <trace from=".C1 .neg" to="net.GND" />
+    <trace from=".C2 .pos" to="net.V5" />
+    <trace from=".C2 .neg" to="net.GND" />
+
+    <trace from=".U1 .LOUT+" to=".J2 .pin1" />
+    <trace from=".U1 .LOUT-" to=".J2 .pin2" />
+    <trace from=".U1 .ROUT+" to=".J3 .pin1" />
+    <trace from=".U1 .ROUT-" to=".J3 .pin2" />
+  </board>
+)
+`} />
+
+## What is Class D Amplification?
+
+Class D amplifiers work fundamentally differently from traditional linear amplifiers (Class A, B, or AB). Instead of using transistors in their linear region, Class D amps use transistors as switches — rapidly turning them on and off.
+
+### How Class D Works
+
+1. **PWM Modulation**: The incoming audio signal is compared to a high-frequency triangular wave (typically 250kHz–1MHz), producing a Pulse Width Modulated (PWM) signal
+2. **Switching Stage**: This PWM signal drives MOSFETs that switch the power supply voltage on and off at the PWM frequency
+3. **LC Filter (or Filterless)**: A low-pass filter (or the speaker's own inductance in "filterless" designs) removes the high-frequency switching noise, leaving only the amplified audio
+
+### Why Class D?
+
+| Feature | Class AB | Class D |
+|---------|----------|---------|
+| Efficiency | 50–70% | 85–95% |
+| Heat | High (needs heatsink) | Low (often no heatsink) |
+| Size | Large | Compact |
+| Battery life | Short | Long |
+| Audio quality | Very good | Very good (modern ICs) |
+
+Class D is the dominant technology for portable speakers, soundbars, car audio, and any battery-powered audio device.
+
+### The PAM8403
+
+The **PAM8403** is one of the most widely used Class D amplifier ICs. Key features:
+
+- **3W per channel** into 4 speakers at 5V
+- **Filterless operation** — no output LC filter needed
+- **Stereo output** — two independent channels
+- **>90% efficiency**
+- **SOP-16 package** — easy to hand-solder
+- **Built-in** shutdown, mute, and pop suppression
+
+## Circuit Requirements
+
+Our Class D amplifier HAT needs to:
+
+- Accept stereo line-level audio input (left and right)
+- Amplify both channels via the PAM8403
+- Output to two separate speakers through pin headers
+- Include power supply decoupling for clean audio
+- Support shutdown and mute control
+- Be powered by a 5V supply
+
+## Building the Circuit Step by Step
+
+### Step 1: Add the PAM8403 Amplifier IC
+
+The PAM8403 is a 16-pin chip with distinct left and right channels. The pin arrangement groups related functions together: power on the top, inputs in the middle, and control on the bottom.
+
+<CircuitPreview splitView={false} hidePCBTab hide3DTab defaultView="schematic" code={`
+export default () => (
+  <board width="50mm" height="35mm">
+    <chip
+      name="U1"
+      manufacturerPartNumber="PAM8403"
+      footprint="sop16"
+      pinLabels={{
+        pin1: ["LOUT-"],
+        pin2: ["PGNDL"],
+        pin3: ["LOUT+"],
+        pin4: ["VDD"],
+        pin5: ["LIN+"],
+        pin6: ["LIN-"],
+        pin7: ["BYPASS"],
+        pin8: ["SHUTDOWN"],
+        pin9: ["MUTE"],
+        pin10: ["VREF"],
+        pin11: ["RIN+"],
+        pin12: ["RIN-"],
+        pin13: ["VDD"],
+        pin14: ["ROUT+"],
+        pin15: ["PGNDR"],
+        pin16: ["ROUT-"],
+      }}
+      schPortArrangement={{
+        leftSide: { pins: ["LOUT-", "PGNDL", "LOUT+", "VDD", "LIN+", "LIN-", "BYPASS", "SHUTDOWN"], direction: "top-to-bottom" },
+        rightSide: { pins: ["ROUT-", "PGNDR", "ROUT+", "VDD", "RIN+", "RIN-", "VREF", "MUTE"], direction: "top-to-bottom" },
+      }}
+      pcbX={0}
+      pcbY={0}
+    />
+  </board>
+)
+`} />
+
+### Step 2: Add Input Coupling Capacitors
+
+Audio input signals often have a DC offset. Input coupling capacitors (C3, C4) block this DC offset, passing only the AC audio signal to the amplifier. Use 1 F ceramic capacitors for good low-frequency response.
+
+<CircuitPreview splitView={false} hidePCBTab hide3DTab defaultView="schematic" code={`
+export default () => (
+  <board width="50mm" height="35mm">
+    <chip
+      name="U1"
+      manufacturerPartNumber="PAM8403"
+      footprint="sop16"
+      pinLabels={{
+        pin1: ["LOUT-"],
+        pin2: ["PGNDL"],
+        pin3: ["LOUT+"],
+        pin4: ["VDD"],
+        pin5: ["LIN+"],
+        pin6: ["LIN-"],
+        pin7: ["BYPASS"],
+        pin8: ["SHUTDOWN"],
+        pin9: ["MUTE"],
+        pin10: ["VREF"],
+        pin11: ["RIN+"],
+        pin12: ["RIN-"],
+        pin13: ["VDD"],
+        pin14: ["ROUT+"],
+        pin15: ["PGNDR"],
+        pin16: ["ROUT-"],
+      }}
+      schPortArrangement={{
+        leftSide: { pins: ["LOUT-", "PGNDL", "LOUT+", "VDD", "LIN+", "LIN-", "BYPASS", "SHUTDOWN"], direction: "top-to-bottom" },
+        rightSide: { pins: ["ROUT-", "PGNDR", "ROUT+", "VDD", "RIN+", "RIN-", "VREF", "MUTE"], direction: "top-to-bottom" },
+      }}
+      pcbX={0}
+      pcbY={0}
+    />
+    <capacitor name="C3" capacitance="1uF" footprint="0603" pcbX={-8} pcbY={8} />
+    <capacitor name="C4" capacitance="1uF" footprint="0603" pcbX={0} pcbY={8} />
+  </board>
+)
+`} />
+
+### Step 3: Add Input Bias Resistors
+
+Input bias resistors (R1–R4) set the input impedance and provide a DC path to ground for the amplifier inputs. The 10k resistors form a voltage divider that establishes the correct DC bias point. LIN- and RIN- are tied directly to ground for single-ended input configuration.
+
+<CircuitPreview splitView={false} hidePCBTab hide3DTab defaultView="schematic" code={`
+export default () => (
+  <board width="50mm" height="35mm">
+    <chip
+      name="U1"
+      manufacturerPartNumber="PAM8403"
+      footprint="sop16"
+      pinLabels={{
+        pin1: ["LOUT-"],
+        pin2: ["PGNDL"],
+        pin3: ["LOUT+"],
+        pin4: ["VDD"],
+        pin5: ["LIN+"],
+        pin6: ["LIN-"],
+        pin7: ["BYPASS"],
+        pin8: ["SHUTDOWN"],
+        pin9: ["MUTE"],
+        pin10: ["VREF"],
+        pin11: ["RIN+"],
+        pin12: ["RIN-"],
+        pin13: ["VDD"],
+        pin14: ["ROUT+"],
+        pin15: ["PGNDR"],
+        pin16: ["ROUT-"],
+      }}
+      schPortArrangement={{
+        leftSide: { pins: ["LOUT-", "PGNDL", "LOUT+", "VDD", "LIN+", "LIN-", "BYPASS", "SHUTDOWN"], direction: "top-to-bottom" },
+        rightSide: { pins: ["ROUT-", "PGNDR", "ROUT+", "VDD", "RIN+", "RIN-", "VREF", "MUTE"], direction: "top-to-bottom" },
+      }}
+      pcbX={0}
+      pcbY={0}
+    />
+    <resistor name="R1" resistance="10k" footprint="0402" pcbX={-10} pcbY={3} />
+    <resistor name="R2" resistance="10k" footprint="0402" pcbX={-6} pcbY={3} />
+    <resistor name="R3" resistance="10k" footprint="0402" pcbX={6} pcbY={3} />
+    <resistor name="R4" resistance="10k" footprint="0402" pcbX={10} pcbY={3} />
+  </board>
+)
+`} />
+
+### Step 4: Add Power Supply Decoupling
+
+Class D amplifiers draw current in short, high-amplitude pulses at the switching frequency. Large bulk capacitors (100 F) supply these current pulses and prevent voltage sag on the power rail. Place them as close as possible to the VDD pins.
+
+<CircuitPreview splitView={false} hidePCBTab hide3DTab defaultView="schematic" code={`
+export default () => (
+  <board width="50mm" height="35mm">
+    <capacitor name="C1" capacitance="100uF" footprint="0805" pcbX={-8} pcbY={-8} />
+    <capacitor name="C2" capacitance="100uF" footprint="0805" pcbX={0} pcbY={-8} />
+  </board>
+)
+`} />
+
+### Step 5: Add Bypass Capacitor
+
+The BYPASS pin requires a 1 F capacitor to ground. This capacitor filters the internal reference voltage, reducing noise and improving Power Supply Rejection Ratio (PSRR).
+
+<CircuitPreview splitView={false} hidePCBTab hide3DTab defaultView="schematic" code={`
+export default () => (
+  <board width="50mm" height="35mm">
+    <capacitor name="C_BYPASS" capacitance="1uF" footprint="0402" pcbX={-5} pcbY={-12} />
+  </board>
+)
+`} />
+
+### Step 6: Wire Everything Together
+
+Now we assemble the complete circuit — amplifier IC, input coupling, bias resistors, power decoupling, control pins, and speaker outputs.
+
+<CircuitPreview hidePCBTab hide3DTab defaultView="schematic" code={`
+export default () => (
+  <board width="50mm" height="35mm">
+    <chip
+      name="U1"
+      manufacturerPartNumber="PAM8403"
+      footprint="sop16"
+      pinLabels={{
+        pin1: ["LOUT-"],
+        pin2: ["PGNDL"],
+        pin3: ["LOUT+"],
+        pin4: ["VDD"],
+        pin5: ["LIN+"],
+        pin6: ["LIN-"],
+        pin7: ["BYPASS"],
+        pin8: ["SHUTDOWN"],
+        pin9: ["MUTE"],
+        pin10: ["VREF"],
+        pin11: ["RIN+"],
+        pin12: ["RIN-"],
+        pin13: ["VDD"],
+        pin14: ["ROUT+"],
+        pin15: ["PGNDR"],
+        pin16: ["ROUT-"],
+      }}
+      schPortArrangement={{
+        leftSide: { pins: ["LOUT-", "PGNDL", "LOUT+", "VDD", "LIN+", "LIN-", "BYPASS", "SHUTDOWN"], direction: "top-to-bottom" },
+        rightSide: { pins: ["ROUT-", "PGNDR", "ROUT+", "VDD", "RIN+", "RIN-", "VREF", "MUTE"], direction: "top-to-bottom" },
+      }}
+      pcbX={0}
+      pcbY={0}
+    />
+
+    <capacitor name="C1" capacitance="100uF" footprint="0805" pcbX={-8} pcbY={-8} />
+    <capacitor name="C2" capacitance="100uF" footprint="0805" pcbX={0} pcbY={-8} />
+    <capacitor name="C3" capacitance="1uF" footprint="0603" pcbX={-8} pcbY={8} />
+    <capacitor name="C4" capacitance="1uF" footprint="0603" pcbX={0} pcbY={8} />
+    <capacitor name="C_BYPASS" capacitance="1uF" footprint="0402" pcbX={-5} pcbY={-12} />
+
+    <resistor name="R1" resistance="10k" footprint="0402" pcbX={-10} pcbY={3} />
+    <resistor name="R2" resistance="10k" footprint="0402" pcbX={-6} pcbY={3} />
+    <resistor name="R3" resistance="10k" footprint="0402" pcbX={6} pcbY={3} />
+    <resistor name="R4" resistance="10k" footprint="0402" pcbX={10} pcbY={3} />
+
+    <pinheader name="J1" pinCount={4} pcbX={-15} pcbY={0} />
+    <pinheader name="J2" pinCount={2} pcbX={15} pcbY={-5} />
+    <pinheader name="J3" pinCount={2} pcbX={15} pcbY={5} />
+
+    <trace from=".J1 .pin1" to="net.V5" />
+    <trace from=".J1 .pin2" to="net.GND" />
+    <trace from=".J1 .pin3" to=".R1 .pos" />
+    <trace from=".J1 .pin4" to=".R3 .pos" />
+
+    <trace from=".R1 .neg" to=".U1 .LIN+" />
+    <trace from=".R2 .pos" to=".U1 .LIN+" />
+    <trace from=".R2 .neg" to="net.GND" />
+
+    <trace from=".R3 .neg" to=".U1 .RIN+" />
+    <trace from=".R4 .pos" to=".U1 .RIN+" />
+    <trace from=".R4 .neg" to="net.GND" />
+
+    <trace from=".C3 .pos" to=".U1 .LIN+" />
+    <trace from=".C3 .neg" to=".R1 .neg" />
+    <trace from=".C4 .pos" to=".U1 .RIN+" />
+    <trace from=".C4 .neg" to=".R3 .neg" />
+
+    <trace from=".U1 .LIN-" to="net.GND" />
+    <trace from=".U1 .RIN-" to="net.GND" />
+
+    <trace from=".U1 .VDD" to="net.V5" />
+    <trace from=".U1 .PGNDL" to="net.GND" />
+    <trace from=".U1 .PGNDR" to="net.GND" />
+
+    <trace from=".U1 .SHUTDOWN" to="net.V5" />
+    <trace from=".U1 .MUTE" to="net.GND" />
+
+    <trace from=".C_BYPASS .pos" to=".U1 .BYPASS" />
+    <trace from=".C_BYPASS .neg" to="net.GND" />
+
+    <trace from=".C1 .pos" to="net.V5" />
+    <trace from=".C1 .neg" to="net.GND" />
+    <trace from=".C2 .pos" to="net.V5" />
+    <trace from=".C2 .neg" to="net.GND" />
+
+    <trace from=".U1 .LOUT+" to=".J2 .pin1" />
+    <trace from=".U1 .LOUT-" to=".J2 .pin2" />
+    <trace from=".U1 .ROUT+" to=".J3 .pin1" />
+    <trace from=".U1 .ROUT-" to=".J3 .pin2" />
+  </board>
+)
+`} />
+
+## Connector Pinout Reference
+
+### Input Header (J1) — 4-pin
+
+| Pin | Signal | Description |
+|-----|--------|-------------|
+| 1   | V5     | 5V power input |
+| 2   | GND    | Ground |
+| 3   | LIN    | Left channel audio input |
+| 4   | RIN    | Right channel audio input |
+
+### Speaker Outputs (J2, J3) — 2-pin each
+
+| Pin | Signal | Description |
+|-----|--------|-------------|
+| 1   | LOUT+ / ROUT+ | Positive speaker terminal |
+| 2   | LOUT- / ROUT- | Negative speaker terminal |
+
+> **Important**: PAM8403 outputs are **bridged (BTL)**. Do NOT connect the negative speaker terminals to ground, and do NOT connect them together. Each speaker connects only to its own + and - outputs.
+
+## Control Pins Explained
+
+The PAM8403 provides two logic-level control pins:
+
+| Pin | Active | Behavior |
+|-----|--------|----------|
+| SHUTDOWN | LOW | Disables the amplifier entirely (typical <1 A current draw) |
+| MUTE | HIGH | Mutes the audio output while keeping the amplifier powered |
+
+In our circuit, SHUTDOWN is tied to V5 (always enabled) and MUTE is tied to GND (never muted). For more control, connect these to GPIO pins on a microcontroller:
+
+```tsx
+<trace from=".U1 .SHUTDOWN" to="net.SHDN" />
+<trace from=".U1 .MUTE" to="net.MUTE" />
+```
+
+Then drive them from your microcontroller — pull SHUTDOWN LOW to power down, pull MUTE HIGH to mute.
+
+## Choosing Speakers
+
+The PAM8403 is optimized for 4 speakers at 5V, delivering up to 3W per channel. Here's the power vs. impedance relationship at 5V:
+
+| Speaker Impedance | Power per Channel | THD |
+|-------------------|-------------------|-----|
+| 4               | 3W                | 10% |
+| 8               | 1.5W              | 10% |
+
+For best results, use 3W–5W rated 4 speakers. The amplifier can drive 8 speakers at reduced power, which may be suitable for headphone-level volumes.
+
+## PCB Layout Guidelines
+
+<CircuitPreview hideSchematicTab hide3DTab defaultView="pcb" code={`
+export default () => (
+  <board width="50mm" height="35mm">
+    <chip
+      name="U1"
+      manufacturerPartNumber="PAM8403"
+      footprint="sop16"
+      pinLabels={{
+        pin1: ["LOUT-"],
+        pin2: ["PGNDL"],
+        pin3: ["LOUT+"],
+        pin4: ["VDD"],
+        pin5: ["LIN+"],
+        pin6: ["LIN-"],
+        pin7: ["BYPASS"],
+        pin8: ["SHUTDOWN"],
+        pin9: ["MUTE"],
+        pin10: ["VREF"],
+        pin11: ["RIN+"],
+        pin12: ["RIN-"],
+        pin13: ["VDD"],
+        pin14: ["ROUT+"],
+        pin15: ["PGNDR"],
+        pin16: ["ROUT-"],
+      }}
+      schPortArrangement={{
+        leftSide: { pins: ["LOUT-", "PGNDL", "LOUT+", "VDD", "LIN+", "LIN-", "BYPASS", "SHUTDOWN"], direction: "top-to-bottom" },
+        rightSide: { pins: ["ROUT-", "PGNDR", "ROUT+", "VDD", "RIN+", "RIN-", "VREF", "MUTE"], direction: "top-to-bottom" },
+      }}
+      pcbX={0}
+      pcbY={0}
+    />
+
+    <capacitor name="C1" capacitance="100uF" footprint="0805" pcbX={-8} pcbY={-8} />
+    <capacitor name="C2" capacitance="100uF" footprint="0805" pcbX={0} pcbY={-8} />
+    <capacitor name="C3" capacitance="1uF" footprint="0603" pcbX={-8} pcbY={8} />
+    <capacitor name="C4" capacitance="1uF" footprint="0603" pcbX={0} pcbY={8} />
+    <capacitor name="C_BYPASS" capacitance="1uF" footprint="0402" pcbX={-5} pcbY={-12} />
+
+    <resistor name="R1" resistance="10k" footprint="0402" pcbX={-10} pcbY={3} />
+    <resistor name="R2" resistance="10k" footprint="0402" pcbX={-6} pcbY={3} />
+    <resistor name="R3" resistance="10k" footprint="0402" pcbX={6} pcbY={3} />
+    <resistor name="R4" resistance="10k" footprint="0402" pcbX={10} pcbY={3} />
+
+    <pinheader name="J1" pinCount={4} pcbX={-15} pcbY={0} />
+    <pinheader name="J2" pinCount={2} pcbX={15} pcbY={-5} />
+    <pinheader name="J3" pinCount={2} pcbX={15} pcbY={5} />
+
+    <trace from=".J1 .pin1" to="net.V5" />
+    <trace from=".J1 .pin2" to="net.GND" />
+    <trace from=".J1 .pin3" to=".R1 .pos" />
+    <trace from=".J1 .pin4" to=".R3 .pos" />
+
+    <trace from=".R1 .neg" to=".U1 .LIN+" />
+    <trace from=".R2 .pos" to=".U1 .LIN+" />
+    <trace from=".R2 .neg" to="net.GND" />
+
+    <trace from=".R3 .neg" to=".U1 .RIN+" />
+    <trace from=".R4 .pos" to=".U1 .RIN+" />
+    <trace from=".R4 .neg" to="net.GND" />
+
+    <trace from=".C3 .pos" to=".U1 .LIN+" />
+    <trace from=".C3 .neg" to=".R1 .neg" />
+    <trace from=".C4 .pos" to=".U1 .RIN+" />
+    <trace from=".C4 .neg" to=".R3 .neg" />
+
+    <trace from=".U1 .LIN-" to="net.GND" />
+    <trace from=".U1 .RIN-" to="net.GND" />
+
+    <trace from=".U1 .VDD" to="net.V5" />
+    <trace from=".U1 .PGNDL" to="net.GND" />
+    <trace from=".U1 .PGNDR" to="net.GND" />
+
+    <trace from=".U1 .SHUTDOWN" to="net.V5" />
+    <trace from=".U1 .MUTE" to="net.GND" />
+
+    <trace from=".C_BYPASS .pos" to=".U1 .BYPASS" />
+    <trace from=".C_BYPASS .neg" to="net.GND" />
+
+    <trace from=".C1 .pos" to="net.V5" />
+    <trace from=".C1 .neg" to="net.GND" />
+    <trace from=".C2 .pos" to="net.V5" />
+    <trace from=".C2 .neg" to="net.GND" />
+
+    <trace from=".U1 .LOUT+" to=".J2 .pin1" />
+    <trace from=".U1 .LOUT-" to=".J2 .pin2" />
+    <trace from=".U1 .ROUT+" to=".J3 .pin1" />
+    <trace from=".U1 .ROUT-" to=".J3 .pin2" />
+  </board>
+)
+`} />
+
+Key layout tips for Class D amplifiers:
+
+- **Keep power traces wide**: Use wide traces (at least 0.5mm) for VDD and output paths to minimize voltage drop
+- **Separate power and signal grounds**: Connect PGNDL and PGNDR with a star-ground approach to avoid ground loops
+- **Place decoupling close**: C1 and C2 should be as close as possible to the VDD pins — within 5mm
+- **Keep input traces away from outputs**: Route audio inputs away from the high-current switching outputs to prevent coupling
+- **Use a ground pour**: A solid ground plane on the bottom layer helps with both noise and thermal performance
+
+## Powering the Amplifier
+
+The PAM8403 operates from 2.5V to 5.5V. For best performance:
+
+- **5V USB power**: The simplest option. Use a USB power bank or wall adapter. At 5V you get the full 3W+3W
+- **3.7V Li-Ion battery**: Lower output power (~1.5W per channel) but excellent for portable use
+- **Pair with a USB PD Trigger HAT**: For higher voltage systems, use a PD trigger to negotiate 9V or 12V, then regulate down to 5V with a buck converter
+
+## Ordering the PCB
+
+You can order this PCB by downloading the fabrication files and uploading them to JLCPCB. Follow the instructions from [Ordering Prototypes](/building-electronics/ordering-prototypes).
+
+## Next Steps
+
+- Add a potentiometer for volume control on the input
+- Add a 3.5mm audio jack instead of (or in addition to) pin headers
+- Integrate a Bluetooth audio module (e.g., MH-M18) for wireless streaming
+- Add an I2S DAC (e.g., PCM5102A) for higher-quality digital audio input
+- Design a speaker enclosure and use the 3D CAD model from tscircuit for fit-checking
+- Combine with a USB PD Trigger HAT to build a complete portable speaker system

--- a/docs/guides/class-d-audio-amplifier-hat.mdx
+++ b/docs/guides/class-d-audio-amplifier-hat.mdx
@@ -425,7 +425,7 @@ The PAM8403 provides two logic-level control pins:
 
 | Pin | Active | Behavior |
 |-----|--------|----------|
-| SHUTDOWN | LOW | Disables the amplifier entirely (typical <1 A current draw) |
+| SHUTDOWN | LOW | Disables the amplifier entirely (typical `<1 µA` current draw) |
 | MUTE | HIGH | Mutes the audio output while keeping the amplifier powered |
 
 In our circuit, SHUTDOWN is tied to V5 (always enabled) and MUTE is tied to GND (never muted). For more control, connect these to GPIO pins on a microcontroller:

--- a/docs/guides/i2c-environmental-sensor.mdx
+++ b/docs/guides/i2c-environmental-sensor.mdx
@@ -1,0 +1,492 @@
+---
+title: I2C Environmental Sensor Module
+description: >-
+  Build an I2C environmental sensor module using tscircuit. Connect a BME280
+  temperature, humidity, and pressure sensor to a Raspberry Pi Pico over I2C,
+  and learn how to read environmental data for weather stations, indoor climate
+  monitoring, and IoT applications.
+---
+
+import CircuitPreview from "@site/src/components/CircuitPreview"
+import TscircuitIframe from "@site/src/components/TscircuitIframe"
+
+## Overview
+
+This tutorial walks through building an I2C environmental sensor module using tscircuit. We'll connect a BME280 sensor — which measures temperature, humidity, and barometric pressure — to a Raspberry Pi Pico over the I2C bus. This sensor module is perfect for weather stations, indoor climate monitoring, greenhouse automation, and IoT data logging.
+
+<TscircuitIframe defaultView="3d" code={`
+import { usePICO_W } from "@tsci/seveibar.PICO_W"
+
+export default () => {
+  const U1 = usePICO_W("U1")
+  return (
+    <board width="45mm" height="35mm" routingDisabled>
+      <U1 pcbY={0} pcbX={-10} />
+
+      <chip
+        name="U2"
+        manufacturerPartNumber="BME280"
+        footprint="lga8"
+        pinLabels={{
+          pin1: ["VDD"],
+          pin2: ["GND"],
+          pin3: ["CSB"],
+          pin4: ["SDI"],
+          pin5: ["SDO"],
+          pin6: ["SCK"],
+          pin7: ["SDO"],
+          pin8: ["VDDIO"],
+        }}
+        schPortArrangement={{
+          leftSide: { pins: ["VDD", "GND", "CSB", "SDI"], direction: "top-to-bottom" },
+          rightSide: { pins: ["VDDIO", "SDO", "SCK", "SDO"], direction: "top-to-bottom" },
+        }}
+        pcbX={12}
+        pcbY={0}
+      />
+
+      <resistor name="R1" resistance="4.7k" footprint="0402" pcbX={6} pcbY={-8} />
+      <resistor name="R2" resistance="4.7k" footprint="0402" pcbX={9} pcbY={-8} />
+
+      <capacitor name="C1" capacitance="100nF" footprint="0402" pcbX={12} pcbY={-5} />
+
+      <trace from={U1.VBUS} to="net.V5" />
+      <trace from={U1.GND1} to="net.GND" />
+      <trace from={U1.GND2} to="net.GND" />
+      <trace from={U1.GND3} to="net.GND" />
+
+      <trace from={U1.GP4_SPI0RX_I2C0SDA_UART1TX} to=".U2 .SDI" />
+      <trace from={U1.GP5_SPI0CSn_I2C0SCL_UART1RX} to=".U2 .SCK" />
+
+      <trace from=".R1 .pos" to={U1.GP4_SPI0RX_I2C0SDA_UART1TX} />
+      <trace from=".R1 .neg" to="net.V5" />
+      <trace from=".R2 .pos" to={U1.GP5_SPI0CSn_I2C0SCL_UART1RX} />
+      <trace from=".R2 .neg" to="net.V5" />
+
+      <trace from=".U2 .VDD" to="net.V5" />
+      <trace from=".U2 .VDDIO" to="net.V5" />
+      <trace from=".U2 .GND" to="net.GND" />
+      <trace from=".U2 .CSB" to="net.V5" />
+
+      <trace from=".C1 .pos" to="net.V5" />
+      <trace from=".C1 .neg" to="net.GND" />
+    </board>
+  )
+}
+`} />
+
+## What is the BME280?
+
+The **BME280** is an integrated environmental sensor from Bosch Sensortec that combines three sensing elements in one tiny package:
+
+| Measurement | Range | Accuracy | Resolution |
+|-------------|-------|----------|------------|
+| Temperature | -40 C to +85 C | ±1.0 C | 0.01 C |
+| Humidity | 0% to 100% RH | ±3% RH | 0.008% RH |
+| Pressure | 300 hPa to 1100 hPa | ±1.0 hPa | 0.18 Pa |
+
+The sensor communicates over I2C or SPI, making it easy to interface with any microcontroller. Its small LGA-8 package (2.5mm x 2.5mm) makes it ideal for compact designs.
+
+### How the BME280 Works
+
+- **Temperature**: Uses an integrated band-gap temperature sensor
+- **Humidity**: Measures the change in capacitance of a polymer dielectric layer as it absorbs moisture from the air
+- **Pressure**: Uses a piezo-resistive MEMS element that changes resistance when atmospheric pressure deforms a silicon membrane
+
+The raw sensor readings are compensated using factory-calibrated coefficients stored in the sensor's internal registers, giving accurate, calibrated output values.
+
+## Circuit Requirements
+
+Our environmental sensor module needs to:
+
+- Host a Raspberry Pi Pico W as the I2C bus master
+- Connect a BME280 on the I2C bus at address 0x76 (or 0x77)
+- Include I2C pull-up resistors (4.7k to V5)
+- Include a decoupling capacitor for clean sensor readings
+- Be compact enough for a weather station or IoT enclosure
+
+## Understanding I2C Communication
+
+**I2C (Inter-Integrated Circuit)** is a two-wire serial protocol that allows multiple devices to share the same bus:
+
+- **SDA (Serial Data)**: Bi-directional data line
+- **SCL (Serial Clock)**: Clock signal controlled by the master
+
+Each device on the bus has a unique 7-bit address. The BME280 typically uses address `0x76` (when the SDO pin is pulled to GND) or `0x77` (when SDO is pulled to VDDIO).
+
+I2C requires **pull-up resistors** on both SDA and SCL lines — typically 4.7k that pull the lines up to the logic level voltage (3.3V or 5V). Without these resistors, the lines would float and communication would fail.
+
+## Building the Circuit Step by Step
+
+### Step 1: Add the Raspberry Pi Pico W
+
+The Pico W serves as both the I2C master and provides WiFi connectivity for sending sensor data to the cloud.
+
+<CircuitPreview splitView={false} hidePCBTab hide3DTab defaultView="schematic" code={`
+import { usePICO_W } from "@tsci/seveibar.PICO_W"
+
+export default () => {
+  const U1 = usePICO_W("U1")
+  return (
+    <board width="45mm" height="35mm" routingDisabled>
+      <U1 pcbY={0} pcbX={-10} />
+    </board>
+  )
+}
+`} />
+
+### Step 2: Add the BME280 Sensor
+
+The BME280 communicates over I2C using its SDI (SDA) and SCK (SCL) pins. We tie CSB high to select I2C mode (instead of SPI).
+
+<CircuitPreview splitView={false} hidePCBTab hide3DTab defaultView="schematic" code={`
+import { usePICO_W } from "@tsci/seveibar.PICO_W"
+
+export default () => {
+  const U1 = usePICO_W("U1")
+  return (
+    <board width="45mm" height="35mm" routingDisabled>
+      <U1 pcbY={0} pcbX={-10} />
+
+      <chip
+        name="U2"
+        manufacturerPartNumber="BME280"
+        footprint="lga8"
+        pinLabels={{
+          pin1: ["VDD"],
+          pin2: ["GND"],
+          pin3: ["CSB"],
+          pin4: ["SDI"],
+          pin5: ["SDO"],
+          pin6: ["SCK"],
+          pin7: ["SDO"],
+          pin8: ["VDDIO"],
+        }}
+        schPortArrangement={{
+          leftSide: { pins: ["VDD", "GND", "CSB", "SDI"], direction: "top-to-bottom" },
+          rightSide: { pins: ["VDDIO", "SDO", "SCK", "SDO"], direction: "top-to-bottom" },
+        }}
+        pcbX={12}
+        pcbY={0}
+      />
+    </board>
+  )
+}
+`} />
+
+### Step 3: Add I2C Pull-Up Resistors
+
+I2C requires pull-up resistors on both SDA and SCL. Without these, the open-drain lines would never go high. 4.7k is a common and safe value for standard (100kHz) and fast (400kHz) I2C modes.
+
+<CircuitPreview splitView={false} hidePCBTab hide3DTab defaultView="schematic" code={`
+import { usePICO_W } from "@tsci/seveibar.PICO_W"
+
+export default () => {
+  const U1 = usePICO_W("U1")
+  return (
+    <board width="45mm" height="35mm" routingDisabled>
+      <U1 pcbY={0} pcbX={-10} />
+
+      <chip
+        name="U2"
+        manufacturerPartNumber="BME280"
+        footprint="lga8"
+        pinLabels={{
+          pin1: ["VDD"],
+          pin2: ["GND"],
+          pin3: ["CSB"],
+          pin4: ["SDI"],
+          pin5: ["SDO"],
+          pin6: ["SCK"],
+          pin7: ["SDO"],
+          pin8: ["VDDIO"],
+        }}
+        schPortArrangement={{
+          leftSide: { pins: ["VDD", "GND", "CSB", "SDI"], direction: "top-to-bottom" },
+          rightSide: { pins: ["VDDIO", "SDO", "SCK", "SDO"], direction: "top-to-bottom" },
+        }}
+        pcbX={12}
+        pcbY={0}
+      />
+
+      <resistor name="R1" resistance="4.7k" footprint="0402" pcbX={6} pcbY={-8} />
+      <resistor name="R2" resistance="4.7k" footprint="0402" pcbX={9} pcbY={-8} />
+    </board>
+  )
+}
+`} />
+
+### Step 4: Add a Decoupling Capacitor
+
+A 100nF decoupling capacitor close to the BME280's VDD pin filters out high-frequency noise from the power supply, ensuring stable sensor readings.
+
+<CircuitPreview splitView={false} hidePCBTab hide3DTab defaultView="schematic" code={`
+import { usePICO_W } from "@tsci/seveibar.PICO_W"
+
+export default () => {
+  const U1 = usePICO_W("U1")
+  return (
+    <board width="45mm" height="35mm" routingDisabled>
+      <U1 pcbY={0} pcbX={-10} />
+
+      <chip
+        name="U2"
+        manufacturerPartNumber="BME280"
+        footprint="lga8"
+        pinLabels={{
+          pin1: ["VDD"],
+          pin2: ["GND"],
+          pin3: ["CSB"],
+          pin4: ["SDI"],
+          pin5: ["SDO"],
+          pin6: ["SCK"],
+          pin7: ["SDO"],
+          pin8: ["VDDIO"],
+        }}
+        schPortArrangement={{
+          leftSide: { pins: ["VDD", "GND", "CSB", "SDI"], direction: "top-to-bottom" },
+          rightSide: { pins: ["VDDIO", "SDO", "SCK", "SDO"], direction: "top-to-bottom" },
+        }}
+        pcbX={12}
+        pcbY={0}
+      />
+
+      <capacitor name="C1" capacitance="100nF" footprint="0402" pcbX={12} pcbY={-5} />
+    </board>
+  )
+}
+`} />
+
+### Step 5: Wire Everything Together
+
+Now we connect all the pieces — I2C bus from Pico to BME280, pull-up resistors to V5, decoupling capacitor, and power rails.
+
+<CircuitPreview hidePCBTab hide3DTab defaultView="schematic" code={`
+import { usePICO_W } from "@tsci/seveibar.PICO_W"
+
+export default () => {
+  const U1 = usePICO_W("U1")
+  return (
+    <board width="45mm" height="35mm" routingDisabled>
+      <U1 pcbY={0} pcbX={-10} />
+
+      <chip
+        name="U2"
+        manufacturerPartNumber="BME280"
+        footprint="lga8"
+        pinLabels={{
+          pin1: ["VDD"],
+          pin2: ["GND"],
+          pin3: ["CSB"],
+          pin4: ["SDI"],
+          pin5: ["SDO"],
+          pin6: ["SCK"],
+          pin7: ["SDO"],
+          pin8: ["VDDIO"],
+        }}
+        schPortArrangement={{
+          leftSide: { pins: ["VDD", "GND", "CSB", "SDI"], direction: "top-to-bottom" },
+          rightSide: { pins: ["VDDIO", "SDO", "SCK", "SDO"], direction: "top-to-bottom" },
+        }}
+        pcbX={12}
+        pcbY={0}
+      />
+
+      <resistor name="R1" resistance="4.7k" footprint="0402" pcbX={6} pcbY={-8} />
+      <resistor name="R2" resistance="4.7k" footprint="0402" pcbX={9} pcbY={-8} />
+      <capacitor name="C1" capacitance="100nF" footprint="0402" pcbX={12} pcbY={-5} />
+
+      <trace from={U1.VBUS} to="net.V5" />
+      <trace from={U1.GND1} to="net.GND" />
+      <trace from={U1.GND2} to="net.GND" />
+      <trace from={U1.GND3} to="net.GND" />
+
+      <trace from={U1.GP4_SPI0RX_I2C0SDA_UART1TX} to=".U2 .SDI" />
+      <trace from={U1.GP5_SPI0CSn_I2C0SCL_UART1RX} to=".U2 .SCK" />
+
+      <trace from=".R1 .pos" to={U1.GP4_SPI0RX_I2C0SDA_UART1TX} />
+      <trace from=".R1 .neg" to="net.V5" />
+      <trace from=".R2 .pos" to={U1.GP5_SPI0CSn_I2C0SCL_UART1RX} />
+      <trace from=".R2 .neg" to="net.V5" />
+
+      <trace from=".U2 .VDD" to="net.V5" />
+      <trace from=".U2 .VDDIO" to="net.V5" />
+      <trace from=".U2 .GND" to="net.GND" />
+      <trace from=".U2 .CSB" to="net.V5" />
+
+      <trace from=".C1 .pos" to="net.V5" />
+      <trace from=".C1 .neg" to="net.GND" />
+    </board>
+  )
+}
+`} />
+
+## Pico W Pin Map for I2C
+
+The Raspberry Pi Pico W has two I2C peripherals:
+
+| I2C Bus | SDA Pin | SCL Pin | Physical Pin |
+|---------|---------|---------|--------------|
+| I2C0    | GP4     | GP5     | Pin 6, 7    |
+| I2C1    | GP6     | GP7     | Pin 9, 10   |
+
+In our circuit, we use **I2C0** with GP4 as SDA and GP5 as SCL. The Pico W's `usePICO_W` hook exposes pins with their full function names: `GP4_SPI0RX_I2C0SDA_UART1TX` and `GP5_SPI0CSn_I2C0SCL_UART1RX`.
+
+## Reading Sensor Data
+
+Once your PCB is assembled, you can read sensor data using MicroPython on the Pico or a C/C++ firmware.
+
+### MicroPython Example
+
+```python
+from machine import Pin, I2C
+import bme280
+import time
+
+i2c = I2C(0, sda=Pin(4), scl=Pin(5), freq=400000)
+bme = bme280.BME280(i2c=i2c)
+
+while True:
+    temp, pressure, humidity = bme.read_compensated_data()
+
+    # Convert pressure from Pa to hPa and temperature to degrees Celsius
+    pressure_hpa = pressure / 25600.0
+    temp_c = temp / 100.0
+    humidity_pct = humidity / 1024.0
+
+    print(f"Temperature: {temp_c:.1f} C")
+    print(f"Pressure: {pressure_hpa:.1f} hPa")
+    print(f"Humidity: {humidity_pct:.1f} %")
+    print("---")
+
+    time.sleep(2)
+```
+
+### Arduino / C++ Example
+
+```cpp
+#include <Wire.h>
+#include <Adafruit_BME280.h>
+
+Adafruit_BME280 bme;
+
+void setup() {
+  Serial.begin(115200);
+  Wire.setSDA(4);
+  Wire.setSCL(5);
+
+  if (!bme.begin(0x76)) {
+    Serial.println("BME280 not found!");
+    while (1);
+  }
+}
+
+void loop() {
+  Serial.print("Temperature: ");
+  Serial.print(bme.readTemperature());
+  Serial.println(" C");
+
+  Serial.print("Pressure: ");
+  Serial.print(bme.readPressure() / 100.0F);
+  Serial.println(" hPa");
+
+  Serial.print("Humidity: ");
+  Serial.print(bme.readHumidity());
+  Serial.println(" %");
+
+  Serial.println("---");
+  delay(2000);
+}
+```
+
+## PCB Layout
+
+Here is the complete PCB layout with the Pico W, BME280, pull-up resistors, and decoupling capacitor:
+
+<CircuitPreview hideSchematicTab hide3DTab defaultView="pcb" code={`
+import { usePICO_W } from "@tsci/seveibar.PICO_W"
+
+export default () => {
+  const U1 = usePICO_W("U1")
+  return (
+    <board width="45mm" height="35mm" routingDisabled>
+      <U1 pcbY={0} pcbX={-10} />
+
+      <chip
+        name="U2"
+        manufacturerPartNumber="BME280"
+        footprint="lga8"
+        pinLabels={{
+          pin1: ["VDD"],
+          pin2: ["GND"],
+          pin3: ["CSB"],
+          pin4: ["SDI"],
+          pin5: ["SDO"],
+          pin6: ["SCK"],
+          pin7: ["SDO"],
+          pin8: ["VDDIO"],
+        }}
+        schPortArrangement={{
+          leftSide: { pins: ["VDD", "GND", "CSB", "SDI"], direction: "top-to-bottom" },
+          rightSide: { pins: ["VDDIO", "SDO", "SCK", "SDO"], direction: "top-to-bottom" },
+        }}
+        pcbX={12}
+        pcbY={0}
+      />
+
+      <resistor name="R1" resistance="4.7k" footprint="0402" pcbX={6} pcbY={-8} />
+      <resistor name="R2" resistance="4.7k" footprint="0402" pcbX={9} pcbY={-8} />
+      <capacitor name="C1" capacitance="100nF" footprint="0402" pcbX={12} pcbY={-5} />
+
+      <trace from={U1.VBUS} to="net.V5" />
+      <trace from={U1.GND1} to="net.GND" />
+      <trace from={U1.GND2} to="net.GND" />
+      <trace from={U1.GND3} to="net.GND" />
+
+      <trace from={U1.GP4_SPI0RX_I2C0SDA_UART1TX} to=".U2 .SDI" />
+      <trace from={U1.GP5_SPI0CSn_I2C0SCL_UART1RX} to=".U2 .SCK" />
+
+      <trace from=".R1 .pos" to={U1.GP4_SPI0RX_I2C0SDA_UART1TX} />
+      <trace from=".R1 .neg" to="net.V5" />
+      <trace from=".R2 .pos" to={U1.GP5_SPI0CSn_I2C0SCL_UART1RX} />
+      <trace from=".R2 .neg" to="net.V5" />
+
+      <trace from=".U2 .VDD" to="net.V5" />
+      <trace from=".U2 .VDDIO" to="net.V5" />
+      <trace from=".U2 .GND" to="net.GND" />
+      <trace from=".U2 .CSB" to="net.V5" />
+
+      <trace from=".C1 .pos" to="net.V5" />
+      <trace from=".C1 .neg" to="net.GND" />
+    </board>
+  )
+}
+`} />
+
+## Design Tips
+
+- **Keep I2C traces short**: Long traces add capacitance that can distort the I2C signals. Keep SDA and SCL traces under 10cm when possible
+- **Place the decoupling capacitor close**: The 100nF cap should be as close as possible to the BME280 VDD/GND pins
+- **Avoid heat near the sensor**: The BME280's temperature reading is affected by nearby heat sources. Keep it away from voltage regulators and the Pico's main processor
+- **Consider a ground pour**: A solid ground pour on the PCB helps with noise immunity and thermal stability
+
+## Troubleshooting I2C
+
+If your sensor isn't responding, check these common issues:
+
+- **Missing pull-up resistors**: Verify both SDA and SCL have 4.7k pull-ups to V5
+- **Wrong I2C address**: Scan the bus to find the sensor. The BME280 defaults to 0x76 when SDO is pulled low, 0x77 when pulled high
+- **Power supply noise**: Add additional decoupling (10 F electrolytic in parallel with the 100nF ceramic)
+- **Incorrect pin mapping**: Double-check your GP4 (SDA) and GP5 (SCL) assignments
+
+## Ordering the PCB
+
+You can order this PCB by downloading the fabrication files and uploading them to JLCPCB. Follow the instructions from [Ordering Prototypes](/building-electronics/ordering-prototypes).
+
+## Next Steps
+
+- Add an OLED display (SSD1306) on the same I2C bus to show real-time readings
+- Add a microSD card slot for data logging
+- Connect the Pico W to WiFi and stream sensor data to a cloud dashboard
+- Expand with additional I2C sensors: light sensor (BH1750), air quality (CCS811), or soil moisture
+- 3D print an enclosure and add a small solar panel for outdoor deployment

--- a/docs/guides/usb-pd-trigger-hat.mdx
+++ b/docs/guides/usb-pd-trigger-hat.mdx
@@ -1,0 +1,565 @@
+---
+title: USB Power Delivery Trigger HAT
+description: >-
+  Learn how to design a USB Power Delivery Trigger HAT using tscircuit. This HAT
+  negotiates higher voltages (9V, 12V, 15V, 20V) from a USB-C PD power source
+  using a CH224K trigger IC, perfect for powering motors, LEDs, or other
+  high-power peripherals.
+---
+
+import CircuitPreview from "@site/src/components/CircuitPreview"
+import TscircuitIframe from "@site/src/components/TscircuitIframe"
+
+## Overview
+
+This tutorial walks through designing a USB Power Delivery (PD) Trigger HAT using tscircuit. A USB PD Trigger HAT negotiates higher voltages from a USB-C PD power source—unlocking 9V, 12V, 15V, or 20V instead of the default 5V. This is ideal for powering motors, high-brightness LEDs, audio amplifiers, or any project needing more than the standard 500mA at 5V.
+
+<TscircuitIframe defaultView="3d" code={`
+export default () => (
+  <board width="65mm" height="30mm">
+    <chip
+      name="J1"
+      manufacturerPartNumber="USB-C-16P"
+      footprint="ssop16"
+      pinLabels={{
+        pin1: ["GND"],
+        pin2: ["VBUS1"],
+        pin3: ["CC1"],
+        pin4: ["D-"],
+        pin5: ["D+"],
+        pin6: ["SBU1"],
+        pin7: ["VBUS2"],
+        pin8: ["GND"],
+        pin9: ["GND"],
+        pin10: ["VBUS3"],
+        pin11: ["CC2"],
+        pin12: ["D+"],
+        pin13: ["D-"],
+        pin14: ["SBU2"],
+        pin15: ["VBUS4"],
+        pin16: ["GND"],
+      }}
+      schPortArrangement={{
+        leftSide: { pins: ["VBUS1", "D-", "D+", "SBU1", "VBUS2", "CC1", "CC2"], direction: "top-to-bottom" },
+        rightSide: { pins: ["VBUS3", "D+", "D-", "SBU2", "VBUS4", "GND", "GND"], direction: "top-to-bottom" },
+      }}
+      pcbX={-22}
+      pcbY={0}
+    />
+
+    <chip
+      name="U1"
+      manufacturerPartNumber="CH224K"
+      footprint="sot23-6"
+      pinLabels={{
+        pin1: ["sel"],
+        pin2: ["vout"],
+        pin3: ["gnd"],
+        pin4: ["cc"],
+        pin5: ["nc"],
+        pin6: ["pg"],
+      }}
+      schPortArrangement={{
+        leftSide: { pins: ["sel", "cc", "nc"], direction: "top-to-bottom" },
+        rightSide: { pins: ["vout", "gnd", "pg"], direction: "top-to-bottom" },
+      }}
+      pcbX={0}
+      pcbY={0}
+    />
+
+    <chip
+      name="U2"
+      manufacturerPartNumber="AMS1117-3.3"
+      footprint="sot223"
+      pinLabels={{
+        pin1: ["gnd"],
+        pin2: ["vout"],
+        pin3: ["vin"],
+      }}
+      schPortArrangement={{
+        leftSide: { pins: ["gnd"], direction: "top-to-bottom" },
+        rightSide: { pins: ["vin", "vout"], direction: "top-to-bottom" },
+      }}
+      pcbX={12}
+      pcbY={0}
+    />
+
+    <capacitor name="C1" capacitance="10uF" footprint="0603" pcbX={12} pcbY={-5} />
+    <capacitor name="C2" capacitance="10uF" footprint="0603" pcbX={12} pcbY={5} />
+
+    <pinheader name="H1" pinCount={4} pcbX={22} pcbY={0} />
+
+    <trace from=".J1 .VBUS1" to=".U1 .vout" />
+    <trace from=".J1 .VBUS2" to=".U1 .vout" />
+    <trace from=".J1 .VBUS3" to=".U1 .vout" />
+    <trace from=".J1 .VBUS4" to=".U1 .vout" />
+    <trace from=".J1 .GND" to="net.GND" />
+
+    <trace from=".J1 .CC1" to=".U1 .cc" />
+    <trace from=".J1 .CC2" to=".U1 .cc" />
+
+    <trace from=".U1 .gnd" to="net.GND" />
+
+    <trace from=".U1 .vout" to=".U2 .vin" />
+    <trace from=".U1 .vout" to=".H1 .pin1" />
+
+    <trace from=".U2 .gnd" to="net.GND" />
+    <trace from=".U2 .vout" to=".C1 .pos" />
+    <trace from=".U2 .vout" to=".H1 .pin3" />
+    <trace from=".C1 .neg" to="net.GND" />
+
+    <trace from=".C2 .pos" to=".U1 .vout" />
+    <trace from=".C2 .neg" to="net.GND" />
+
+    <trace from=".H1 .pin2" to="net.GND" />
+    <trace from=".H1 .pin4" to="net.GND" />
+  </board>
+)
+`} />
+
+## What is USB Power Delivery?
+
+USB Power Delivery (USB PD) is a fast-charging standard that allows USB-C devices to negotiate higher power levels. Standard USB provides 5V at up to 500mA (2.5W), but USB PD can deliver:
+
+| Voltage | Max Current | Max Power |
+|---------|-------------|-----------|
+| 5V      | 3A          | 15W       |
+| 9V      | 3A          | 27W       |
+| 12V     | 3A          | 36W       |
+| 15V     | 3A          | 45W       |
+| 20V     | 5A          | 100W      |
+
+### How PD Negotiation Works
+
+When you plug a USB-C PD charger into a device, communication happens over the **CC (Configuration Channel)** pins. The process works like this:
+
+1. **Detection**: The charger (source) detects a device (sink) on the CC line with a pull-down resistor
+2. **Capability Advertisement**: The source sends its supported voltage/current profiles to the sink
+3. **Request**: The sink requests a specific voltage from the available profiles
+4. **Acceptance**: The source switches to the requested voltage and signals "power ready"
+5. **Delivery**: Power flows at the negotiated voltage
+
+### PD Trigger ICs
+
+A **PD Trigger IC** handles this negotiation automatically. Instead of implementing the complex USB PD protocol yourself, a tiny chip like the **CH224K** or **IP2721** does it all:
+
+- **CH224K**: Configurable via a single resistor or pin. Supports 5V/9V/12V/15V/20V output. SOT-23-6 package, costs under $0.15.
+- **IP2721**: Similar functionality with additional protection features. Supports up to 100W.
+
+The trigger IC connects to the CC pins of the USB-C port and handles the entire PD handshake, outputting the negotiated voltage on its VOUT pin.
+
+## Circuit Requirements
+
+Our USB PD Trigger HAT needs to:
+
+- Accept USB-C input with PD negotiation
+- Output a configurable PD voltage (e.g., 12V or 20V)
+- Provide a regulated 3.3V rail for logic-level devices
+- Expose power rails via pin headers for downstream use
+
+## Building the Circuit Step by Step
+
+### Step 1: Add the USB-C Connector
+
+The USB-C connector provides access to VBUS (power), CC (configuration), and GND pins. We use all four VBUS pins to handle the full current capacity.
+
+<CircuitPreview splitView={false} hidePCBTab hide3DTab defaultView="schematic" code={`
+export default () => (
+  <board width="65mm" height="30mm">
+    <chip
+      name="J1"
+      manufacturerPartNumber="USB-C-16P"
+      footprint="ssop16"
+      pinLabels={{
+        pin1: ["GND"],
+        pin2: ["VBUS1"],
+        pin3: ["CC1"],
+        pin4: ["D-"],
+        pin5: ["D+"],
+        pin6: ["SBU1"],
+        pin7: ["VBUS2"],
+        pin8: ["GND"],
+        pin9: ["GND"],
+        pin10: ["VBUS3"],
+        pin11: ["CC2"],
+        pin12: ["D+"],
+        pin13: ["D-"],
+        pin14: ["SBU2"],
+        pin15: ["VBUS4"],
+        pin16: ["GND"],
+      }}
+      schPortArrangement={{
+        leftSide: { pins: ["VBUS1", "D-", "D+", "SBU1", "VBUS2", "CC1", "CC2"], direction: "top-to-bottom" },
+        rightSide: { pins: ["VBUS3", "D+", "D-", "SBU2", "VBUS4", "GND", "GND"], direction: "top-to-bottom" },
+      }}
+      pcbX={-22}
+      pcbY={0}
+    />
+  </board>
+)
+`} />
+
+### Step 2: Add the PD Trigger IC (CH224K)
+
+The CH224K is a 6-pin chip. The key pins are:
+
+- **CC**: Connects to both CC1 and CC2 of the USB-C port for PD negotiation
+- **VOUT**: Outputs the negotiated voltage (e.g., 12V)
+- **SEL**: Configuration pin — setting this pin high/low selects the desired output voltage
+- **PG**: Power Good indicator — goes high when negotiation is complete and power is stable
+
+<CircuitPreview splitView={false} hidePCBTab hide3DTab defaultView="schematic" code={`
+export default () => (
+  <board width="65mm" height="30mm">
+    <chip
+      name="J1"
+      manufacturerPartNumber="USB-C-16P"
+      footprint="ssop16"
+      pinLabels={{
+        pin1: ["GND"],
+        pin2: ["VBUS1"],
+        pin3: ["CC1"],
+        pin4: ["D-"],
+        pin5: ["D+"],
+        pin6: ["SBU1"],
+        pin7: ["VBUS2"],
+        pin8: ["GND"],
+        pin9: ["GND"],
+        pin10: ["VBUS3"],
+        pin11: ["CC2"],
+        pin12: ["D+"],
+        pin13: ["D-"],
+        pin14: ["SBU2"],
+        pin15: ["VBUS4"],
+        pin16: ["GND"],
+      }}
+      schPortArrangement={{
+        leftSide: { pins: ["VBUS1", "D-", "D+", "SBU1", "VBUS2", "CC1", "CC2"], direction: "top-to-bottom" },
+        rightSide: { pins: ["VBUS3", "D+", "D-", "SBU2", "VBUS4", "GND", "GND"], direction: "top-to-bottom" },
+      }}
+      pcbX={-22}
+      pcbY={0}
+    />
+    <chip
+      name="U1"
+      manufacturerPartNumber="CH224K"
+      footprint="sot23-6"
+      pinLabels={{
+        pin1: ["sel"],
+        pin2: ["vout"],
+        pin3: ["gnd"],
+        pin4: ["cc"],
+        pin5: ["nc"],
+        pin6: ["pg"],
+      }}
+      schPortArrangement={{
+        leftSide: { pins: ["sel", "cc", "nc"], direction: "top-to-bottom" },
+        rightSide: { pins: ["vout", "gnd", "pg"], direction: "top-to-bottom" },
+      }}
+      pcbX={0}
+      pcbY={0}
+    />
+  </board>
+)
+`} />
+
+### Step 3: Add a 3.3V Voltage Regulator
+
+Most microcontrollers and logic circuits run at 3.3V. We add an AMS1117-3.3 regulator to derive 3.3V from the PD voltage. Input and output capacitors are essential for stability.
+
+<CircuitPreview splitView={false} hidePCBTab hide3DTab defaultView="schematic" code={`
+export default () => (
+  <board width="65mm" height="30mm">
+    <chip
+      name="U2"
+      manufacturerPartNumber="AMS1117-3.3"
+      footprint="sot223"
+      pinLabels={{
+        pin1: ["gnd"],
+        pin2: ["vout"],
+        pin3: ["vin"],
+      }}
+      schPortArrangement={{
+        leftSide: { pins: ["gnd"], direction: "top-to-bottom" },
+        rightSide: { pins: ["vin", "vout"], direction: "top-to-bottom" },
+      }}
+      pcbX={12}
+      pcbY={0}
+    />
+    <capacitor name="C1" capacitance="10uF" footprint="0603" pcbX={12} pcbY={-5} />
+    <capacitor name="C2" capacitance="10uF" footprint="0603" pcbX={12} pcbY={5} />
+  </board>
+)
+`} />
+
+### Step 4: Add Output Headers
+
+Pin headers make it easy to tap into the PD voltage and 3.3V rail for downstream circuits.
+
+<CircuitPreview splitView={false} hidePCBTab hide3DTab defaultView="schematic" code={`
+export default () => (
+  <board width="65mm" height="30mm">
+    <pinheader name="H1" pinCount={4} pcbX={22} pcbY={0} />
+  </board>
+)
+`} />
+
+### Step 5: Wire Everything Together
+
+Now we connect all components — USB-C VBUS to the PD trigger IC, CC pins for negotiation, the regulator, and the output headers.
+
+<CircuitPreview hidePCBTab hide3DTab defaultView="schematic" code={`
+export default () => (
+  <board width="65mm" height="30mm">
+    <chip
+      name="J1"
+      manufacturerPartNumber="USB-C-16P"
+      footprint="ssop16"
+      pinLabels={{
+        pin1: ["GND"],
+        pin2: ["VBUS1"],
+        pin3: ["CC1"],
+        pin4: ["D-"],
+        pin5: ["D+"],
+        pin6: ["SBU1"],
+        pin7: ["VBUS2"],
+        pin8: ["GND"],
+        pin9: ["GND"],
+        pin10: ["VBUS3"],
+        pin11: ["CC2"],
+        pin12: ["D+"],
+        pin13: ["D-"],
+        pin14: ["SBU2"],
+        pin15: ["VBUS4"],
+        pin16: ["GND"],
+      }}
+      schPortArrangement={{
+        leftSide: { pins: ["VBUS1", "D-", "D+", "SBU1", "VBUS2", "CC1", "CC2"], direction: "top-to-bottom" },
+        rightSide: { pins: ["VBUS3", "D+", "D-", "SBU2", "VBUS4", "GND", "GND"], direction: "top-to-bottom" },
+      }}
+      pcbX={-22}
+      pcbY={0}
+    />
+    <chip
+      name="U1"
+      manufacturerPartNumber="CH224K"
+      footprint="sot23-6"
+      pinLabels={{
+        pin1: ["sel"],
+        pin2: ["vout"],
+        pin3: ["gnd"],
+        pin4: ["cc"],
+        pin5: ["nc"],
+        pin6: ["pg"],
+      }}
+      schPortArrangement={{
+        leftSide: { pins: ["sel", "cc", "nc"], direction: "top-to-bottom" },
+        rightSide: { pins: ["vout", "gnd", "pg"], direction: "top-to-bottom" },
+      }}
+      pcbX={0}
+      pcbY={0}
+    />
+    <chip
+      name="U2"
+      manufacturerPartNumber="AMS1117-3.3"
+      footprint="sot223"
+      pinLabels={{
+        pin1: ["gnd"],
+        pin2: ["vout"],
+        pin3: ["vin"],
+      }}
+      schPortArrangement={{
+        leftSide: { pins: ["gnd"], direction: "top-to-bottom" },
+        rightSide: { pins: ["vin", "vout"], direction: "top-to-bottom" },
+      }}
+      pcbX={12}
+      pcbY={0}
+    />
+    <capacitor name="C1" capacitance="10uF" footprint="0603" pcbX={12} pcbY={-5} />
+    <capacitor name="C2" capacitance="10uF" footprint="0603" pcbX={12} pcbY={5} />
+    <pinheader name="H1" pinCount={4} pcbX={22} pcbY={0} />
+
+    <trace from=".J1 .VBUS1" to=".U1 .vout" />
+    <trace from=".J1 .VBUS2" to=".U1 .vout" />
+    <trace from=".J1 .VBUS3" to=".U1 .vout" />
+    <trace from=".J1 .VBUS4" to=".U1 .vout" />
+    <trace from=".J1 .GND" to="net.GND" />
+
+    <trace from=".J1 .CC1" to=".U1 .cc" />
+    <trace from=".J1 .CC2" to=".U1 .cc" />
+
+    <trace from=".U1 .gnd" to="net.GND" />
+
+    <trace from=".U1 .vout" to=".U2 .vin" />
+    <trace from=".U1 .vout" to=".H1 .pin1" />
+
+    <trace from=".U2 .gnd" to="net.GND" />
+    <trace from=".U2 .vout" to=".C1 .pos" />
+    <trace from=".U2 .vout" to=".H1 .pin3" />
+    <trace from=".C1 .neg" to="net.GND" />
+
+    <trace from=".C2 .pos" to=".U1 .vout" />
+    <trace from=".C2 .neg" to="net.GND" />
+
+    <trace from=".H1 .pin2" to="net.GND" />
+    <trace from=".H1 .pin4" to="net.GND" />
+  </board>
+)
+`} />
+
+## Configuring the Output Voltage
+
+The CH224K trigger IC detects the desired voltage based on the state of the `SEL` pin. The CH224K supports multiple configuration modes:
+
+### Resistor-Based Configuration (CH224K)
+
+Connect a resistor between the SEL pin and GND to select the output voltage:
+
+| Resistance | Output Voltage |
+|------------|----------------|
+| NC (float) | 5V             |
+| 10k       | 9V             |
+| 5.1k      | 12V            |
+| 3.3k      | 15V            |
+| 2k        | 20V            |
+
+In our circuit, you can replace the `SEL` pin connection with a specific resistor to set the desired voltage. For example, to select 12V output:
+
+```tsx
+<resistor name="R_SEL" resistance="5.1k" footprint="0402" pcbX={-5} pcbY={-5} />
+<trace from=".U1 .sel" to=".R_SEL .pos" />
+<trace from=".R_SEL .neg" to="net.GND" />
+```
+
+## Output Pin Header Reference
+
+The 4-pin output header provides:
+
+| Pin | Signal | Description |
+|-----|--------|-------------|
+| 1   | VPD    | Negotiated PD voltage (e.g., 12V) |
+| 2   | GND    | Ground |
+| 3   | V3.3   | Regulated 3.3V output |
+| 4   | GND    | Ground |
+
+## Safety Considerations
+
+- **Minimum Load**: Some PD chargers require a minimum current draw to maintain the negotiated voltage. If the output drops unexpectedly, add a small load resistor
+- **Heat Dissipation**: At higher voltages, the AMS1117 may get hot if drawing significant current on the 3.3V rail. Consider a switching regulator for high-current 3.3V loads
+- **Inrush Current**: Add a bulk capacitor (10-100 F) on the PD output if powering inductive loads like motors
+- **Reverse Current Protection**: Add a Schottky diode if there's any risk of back-feeding voltage into the PD trigger IC
+
+## PCB Layout
+
+Here is the full PCB layout with all components positioned:
+
+<CircuitPreview hideSchematicTab hide3DTab defaultView="pcb" code={`
+export default () => (
+  <board width="65mm" height="30mm">
+    <chip
+      name="J1"
+      manufacturerPartNumber="USB-C-16P"
+      footprint="ssop16"
+      pinLabels={{
+        pin1: ["GND"],
+        pin2: ["VBUS1"],
+        pin3: ["CC1"],
+        pin4: ["D-"],
+        pin5: ["D+"],
+        pin6: ["SBU1"],
+        pin7: ["VBUS2"],
+        pin8: ["GND"],
+        pin9: ["GND"],
+        pin10: ["VBUS3"],
+        pin11: ["CC2"],
+        pin12: ["D+"],
+        pin13: ["D-"],
+        pin14: ["SBU2"],
+        pin15: ["VBUS4"],
+        pin16: ["GND"],
+      }}
+      schPortArrangement={{
+        leftSide: { pins: ["VBUS1", "D-", "D+", "SBU1", "VBUS2", "CC1", "CC2"], direction: "top-to-bottom" },
+        rightSide: { pins: ["VBUS3", "D+", "D-", "SBU2", "VBUS4", "GND", "GND"], direction: "top-to-bottom" },
+      }}
+      pcbX={-22}
+      pcbY={0}
+    />
+    <chip
+      name="U1"
+      manufacturerPartNumber="CH224K"
+      footprint="sot23-6"
+      pinLabels={{
+        pin1: ["sel"],
+        pin2: ["vout"],
+        pin3: ["gnd"],
+        pin4: ["cc"],
+        pin5: ["nc"],
+        pin6: ["pg"],
+      }}
+      schPortArrangement={{
+        leftSide: { pins: ["sel", "cc", "nc"], direction: "top-to-bottom" },
+        rightSide: { pins: ["vout", "gnd", "pg"], direction: "top-to-bottom" },
+      }}
+      pcbX={0}
+      pcbY={0}
+    />
+    <chip
+      name="U2"
+      manufacturerPartNumber="AMS1117-3.3"
+      footprint="sot223"
+      pinLabels={{
+        pin1: ["gnd"],
+        pin2: ["vout"],
+        pin3: ["vin"],
+      }}
+      schPortArrangement={{
+        leftSide: { pins: ["gnd"], direction: "top-to-bottom" },
+        rightSide: { pins: ["vin", "vout"], direction: "top-to-bottom" },
+      }}
+      pcbX={12}
+      pcbY={0}
+    />
+    <capacitor name="C1" capacitance="10uF" footprint="0603" pcbX={12} pcbY={-5} />
+    <capacitor name="C2" capacitance="10uF" footprint="0603" pcbX={12} pcbY={5} />
+    <pinheader name="H1" pinCount={4} pcbX={22} pcbY={0} />
+
+    <trace from=".J1 .VBUS1" to=".U1 .vout" />
+    <trace from=".J1 .VBUS2" to=".U1 .vout" />
+    <trace from=".J1 .VBUS3" to=".U1 .vout" />
+    <trace from=".J1 .VBUS4" to=".U1 .vout" />
+    <trace from=".J1 .GND" to="net.GND" />
+
+    <trace from=".J1 .CC1" to=".U1 .cc" />
+    <trace from=".J1 .CC2" to=".U1 .cc" />
+
+    <trace from=".U1 .gnd" to="net.GND" />
+
+    <trace from=".U1 .vout" to=".U2 .vin" />
+    <trace from=".U1 .vout" to=".H1 .pin1" />
+
+    <trace from=".U2 .gnd" to="net.GND" />
+    <trace from=".U2 .vout" to=".C1 .pos" />
+    <trace from=".U2 .vout" to=".H1 .pin3" />
+    <trace from=".C1 .neg" to="net.GND" />
+
+    <trace from=".C2 .pos" to=".U1 .vout" />
+    <trace from=".C2 .neg" to="net.GND" />
+
+    <trace from=".H1 .pin2" to="net.GND" />
+    <trace from=".H1 .pin4" to="net.GND" />
+  </board>
+)
+`} />
+
+## Ordering the PCB
+
+You can order this PCB by downloading the fabrication files (Gerbers) and uploading them to JLCPCB. Follow the instructions from [Ordering Prototypes](/building-electronics/ordering-prototypes).
+
+## Next Steps
+
+- Add a toggle switch or jumper to select between multiple PD voltage levels
+- Integrate a microcontroller to monitor the PG (Power Good) signal
+- Add an INA219 current sensor to measure power consumption
+- Pair with a Class D audio amplifier HAT that needs a 12V supply
+- Design a custom enclosure using the 3D CAD model from tscircuit


### PR DESCRIPTION
/claim #601
/claim #602
/claim #603

## Tutorials Added

### USB PD Trigger HAT (#601)
Design a USB PD Trigger HAT using the CH224K trigger IC. Covers PD negotiation, USB-C connector integration, voltage regulator, and output headers.

### I2C Environmental Sensor Module (#602)
Build a BME280 environmental sensor module connected to a Raspberry Pi Pico W over I2C. Covers temperature, humidity, and pressure sensing.

### Class D Audio Amplifier HAT (#603)
Design a PAM8403 Class D stereo audio amplifier HAT. Covers input coupling, bias resistors, power decoupling, and speaker outputs.