### PR TITLE
docs: update online editor navbar link

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -179,8 +179,8 @@ const config: Config = {
         },
         { to: "https://blog.tscircuit.com", label: "Blog", position: "left" },
         {
-          to: "https://tscircuit.com",
-          label: "Use Online",
+          to: "https://tscircuit.com/editor",
+          label: "Try Online",
           position: "left",
         },
 


### PR DESCRIPTION
Claims tscircuit/docs-old#67

/claim #67

## Summary
- Rename the navbar online link to "Try Online"
- Point the link directly to https://tscircuit.com/editor

## Verification
- Confirmed GitHub comparison shows 1 file changed with 2 additions and 2 deletions