### PR TITLE
docs: add TI parts engine platform config guide

### DIFF
--- a/docs/guides/running-tscircuit/platform-configuration.md
+++ b/docs/guides/running-tscircuit/platform-configuration.md
@@ -15,6 +15,8 @@ Some use cases:
 - Organizations may want to customize the cloud autorouter to avoid sending sensitive designs outside your company
 - Organizations may want to introduce custom footprint strings
   using a prefix like `footprint="my-company:*"`
+- Organizations may want to provide vendor-specific behavior, such as a custom
+  TI parts engine or `ti:` footprint library
 - Organizations may want to use their own internal registry for importing circuits instead of [tscircuit.com](https://tscircuit.com)
 - For [autorouting.com](https://autorouting.com), we configure the platform to not perform any autorouting
 
@@ -88,6 +90,18 @@ await circuitRunner.renderUntilSettled()
 
 const circuitJson = await circuitRunner.getCircuitJson()
 ```
+
+## External Vendor Integrations
+
+Vendor-specific integrations do not need to be built into `@tscircuit/eval`.
+You can provide them through a custom platform configuration instead.
+
+For a concrete example, see
+[Using ti-parts-engine](./using-ti-parts-engine). That guide shows:
+
+- how to provide a custom TI-backed `partsEngine`
+- how to enable explicit `footprint="ti:..."` strings when needed
+- how to keep partner-token usage in local tooling instead of browser clients
 
 :::info
 Interested in running the entire tscircuit platform privately inside your company?

--- a/docs/guides/running-tscircuit/platform-configuration.md
+++ b/docs/guides/running-tscircuit/platform-configuration.md
@@ -15,8 +15,6 @@ Some use cases:
 - Organizations may want to customize the cloud autorouter to avoid sending sensitive designs outside your company
 - Organizations may want to introduce custom footprint strings
   using a prefix like `footprint="my-company:*"`
-- Organizations may want to provide vendor-specific behavior, such as a custom
-  TI parts engine or `ti:` footprint library
 - Organizations may want to use their own internal registry for importing circuits instead of [tscircuit.com](https://tscircuit.com)
 - For [autorouting.com](https://autorouting.com), we configure the platform to not perform any autorouting
 
@@ -93,7 +91,6 @@ const circuitJson = await circuitRunner.getCircuitJson()
 
 ## External Vendor Integrations
 
-Vendor-specific integrations do not need to be built into `@tscircuit/eval`.
 You can provide them through a custom platform configuration instead.
 
 For a concrete example, see

--- a/docs/guides/running-tscircuit/using-ti-parts-engine.mdx
+++ b/docs/guides/running-tscircuit/using-ti-parts-engine.mdx
@@ -1,0 +1,85 @@
+---
+title: Using ti-parts-engine
+description: Configure TI-backed part lookup and explicit `ti:` footprints through a custom platform config
+sidebar_position: 5
+---
+
+`@tscircuit/ti-parts-engine` is an external helper package for local TI-backed
+development workflows. It is not built into `@tscircuit/eval` by default.
+Instead, provide it through a custom platform configuration.
+
+## Install from GitHub
+
+`ti-parts-engine` is currently installed directly from GitHub:
+
+```bash
+bun add -D github:tscircuit/ti-parts-engine
+```
+
+## Use TI as a Custom Parts Engine
+
+If your local tooling loads a JS/TS platform config module, you can keep the TI
+parts engine in a `tscircuit.config.ts`-style file:
+
+```ts
+import { createTiPartsEngine } from "@tscircuit/ti-parts-engine"
+
+export default {
+  platformConfig: {
+    partsEngine: createTiPartsEngine({
+      // local CLI/dev usage only
+      partnerToken: process.env.PARTNER_TOKEN!,
+    }),
+  },
+}
+```
+
+This wires TI-backed automatic part lookup through `platform.partsEngine`.
+
+:::info
+Keep `PARTNER_TOKEN` in local development tooling only. Do not expose it to
+browser clients or commit it to your repository.
+:::
+
+## Use Explicit `ti:` Footprint Strings
+
+If you want to use explicit footprint strings such as
+`footprint="ti:MSP430"`, you also need a TI footprint library mapping. The
+easiest way to wire both pieces together is `createTiPlatformConfig(...)`:
+
+```ts
+import { createTiPlatformConfig } from "@tscircuit/ti-parts-engine"
+
+export default {
+  platformConfig: createTiPlatformConfig({
+    partnerToken: process.env.PARTNER_TOKEN!,
+  }),
+}
+```
+
+This configures:
+
+- `partsEngine` for TI-backed part lookup
+- `footprintLibraryMap.ti` for explicit `ti:` footprint strings
+
+If you only provide `createTiPartsEngine(...)`, automatic TI part lookup works,
+but the `ti:` footprint prefix is not added by itself.
+
+## Programmatic Usage
+
+You can also pass the same platform config directly when creating a runner or
+root circuit:
+
+```ts
+import { createTiPlatformConfig } from "@tscircuit/ti-parts-engine"
+import { RootCircuit } from "@tscircuit/core"
+
+const circuit = new RootCircuit({
+  platform: createTiPlatformConfig({
+    partnerToken: process.env.PARTNER_TOKEN!,
+  }),
+})
+```
+
+For more background on platform customization, see
+[Platform Configuration](./platform-configuration).

--- a/docs/guides/running-tscircuit/using-ti-parts-engine.mdx
+++ b/docs/guides/running-tscircuit/using-ti-parts-engine.mdx
@@ -4,17 +4,11 @@ description: Configure TI-backed part lookup and explicit `ti:` footprints throu
 sidebar_position: 5
 ---
 
-`@tscircuit/ti-parts-engine` is an external helper package for local TI-backed
-development workflows. It is not built into `@tscircuit/eval` by default.
-Instead, provide it through a custom platform configuration.
+`@tscircuit/ti-parts-engine` helps you provide TI-backed behavior through a
+custom platform configuration in local development workflows.
 
-## Install from GitHub
-
-`ti-parts-engine` is currently installed directly from GitHub:
-
-```bash
-bun add -D github:tscircuit/ti-parts-engine
-```
+This guide assumes `@tscircuit/ti-parts-engine` is available in your local
+development environment.
 
 ## Use TI as a Custom Parts Engine
 
@@ -65,13 +59,43 @@ This configures:
 If you only provide `createTiPartsEngine(...)`, automatic TI part lookup works,
 but the `ti:` footprint prefix is not added by itself.
 
-## Programmatic Usage
+## Example User Project Files
 
-You can also pass the same platform config directly when creating a runner or
-root circuit:
+If your local tooling supports a JS/TS platform config module, a minimal TI
+footprint project can look like this:
+
+`index.circuit.tsx`
+
+```tsx
+export default () => (
+  <board width="20mm" height="20mm">
+    <chip name="U1" footprint="ti:MSP430" />
+  </board>
+)
+```
+
+`tscircuit.config.ts`
 
 ```ts
 import { createTiPlatformConfig } from "@tscircuit/ti-parts-engine"
+
+export default {
+  platformConfig: createTiPlatformConfig({
+    // local CLI/dev usage only
+    partnerToken: process.env.PARTNER_TOKEN!,
+  }),
+}
+```
+
+This is a local CLI/dev style workflow. Do not expose a real `PARTNER_TOKEN`
+to browser clients.
+
+## Programmatic Usage
+
+You can also pass the same `createTiPlatformConfig(...)` result directly when
+creating a runner or root circuit:
+
+```ts
 import { RootCircuit } from "@tscircuit/core"
 
 const circuit = new RootCircuit({

--- a/docs/guides/tscircuit-essentials/tscircuit-config.mdx
+++ b/docs/guides/tscircuit-essentials/tscircuit-config.mdx
@@ -5,50 +5,34 @@ description: Configure your tscircuit project settings
 
 The `tscircuit.config.json` file is a project-level configuration file that allows you to customize settings for your tscircuit project. This file should be placed in the root of your project directory and is automatically created when you run `tsci init`.
 
-`tscircuit.config.json` is designed for serializable project settings. It is a
-good place for entrypoints, build options, snapshot preferences, and other JSON
-configuration.
-
-If you need function-valued platform settings such as a custom `partsEngine` or
-`footprintLibraryMap`, keep those in a separate JS/TS module and pass that
-platform config from your runtime or local tooling instead of trying to embed
-them directly in `tscircuit.config.json`.
-
 ## Example
 
 ```json
 {
   "mainEntrypoint": "lib/circuits/main-board.tsx",
-  "ignoredFiles": [
-    "dist",
-    "build",
-    "coverage",
-    "*.log",
-    ".DS_Store",
-    "temp"
-  ]
+  "ignoredFiles": ["dist", "build", "coverage", "*.log", ".DS_Store", "temp"]
 }
 ```
 
 ## Configuration Options
 
-| Property | Description |
-| --- | --- |
-| `$schema` | [Optional JSON schema reference for editor tooling.](#schema) |
-| `mainEntrypoint` | [Primary entry file for builds and dev workflows.](#mainentrypoint) |
-| `previewComponentPath` | [Overrides which component is used for preview images/GLTF.](#previewcomponentpath) |
-| `siteDefaultComponentPath` | [Default component shown in generated static sites.](#sitedefaultcomponentpath) |
-| `ignoredFiles` | [Extra file and directory ignore patterns for CLI workflows.](#ignoredfiles) |
-| `includeBoardFiles` | [Glob list for which board files are built or snapshotted.](#includeboardfiles) |
-| `snapshotsDir` | [Centralized directory for snapshot outputs.](#snapshotsdir) |
-| `prebuildCommand` | [Command to run before builds.](#prebuildcommand) |
-| `buildCommand` | [Override command used for cloud builds.](#buildcommand) |
-| `kicadProjectEntrypointPath` | [Entry file for KiCad project generation.](#kicadprojectentrypointpath) |
-| `kicadLibraryEntrypointPath` | [Entry file for KiCad footprint library generation.](#kicadlibraryentrypointpath) |
-| `kicadLibraryName` | [Name for the generated KiCad library.](#kicadlibraryname) |
+| Property                          | Description                                                                         |
+| --------------------------------- | ----------------------------------------------------------------------------------- |
+| `$schema`                         | [Optional JSON schema reference for editor tooling.](#schema)                       |
+| `mainEntrypoint`                  | [Primary entry file for builds and dev workflows.](#mainentrypoint)                 |
+| `previewComponentPath`            | [Overrides which component is used for preview images/GLTF.](#previewcomponentpath) |
+| `siteDefaultComponentPath`        | [Default component shown in generated static sites.](#sitedefaultcomponentpath)     |
+| `ignoredFiles`                    | [Extra file and directory ignore patterns for CLI workflows.](#ignoredfiles)        |
+| `includeBoardFiles`               | [Glob list for which board files are built or snapshotted.](#includeboardfiles)     |
+| `snapshotsDir`                    | [Centralized directory for snapshot outputs.](#snapshotsdir)                        |
+| `prebuildCommand`                 | [Command to run before builds.](#prebuildcommand)                                   |
+| `buildCommand`                    | [Override command used for cloud builds.](#buildcommand)                            |
+| `kicadProjectEntrypointPath`      | [Entry file for KiCad project generation.](#kicadprojectentrypointpath)             |
+| `kicadLibraryEntrypointPath`      | [Entry file for KiCad footprint library generation.](#kicadlibraryentrypointpath)   |
+| `kicadLibraryName`                | [Name for the generated KiCad library.](#kicadlibraryname)                          |
 | `alwaysUseLatestTscircuitOnCloud` | [Force latest tscircuit version in cloud builds.](#alwaysuselatesttscircuitoncloud) |
-| `build` | [Build output toggles for CLI builds.](#build) |
-| `pcbSnapshotSettings` | [Rendering options for PCB snapshots and preview images.](#pcbsnapshotsettings) |
+| `build`                           | [Build output toggles for CLI builds.](#build)                                      |
+| `pcbSnapshotSettings`             | [Rendering options for PCB snapshots and preview images.](#pcbsnapshotsettings)     |
 
 ### $schema
 
@@ -145,13 +129,7 @@ Specifies paths or directory names that should be ignored when the dev server sy
 
 ```json
 {
-  "ignoredFiles": [
-    "dist",
-    "build",
-    ".git",
-    "*.log",
-    "temp"
-  ]
+  "ignoredFiles": ["dist", "build", ".git", "*.log", "temp"]
 }
 ```
 
@@ -362,6 +340,7 @@ Toggle build outputs for `tsci build`.
 ```
 
 **Options:**
+
 - `circuitJson` (`boolean`): Enable circuit JSON output in build.
 - `kicadProject` (`boolean`): Enable KiCad project output (`.kicad_pro`, `.kicad_sch`, `.kicad_pcb`) in build.
 - `kicadLibrary` (`boolean`): Enable KiCad library output in build.
@@ -390,6 +369,7 @@ Controls rendering options for PCB images generated by `tsci snapshot` and `tsci
 ```
 
 **Options:**
+
 - `showCourtyards` (`boolean`): Render courtyard outlines around components. Courtyards define the keepout boundary for a footprint. Defaults to `false`.
 - `showPcbNotes` (`boolean`): Render PCB notes layer in the output image. Defaults to `false`.
 - `showFabricationNotes` (`boolean`): Render fabrication notes layer in the output image. Defaults to `false`.

--- a/docs/guides/tscircuit-essentials/tscircuit-config.mdx
+++ b/docs/guides/tscircuit-essentials/tscircuit-config.mdx
@@ -5,6 +5,15 @@ description: Configure your tscircuit project settings
 
 The `tscircuit.config.json` file is a project-level configuration file that allows you to customize settings for your tscircuit project. This file should be placed in the root of your project directory and is automatically created when you run `tsci init`.
 
+`tscircuit.config.json` is designed for serializable project settings. It is a
+good place for entrypoints, build options, snapshot preferences, and other JSON
+configuration.
+
+If you need function-valued platform settings such as a custom `partsEngine` or
+`footprintLibraryMap`, keep those in a separate JS/TS module and pass that
+platform config from your runtime or local tooling instead of trying to embed
+them directly in `tscircuit.config.json`.
+
 ## Example
 
 ```json


### PR DESCRIPTION
## Summary

- add a new guide for using `@tscircuit/ti-parts-engine` through custom platform configuration
- clarify that `tscircuit.config.json` is for serializable JSON settings, not function-valued platform config
- expand the platform configuration docs with vendor integration guidance and link to the new TI guide

## Why

These changes make it clearer how to wire TI-backed part lookup and `ti:` footprint support into local tooling without implying that this behavior is built into `@tscircuit/eval` or should live inside `tscircuit.config.json`.
