### PR TITLE
docs: add Arduino Uno reference schematic

### DIFF
--- a/docs/tutorials/arduino-uno-reference-schematic.mdx
+++ b/docs/tutorials/arduino-uno-reference-schematic.mdx
@@ -1,0 +1,415 @@
+---
+title: Arduino Uno Reference Schematic
+description: >-
+  Build a schematic-only Arduino Uno style reference circuit with ATmega328P,
+  USB serial, power, reset, clock, headers, and ICSP blocks.
+---
+
+import CircuitPreview from "@site/src/components/CircuitPreview"
+
+## Overview
+
+This tutorial builds a schematic-only Arduino Uno style reference in tscircuit.
+It focuses on the recognizable functional blocks instead of PCB routing:
+
+- ATmega328P microcontroller core
+- USB serial bridge for uploads and serial monitor traffic
+- 5 V, 3.3 V, VIN, and ground rails
+- reset pull-up, reset button, and auto-reset capacitor
+- 16 MHz clock and load capacitors
+- digital, analog, power, and ICSP headers
+- built-in `L` LED on `D13`
+
+Use the official Arduino Uno Rev3 documentation and schematic when adapting this
+example to a production-compatible design:
+
+- [Arduino Uno Rev3 product page](https://store.arduino.cc/products/arduino-uno-rev3)
+- [Arduino Uno Rev3 schematic PDF](https://docs.arduino.cc/resources/schematics/A000066-schematics.pdf)
+
+## Full Schematic
+
+The snippet below keeps the board schematic-only with `routingDisabled`, then
+names the functional nets so each Uno block is easy to review.
+
+<CircuitPreview
+  alwaysShowCode
+  splitView
+  defaultView="schematic"
+  hidePCBTab
+  hide3DTab
+  code={`
+export default () => (
+  <board width="120mm" height="86mm" routingDisabled>
+    <net name="VIN" />
+    <net name="VUSB" />
+    <net name="V5" />
+    <net name="V3_3" />
+    <net name="GND" />
+    <net name="RESET" />
+    <net name="AREF" />
+    <net name="XTAL1" />
+    <net name="XTAL2" />
+    <net name="DTR" />
+    <net name="USB_D_PLUS" />
+    <net name="USB_D_MINUS" />
+
+    <chip
+      name="U_ATMEGA328P"
+      footprint="dip28"
+      schX={0}
+      schY={0}
+      schWidth="36mm"
+      schHeight="56mm"
+      pinLabels={{
+        pin1: "RESET",
+        pin2: "D0_RX",
+        pin3: "D1_TX",
+        pin4: "D2",
+        pin5: "D3_PWM",
+        pin6: "D4",
+        pin7: "VCC",
+        pin8: "GND",
+        pin9: "XTAL1",
+        pin10: "XTAL2",
+        pin11: "D5_PWM",
+        pin12: "D6_PWM",
+        pin13: "D7",
+        pin14: "D8",
+        pin15: "D9_PWM",
+        pin16: "D10_SS",
+        pin17: "D11_MOSI",
+        pin18: "D12_MISO",
+        pin19: "D13_SCK",
+        pin20: "AVCC",
+        pin21: "AREF",
+        pin22: "AGND",
+        pin23: "A0",
+        pin24: "A1",
+        pin25: "A2",
+        pin26: "A3",
+        pin27: "A4_SDA",
+        pin28: "A5_SCL",
+      }}
+      schPinArrangement={{
+        leftSide: {
+          direction: "top-to-bottom",
+          pins: ["RESET", "D0_RX", "D1_TX", "D2", "D3_PWM", "D4", "D5_PWM", "D6_PWM", "D7"],
+        },
+        rightSide: {
+          direction: "top-to-bottom",
+          pins: [
+            "D8",
+            "D9_PWM",
+            "D10_SS",
+            "D11_MOSI",
+            "D12_MISO",
+            "D13_SCK",
+            "A0",
+            "A1",
+            "A2",
+            "A3",
+            "A4_SDA",
+            "A5_SCL",
+          ],
+        },
+        topSide: {
+          direction: "left-to-right",
+          pins: ["VCC", "AVCC", "AREF"],
+        },
+        bottomSide: {
+          direction: "left-to-right",
+          pins: ["GND", "AGND", "XTAL1", "XTAL2"],
+        },
+      }}
+      connections={{
+        VCC: "net.V5",
+        AVCC: "net.V5",
+        GND: "net.GND",
+        AGND: "net.GND",
+        AREF: "net.AREF",
+        RESET: "net.RESET",
+        XTAL1: "net.XTAL1",
+        XTAL2: "net.XTAL2",
+        D0_RX: "net.D0_RX",
+        D1_TX: "net.D1_TX",
+        D2: "net.D2",
+        D3_PWM: "net.D3_PWM",
+        D4: "net.D4",
+        D5_PWM: "net.D5_PWM",
+        D6_PWM: "net.D6_PWM",
+        D7: "net.D7",
+        D8: "net.D8",
+        D9_PWM: "net.D9_PWM",
+        D10_SS: "net.D10_SS",
+        D11_MOSI: "net.D11_MOSI",
+        D12_MISO: "net.D12_MISO",
+        D13_SCK: "net.D13_SCK",
+        A0: "net.A0",
+        A1: "net.A1",
+        A2: "net.A2",
+        A3: "net.A3",
+        A4_SDA: "net.A4_SDA",
+        A5_SCL: "net.A5_SCL",
+      }}
+    />
+
+    <connector
+      name="J_USB"
+      standard="usb_c"
+      schX={-56}
+      schY={20}
+      pinLabels={{ pin1: "VBUS", pin2: "D-", pin3: "D+", pin4: "GND" }}
+      connections={{
+        VBUS: "net.VUSB",
+        "D-": "net.USB_D_MINUS",
+        "D+": "net.USB_D_PLUS",
+        GND: "net.GND",
+      }}
+    />
+    <fuse
+      name="F_USB"
+      footprint="0603"
+      schX={-38}
+      schY={20}
+      connections={{ pin1: "net.VUSB", pin2: "net.V5" }}
+    />
+    <chip
+      name="U_USB_SERIAL"
+      footprint="soic16"
+      schX={-28}
+      schY={4}
+      schWidth="24mm"
+      schHeight="30mm"
+      pinLabels={{
+        pin1: "VCC",
+        pin2: "GND",
+        pin3: "TXD",
+        pin4: "RXD",
+        pin5: "DTR",
+        pin6: "D+",
+        pin7: "D-",
+      }}
+      connections={{
+        VCC: "net.V5",
+        GND: "net.GND",
+        TXD: "net.D0_RX",
+        RXD: "net.D1_TX",
+        DTR: "net.DTR",
+        "D+": "net.USB_D_PLUS",
+        "D-": "net.USB_D_MINUS",
+      }}
+    />
+
+    <chip
+      name="U_5V_REG"
+      footprint="sot223"
+      schX={-46}
+      schY={-24}
+      pinLabels={{ pin1: "GND", pin2: "VOUT", pin3: "VIN" }}
+      connections={{ VIN: "net.VIN", VOUT: "net.V5", GND: "net.GND" }}
+    />
+    <chip
+      name="U_3V3_REG"
+      footprint="sot23-5"
+      schX={-22}
+      schY={-24}
+      pinLabels={{ pin1: "VIN", pin2: "GND", pin3: "EN", pin4: "NC", pin5: "VOUT" }}
+      connections={{ VIN: "net.V5", VOUT: "net.V3_3", GND: "net.GND", EN: "net.V5" }}
+    />
+    <capacitor
+      name="C_5V_IN"
+      capacitance="10uF"
+      footprint="0805"
+      schX={-58}
+      schY={-34}
+      connections={{ pos: "net.VIN", neg: "net.GND" }}
+    />
+    <capacitor
+      name="C_5V_OUT"
+      capacitance="10uF"
+      footprint="0805"
+      schX={-34}
+      schY={-34}
+      connections={{ pos: "net.V5", neg: "net.GND" }}
+    />
+    <capacitor
+      name="C_3V3_OUT"
+      capacitance="10uF"
+      footprint="0805"
+      schX={-12}
+      schY={-34}
+      connections={{ pos: "net.V3_3", neg: "net.GND" }}
+    />
+
+    <crystal name="Y_16MHZ" frequency="16MHz" loadCapacitance="18pF" footprint="hc49" schX={4} schY={-38} />
+    <capacitor
+      name="C_XTAL1"
+      capacitance="22pF"
+      footprint="0402"
+      schX={-8}
+      schY={-48}
+      connections={{ pos: "net.XTAL1", neg: "net.GND" }}
+    />
+    <capacitor
+      name="C_XTAL2"
+      capacitance="22pF"
+      footprint="0402"
+      schX={16}
+      schY={-48}
+      connections={{ pos: "net.XTAL2", neg: "net.GND" }}
+    />
+    <trace from=".Y_16MHZ > .pin1" to="net.XTAL1" />
+    <trace from=".Y_16MHZ > .pin2" to="net.XTAL2" />
+
+    <resistor
+      name="R_RESET"
+      resistance="10k"
+      footprint="0402"
+      schX={-16}
+      schY={34}
+      connections={{ pos: "net.V5", neg: "net.RESET" }}
+    />
+    <capacitor
+      name="C_AUTO_RESET"
+      capacitance="100nF"
+      footprint="0402"
+      schX={-32}
+      schY={34}
+      connections={{ pos: "net.DTR", neg: "net.RESET" }}
+    />
+    <pushbutton name="SW_RESET" schX={2} schY={34} connections={{ pin1: "net.RESET", pin2: "net.GND" }} />
+    <capacitor
+      name="C_AREF"
+      capacitance="100nF"
+      footprint="0402"
+      schX={20}
+      schY={34}
+      connections={{ pos: "net.AREF", neg: "net.GND" }}
+    />
+
+    <led name="LED_L" color="yellow" footprint="0603" schX={34} schY={16} />
+    <resistor
+      name="R_LED_L"
+      resistance="1k"
+      footprint="0402"
+      schX={48}
+      schY={16}
+      connections={{ pos: "net.D13_SCK", neg: ".LED_L > .anode" }}
+    />
+    <trace from=".LED_L > .cathode" to="net.GND" />
+
+    <connector
+      name="J_DIGITAL_0_7"
+      schX={56}
+      schY={36}
+      pinLabels={{
+        pin1: "D0/RX",
+        pin2: "D1/TX",
+        pin3: "D2",
+        pin4: "D3 PWM",
+        pin5: "D4",
+        pin6: "D5 PWM",
+        pin7: "D6 PWM",
+        pin8: "D7",
+      }}
+      connections={{
+        "D0/RX": "net.D0_RX",
+        "D1/TX": "net.D1_TX",
+        D2: "net.D2",
+        "D3 PWM": "net.D3_PWM",
+        D4: "net.D4",
+        "D5 PWM": "net.D5_PWM",
+        "D6 PWM": "net.D6_PWM",
+        D7: "net.D7",
+      }}
+    />
+    <connector
+      name="J_DIGITAL_8_13"
+      schX={56}
+      schY={8}
+      pinLabels={{
+        pin1: "D8",
+        pin2: "D9 PWM",
+        pin3: "D10 SS",
+        pin4: "D11 MOSI",
+        pin5: "D12 MISO",
+        pin6: "D13 SCK",
+        pin7: "GND",
+        pin8: "AREF",
+        pin9: "SDA",
+        pin10: "SCL",
+      }}
+      connections={{
+        D8: "net.D8",
+        "D9 PWM": "net.D9_PWM",
+        "D10 SS": "net.D10_SS",
+        "D11 MOSI": "net.D11_MOSI",
+        "D12 MISO": "net.D12_MISO",
+        "D13 SCK": "net.D13_SCK",
+        GND: "net.GND",
+        AREF: "net.AREF",
+        SDA: "net.A4_SDA",
+        SCL: "net.A5_SCL",
+      }}
+    />
+    <connector
+      name="J_ANALOG"
+      schX={56}
+      schY={-18}
+      pinLabels={{ pin1: "A0", pin2: "A1", pin3: "A2", pin4: "A3", pin5: "A4 SDA", pin6: "A5 SCL" }}
+      connections={{
+        A0: "net.A0",
+        A1: "net.A1",
+        A2: "net.A2",
+        A3: "net.A3",
+        "A4 SDA": "net.A4_SDA",
+        "A5 SCL": "net.A5_SCL",
+      }}
+    />
+    <connector
+      name="J_POWER"
+      schX={-58}
+      schY={-8}
+      pinLabels={{ pin1: "RESET", pin2: "3V3", pin3: "5V", pin4: "GND", pin5: "GND", pin6: "VIN" }}
+      connections={{ RESET: "net.RESET", "3V3": "net.V3_3", "5V": "net.V5", GND: "net.GND", VIN: "net.VIN" }}
+    />
+    <connector
+      name="J_ICSP"
+      schX={34}
+      schY={-36}
+      pinLabels={{ pin1: "MISO", pin2: "V5", pin3: "SCK", pin4: "MOSI", pin5: "RESET", pin6: "GND" }}
+      connections={{
+        MISO: "net.D12_MISO",
+        V5: "net.V5",
+        SCK: "net.D13_SCK",
+        MOSI: "net.D11_MOSI",
+        RESET: "net.RESET",
+        GND: "net.GND",
+      }}
+    />
+  </board>
+)
+`}
+/>
+
+## Block Review
+
+| Block | What to verify |
+| --- | --- |
+| ATmega328P | `VCC`, `AVCC`, `GND`, `AGND`, `AREF`, reset, oscillator, digital IO, and analog IO are all named. |
+| USB serial | USB data connects to the serial bridge, and serial bridge `TXD`/`RXD` cross to `D0_RX`/`D1_TX`. |
+| Power | USB power, VIN, 5 V regulator, 3.3 V regulator, and decoupling capacitors are reviewable as separate rails. |
+| Clock | `XTAL1` and `XTAL2` connect to a 16 MHz crystal and two load capacitors to ground. |
+| Reset | `RESET` has a pull-up, pushbutton path to ground, and DTR auto-reset capacitor. |
+| Headers | Digital, analog, power, and ICSP headers expose the same functional groups users expect from an Uno. |
+
+## Why This Is Schematic-Only
+
+The archived bounty asks for an Arduino Uno schematic, not a routed board. Keeping
+the example schematic-only makes it easier to inspect the logical nets and to use
+the circuit as a reference when creating a board-specific layout later.
+
+For a manufacturable Uno-compatible board, replace the generic footprints with
+the exact sourced components, verify USB connector pinout, add board geometry,
+place headers on the Uno mechanical grid, and route the 16 MHz crystal and USB
+signals with their layout constraints.


### PR DESCRIPTION
Claims tscircuit/docs-old#42.

/claim #42

The archived bounty issue is locked, so I could not post an /attempt comment there.

This adds a separate schematic-only Arduino Uno reference tutorial with an ATmega328P core, USB serial bridge, power rails, reset/auto-reset, 16 MHz clock, digital/analog/power/ICSP headers, and the D13 L LED. It links the official Arduino Uno Rev3 product page and schematic PDF for source context.

Local verification:
- git diff --check
- static MDX checks for frontmatter, CircuitPreview usage, balanced code fences, ASCII-only content, Arduino source link, schematic-only flags, and bounded line lengths
