### PR TITLE
docs: link navbar CTA to online editor

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -179,8 +179,8 @@ const config: Config = {
         },
         { to: "https://blog.tscircuit.com", label: "Blog", position: "left" },
         {
-          to: "https://tscircuit.com",
-          label: "Use Online",
+          to: "https://tscircuit.com/editor",
+          label: "Try Online",
           position: "left",
         },
 


### PR DESCRIPTION
Supersedes #725, which was automatically closed as stale on June 10, 2026 before maintainer review.

Claims original bounty issue https://github.com/tscircuit/docs-old/issues/67.

/claim https://github.com/tscircuit/docs-old/issues/67
/claim #67

## Summary

- Rename the top navbar CTA from `Use Online` to `Try Online`.
- Point the CTA directly at `https://tscircuit.com/editor` so docs users land in the online editor.

## Verification

- `npx --yes bun run typecheck`
- `npx --yes bun run build`
- `git diff --check origin/main...HEAD`

## Notes

The original bounty issue is in archived `tscircuit/docs-old`, so a fresh `/attempt` comment cannot be added there. This PR targets the active docs repository and keeps the change to one navbar item.