### PR TITLE
Document oval hole support

### DIFF
--- a/docs/elements/hole.mdx
+++ b/docs/elements/hole.mdx
@@ -18,9 +18,10 @@ import CircuitPreview from "@site/src/components/CircuitPreview"
 
 ## Hole Shapes
 
-Three hole shapes are supported:
+Four hole shapes are supported:
 
 - `circle` - A circular hole (default)
+- `oval` - An oval hole
 - `pill` - A pill-shaped hole (rounded rectangle)
 - `rect` - A rectangular hole
 
@@ -36,6 +37,28 @@ A circular hole is the most common type used for mounting. Provide either
   code={`export default () => (
     <board width="30mm" height="20mm">
       <hole radius="1.5mm" pcbX={0} pcbY={0} />
+    </board>
+  )`}
+/>
+
+### Oval Hole
+
+Oval holes are useful for mechanical slots that need smooth curved ends without
+the fully rounded rectangle shape of a pill:
+
+<CircuitPreview
+  defaultView="pcb"
+  hideSchematicTab
+  browser3dView={false}
+  code={`export default () => (
+    <board width="30mm" height="20mm">
+      <hole
+        shape="oval"
+        width="5mm"
+        height="2.5mm"
+        pcbX={0}
+        pcbY={0}
+      />
     </board>
   )`}
 />
@@ -82,7 +105,7 @@ Rectangular holes are useful when you need a slot with straight edges:
   )`}
 />
 
-### Rotated Pill Hole
+### Rotated Holes
 
 Pill-shaped and rectangular holes can be rotated using the `pcbRotation`
 property:
@@ -111,11 +134,11 @@ property:
 
 | Property | Shape | Type | Default | Description |
 |----------|-------|------|---------|-------------|
-| shape | all | `"circle"` \| `"pill"` \| `"rect"` | `"circle"` | Shape of the hole |
+| shape | all | `"circle"` \| `"oval"` \| `"pill"` \| `"rect"` | `"circle"` | Shape of the hole |
 | diameter | circle | number \| string | - | Diameter of the circular hole |
 | radius | circle | number \| string | - | Radius of the circular hole |
-| width | pill, rect | number \| string | - | Width of the pill-shaped or rectangular hole |
-| height | pill, rect | number \| string | - | Height of the pill-shaped or rectangular hole |
+| width | oval, pill, rect | number \| string | - | Width of the oval, pill-shaped, or rectangular hole |
+| height | oval, pill, rect | number \| string | - | Height of the oval, pill-shaped, or rectangular hole |
 | solderMaskMargin | all | number \| string | - | Solder mask opening margin around the hole |
 | coveredWithSolderMask | all | boolean | - | Whether the hole should be covered by solder mask |
 | pcbX | all | number | 0 | X position of the hole center on the PCB |


### PR DESCRIPTION
## Summary

This PR updates the `<hole />` docs to include `oval` as a supported hole shape.

## What Changed

- added `oval` to the supported shape list
- added an oval-hole example to the docs page
- updated the properties table so `shape`, `width`, and `height` reflect oval support
- renamed the rotation section to `Rotated Holes` while keeping rotation docs limited to the shapes currently supported in `core`

## Why

`../core` already supports plain `shape="oval"` for `Hole`, but the docs page still listed only circle, pill, and rect. This left the docs out of sync with the implementation.

## Validation

- reviewed `docs/elements/hole.mdx`
- checked `../core/lib/components/primitive-components/Hole.ts`
- checked `../core/tests/components/primitive-components/hole-oval.test.tsx`

## Notes

I intentionally did not document rotated oval holes because the current `core` implementation does not wire `pcbRotation` for `shape="oval"` yet.