### PR TITLE
docs: use GitHub edit links

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -42,7 +42,7 @@ const config: Config = {
         docs: {
           sidebarPath: "./sidebars.ts",
           routeBasePath: "/", // Serve docs at root
-          editUrl: "https://github.com/tscircuit/docs/tree/main/",
+          editUrl: "https://github.com/tscircuit/docs/edit/main/",
           breadcrumbs: false,
         },
         theme: {


### PR DESCRIPTION
Claims tscircuit/docs-old#65.

/claim #65

## Summary

- Update the Docusaurus `editUrl` to use GitHub edit mode.
- Keep the docs source repository and branch unchanged.
- Make generated doc edit links open the in-browser GitHub editor instead of the file browser.

## Verification

- `git diff --check`
- Checked `docusaurus.config.ts` contains `https://github.com/tscircuit/docs/edit/main/`

## Notes

The original bounty issue is in the archived `tscircuit/docs-old` repository, which is read-only and does not allow a fresh `/attempt` comment. This PR targets the active `tscircuit/docs` repository, matching the pattern used by other `docs-old` bounty claims.
