### PR TITLE
Document schematic section title font size prop

### DIFF
--- a/docs/elements/schematicsection.mdx
+++ b/docs/elements/schematicsection.mdx
@@ -8,7 +8,7 @@ import CircuitPreview from "@site/src/components/CircuitPreview"
 
 ## Overview
 
-`<schematicsection />` groups schematic components into named, labeled regions. Each section draws a bounding box around its member components and renders a display label. When multiple sections exist, automatic dividing lines separate them.
+`<schematicsection />` groups schematic components into named, labeled regions. Each section draws a bounding box around its member components and renders a display label. You can control the label size with `sectionTitleFontSize`. When multiple sections exist, automatic dividing lines separate them.
 
 Components opt in to a section by setting `schSectionName` to match the section's `name` prop.
 
@@ -61,6 +61,7 @@ export default () => (
 |------|------|----------|-------------|
 | `name` | `string` | Yes | Identifier matched by `schSectionName` on member components |
 | `displayName` | `string` | No | Label rendered in the top-left corner of the section region |
+| `sectionTitleFontSize` | `number \| string` | No | Font size for the section title label. Defaults to `0.18` schematic units. |
 
 ## Component `schSectionName`
 
@@ -74,4 +75,3 @@ Any component that accepts schematic position props also accepts `schSectionName
   schSectionName="power"
 />
 ```
-

--- a/docs/footprints/footprinter-strings.mdx
+++ b/docs/footprints/footprinter-strings.mdx
@@ -305,19 +305,23 @@ Parameters:
 
 ## qfn
 
-Quad Flat No-Lead (QFN) package footprint with configurable number of pins.
+Quad Flat No-Lead (QFN) package footprint with configurable number of pins. Add
+`thermalpad` for a centered exposed pad, or pass dimensions such as
+`thermalpad3.1x3.1mm` to size it.
 
-<FootprintPreview footprints={["qfn20", "qfn32"]} />
+<FootprintPreview footprints={["qfn20", "qfn32_thermalpad", "qfn32_thermalpad3.1x3.1mm"]} />
 
 Parameters:
 
 | Parameter | Default | Description |
 |-----------|---------|-------------|
 | `num_pins` | `20` | Total number of pins (must be divisible by 4) |
-| `body_size` | `"4mm"` | Size of the package body (square) |
+| `w` | _calculated_ | Package body width |
+| `h` | _same as `w`_ | Package body height |
 | `p` | `"0.5mm"` | Pin pitch (center-to-center distance between adjacent pins) |
 | `pw` | `"0.25mm"` | Pin width |
-| `pl` | `"0.4mm"` | Pin length (exposed pad length) |
+| `pl` | `"0.875mm"` | Pin length (exposed pad length) |
+| `thermalpad` | _none_ | Center exposed thermal pad. Use `thermalpad` for the default size or `thermalpad3.1x3.1mm` for a custom width and height. |
 
 ## sot23
 


### PR DESCRIPTION
Add documentation for the sectionTitleFontSize prop on schematicsection, including its purpose and default fallback of 0.18 schematic units.