### PR TITLE
docs: remove header support link

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -185,12 +185,6 @@ const config: Config = {
         },
 
         {
-          href: "https://discord.com/invite/V7FGE5ZCbA",
-          position: "right",
-          className: "header-discord-link header-icon-link",
-          html: '<img src="/img/discord.svg" alt="Discord" style="height: 18px; width: 18px; margin-bottom: -4px;" class="github-icon" />',
-        },
-        {
           href: "https://github.com/tscircuit/tscircuit",
           position: "right",
           className: "header-github-link header-icon-link",


### PR DESCRIPTION
Claims tscircuit/docs-old#66.

/claim #66

## Summary

- Remove the Discord/support icon link from the top docs navbar.
- Keep the GitHub navbar icon and footer/community Discord links intact.

## Verification

- `git diff --check`
- Local Node assertion that the navbar block no longer contains the Discord invite and still contains the GitHub link

## Notes

The original bounty issue is in the archived `tscircuit/docs-old` repository, which is read-only and does not allow a fresh `/attempt` comment. This PR targets the active `tscircuit/docs` repository, matching the pattern used by other `docs-old` bounty claims.
