### PR TITLE
Add documentation for cornerRadius property in silkscreen rectangles

### DIFF
--- a/docs/footprints/silkscreenrect.mdx
+++ b/docs/footprints/silkscreenrect.mdx
@@ -28,6 +28,7 @@ import CircuitPreview from "@site/src/components/CircuitPreview"
 | `pcbY` | length | Y coordinate of the rectangle center on the PCB silkscreen. |
 | `width` | length | Width of the rectangle. |
 | `height` | length | Height of the rectangle. |
+| `cornerRadius` | length | Corner radius for rounded rectangle corners. |
 | `strokeWidth` | length | Thickness of the rectangle outline. |
 | `filled` | boolean | When `true`, fills the rectangle instead of drawing only the outline. |
 | `hasStroke` | boolean | When `false`, hides the outline even if `filled` is not set. |
@@ -44,6 +45,26 @@ Use `strokeWidth` to control the outline thickness of the rectangle. This is hel
     <footprint name="U1">
       <silkscreenrect pcbX={-2} pcbY={0} width={2} height={2} strokeWidth={0.1} />
       <silkscreenrect pcbX={2} pcbY={0} width={2} height={2} strokeWidth={0.35} />
+    </footprint>
+  </board>
+  )
+`} />
+
+## Rounded Corners
+
+Use `cornerRadius` to round the corners of a silkscreen rectangle.
+
+<CircuitPreview code={`
+  export default () => (
+  <board width="6mm" height="5mm">
+    <footprint name="U1">
+      <silkscreenrect
+        pcbX={0}
+        pcbY={0}
+        width={3}
+        height={2}
+        cornerRadius={0.4}
+      />
     </footprint>
   </board>
   )

--- a/docs/footprints/silkscreenrect.mdx
+++ b/docs/footprints/silkscreenrect.mdx
@@ -50,26 +50,6 @@ Use `strokeWidth` to control the outline thickness of the rectangle. This is hel
   )
 `} />
 
-## Rounded Corners
-
-Use `cornerRadius` to round the corners of a silkscreen rectangle.
-
-<CircuitPreview code={`
-  export default () => (
-  <board width="6mm" height="5mm">
-    <footprint name="U1">
-      <silkscreenrect
-        pcbX={0}
-        pcbY={0}
-        width={3}
-        height={2}
-        cornerRadius={0.4}
-      />
-    </footprint>
-  </board>
-  )
-`} />
-
 ## Filled Silkscreen Rectangles
 
 Enable the `filled` prop to create solid silkscreen blocks—useful for alignment targets or bold markings. You can mix filled and outlined rectangles within the same footprint.


### PR DESCRIPTION
This pull request updates the documentation for the `silkscreenrect` component to add support and usage instructions for rounded rectangle corners. The main changes clarify the new `cornerRadius` property and provide an example of its usage.

**Documentation updates for rounded corners:**

* Added a description of the `cornerRadius` property to the properties table, explaining that it controls the corner radius for rounded rectangle corners.
* Introduced a new "Rounded Corners" section with an example demonstrating how to use the `cornerRadius` prop in `silkscreenrect`.