### PR TITLE
docs: document project and programmatic platform configuration

### DIFF
--- a/docs/guides/running-tscircuit/platform-configuration.md
+++ b/docs/guides/running-tscircuit/platform-configuration.md
@@ -51,6 +51,39 @@ if tscircuit finds parts for a vendor, you don't have to use that vendor!
 Want more platform features? Tell us about your use case in [this GitHub Discussion!](https://github.com/orgs/tscircuit/discussions/514)
 :::
 
+### Configure a project with `tscircuit.config.ts`
+
+For CLI projects, define a `platformConfig` export in `tscircuit.config.ts` at
+the root of your project. This lets every board in the project use the same
+parts engine, autorouter, registry, or footprint libraries without passing a
+platform object into each circuit manually.
+
+For example, the TI parts engine can define components from Texas Instruments
+part data. First install it as a development dependency:
+
+```sh
+bun add -D github:tscircuit/ti-parts-engine
+```
+
+Then configure it in your project:
+
+```ts title="tscircuit.config.ts"
+import { createTiPlatformConfig } from "@tscircuit/ti-parts-engine"
+
+export default {
+  platformConfig: createTiPlatformConfig(),
+}
+```
+
+You can now use TI components inside tscircuit with automatically loaded SPICE
+and footprints:
+
+```tsx
+<chip name="U1" footprint="ti:LM358" />
+```
+
+### Provide a platform programmatically
+
 When you initialize a `RootCircuit`, you can provide the platform configuration
 as the `{ platform }` parameter:
 


### PR DESCRIPTION
### Motivation
- Clarify how to configure the tscircuit platform once per project instead of passing platform objects into each circuit. 
- Provide a concrete example showing how to enable a vendor parts engine (TI) so users can automatically load SPICE models and footprints.

### Description
- Add a new section explaining how to define a `platformConfig` export in `tscircuit.config.ts` and an example using `createTiPlatformConfig()` from the TI parts engine. 
- Show the installation command for the TI parts engine with `bun add -D github:tscircuit/ti-parts-engine` and an example snippet using `<chip name="U1" footprint="ti:LM358" />`.
- Expand the docs to reiterate how to provide a platform programmatically via the `platform` parameter when constructing `RootCircuit` and when creating a `CircuitRunner` for evaluation.

### Testing
- This is a documentation-only change, so no code behavior changes were required. 
- Local documentation build and markdown linting were run and completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a20e0a7fefc832e9c7d278d3ad06053)