### PR TITLE
docs: center ordinary doc content column

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -851,9 +851,17 @@ article h4 {
   display: none !important;
 }
 
-/* Force center all documentation content */
-.col:not(.col--3) {
-  max-width: 1000px !important;
+/* Center ordinary doc pages after hiding the right table of contents. */
+[class*="docItemCol"] {
+  float: none !important;
+  max-width: 860px !important;
+  margin-left: auto !important;
+  margin-right: auto !important;
+}
+
+[class*="docItemContainer"] article,
+[class*="docItemContainer"] .markdown {
+  max-width: 860px !important;
   margin-left: auto !important;
   margin-right: auto !important;
 }


### PR DESCRIPTION
Claims tscircuit/docs-old#64.

/claim #64

## Summary

- Center ordinary Docusaurus doc pages with a readable `860px` max-width after the right table of contents is hidden.
- Scope the centering to `docItem` containers instead of globally squeezing every `.col`, so generated index pages and other layouts keep their current width behavior.
- Preserve the existing generated-index page centering overrides.

## Verification

- `git diff --check`
- Local Node assertion that the scoped doc item selectors and `860px` max-width are present.
- Local Node assertion that the broad `.col:not(.col--3)` selector is not used for this fix.

Note: the archived `tscircuit/docs-old#64` issue is read-only/locked, so I could not post `/attempt` there. This PR follows the same live-repo claim pattern used by the current docs-old bounty claims.