### PR TITLE
Update docs nav editor link

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -179,8 +179,8 @@ const config: Config = {
         },
         { to: "https://blog.tscircuit.com", label: "Blog", position: "left" },
         {
-          to: "https://tscircuit.com",
-          label: "Use Online",
+          to: "https://tscircuit.com/editor",
+          label: "Try Online",
           position: "left",
         },
 


### PR DESCRIPTION
## Summary

- rename the top nav "Use Online" link to "Try Online"
- point it directly to `https://tscircuit.com/editor`

## Validation

- `git diff --check`
- Node assertion that the nav contains `label: "Try Online"` and `to: "https://tscircuit.com/editor"`

Fixes tscircuit/docs-old#67

/claim #67

Note: the source issue is in the archived `tscircuit/docs-old` issue tracker, so I could not add an `/attempt` comment there. This PR targets the active `tscircuit/docs` repo where the docs config lives.
