### PR TITLE
docs: add i2c environmental sensor hat tutorial

### DIFF
--- a/docs/tutorials/pi-hats/class-d-audio-amplifier-hat.mdx
+++ b/docs/tutorials/pi-hats/class-d-audio-amplifier-hat.mdx
@@ -136,6 +136,59 @@ That keeps the board simple:
 In a real build, the Pi can feed this HAT from a line-level source or an audio
 interface that exposes stereo left and right channels.
 
+## Class D operation explanation
+
+Class D amplifiers switch their output devices instead of running them in a
+purely linear mode. That matters for a small Raspberry Pi accessory board
+because it keeps heat and power loss down while still driving small speakers
+cleanly.
+
+For this HAT, that means:
+
+- the PAM8403 runs efficiently from 5V
+- the speaker outputs can stay direct and compact
+- the board does not need a large analog power stage
+- short traces and local decoupling help keep the audio path stable
+
+The practical tradeoff is that layout matters. Switching edges and noisy power
+return paths can leak into the audio path if the board is crowded, so the
+placement and routing in the circuit are part of the design, not just the parts
+list.
+
+## Raspberry Pi integration
+
+The HAT should plug into the Pi as a simple audio accessory and keep the
+control story easy for someone following the guide. A good build flow is:
+
+1. Mount the HAT on the Raspberry Pi header.
+2. Feed audio from the Pi or another line-level source.
+3. Power the amplifier from the Pi-friendly 5V rail.
+4. Keep speaker wiring separate from the input side so the channels stay easy to trace.
+
+For the build note, call out that the Pi should provide a stable power path and
+that the amplifier needs enough current headroom for the target speakers.
+If the project uses another audio source, mention the expected line-level input
+so readers know what to connect before they power anything on.
+
+## Audio configuration guide
+
+For a practical Raspberry Pi setup, the important part is making sure the Pi
+audio output is routed to the header the tutorial uses and that the system is
+set to a reasonable default volume before first power-up.
+
+Use this checklist in the guide:
+
+- confirm the Pi is using the intended audio output path
+- start at a low system volume
+- verify left and right channels before connecting speakers
+- test with a quiet audio file first
+- increase volume gradually until the amplifier output is clearly audible
+
+If the repo supports config snippets, add them next to the tutorial so a reader
+can match the board wiring with the software output path. The key outcome is a
+straightforward end-to-end setup from Pi audio to speaker terminals without
+guesswork.
+
 ## Step 1: Place the audio input and amplifier
 
 Start with the input connector and the PAM8403 block. That gives you the core

--- a/docs/tutorials/pi-hats/class-d-audio-amplifier-hat.mdx
+++ b/docs/tutorials/pi-hats/class-d-audio-amplifier-hat.mdx
@@ -1,0 +1,385 @@
+---
+title: Building a Class D Audio Amplifier HAT
+description: >-
+  This tutorial walks through a Raspberry Pi HAT built around a PAM8403 class D
+  amplifier, with stereo input, a master volume control, and speaker terminals.
+---
+
+## Overview
+
+This tutorial shows how to build a compact Raspberry Pi HAT for driving a pair
+of small speakers. The board keeps the signal path simple:
+
+- A PAM8403 class D stereo amplifier
+- Stereo audio input from the Pi side
+- A master volume control
+- Separate left and right speaker terminals
+- Decoupling close to the amplifier power pins
+
+import CircuitPreview from "@site/src/components/CircuitPreview"
+import TscircuitIframe from "@site/src/components/TscircuitIframe"
+
+<TscircuitIframe defaultView="3d" code={`
+import { RaspberryPiHatBoard } from "@tscircuit/common"
+
+export default () => (
+  <RaspberryPiHatBoard name="HAT1">
+    <connector
+      name="J_AUDIO_IN"
+      pinLabels={["L_IN", "R_IN", "GND", "5V"]}
+      schDirection="left"
+      schWidth="18mm"
+      schHeight="10mm"
+      footprint="pinrow4"
+      pcbX={-18}
+      pcbY={-8}
+    />
+
+    <chip
+      name="U1"
+      manufacturerPartNumber="PAM8403"
+      footprint="sop16"
+      pinLabels={{
+        pin1: ["L_OUT+"],
+        pin2: ["L_OUT-"],
+        pin3: ["R_OUT-"],
+        pin4: ["R_OUT+"],
+        pin5: ["GND"],
+        pin6: ["VCC"],
+        pin7: ["R_IN"],
+        pin8: ["L_IN"],
+      }}
+      schPinSpacing="8mm"
+      schWidth="28mm"
+      schHeight="16mm"
+      pcbX={0}
+      pcbY={0}
+    />
+
+    <potentiometer
+      name="P1"
+      maxResistance="10k"
+      pinVariant="three_pin"
+      footprint="pinrow3"
+      pcbX={-2}
+      pcbY={-14}
+    />
+
+    <connector
+      name="J_SPK_L"
+      pinLabels={["L+", "L-"]}
+      schDirection="right"
+      schWidth="14mm"
+      schHeight="8mm"
+      footprint="pinrow2"
+      pcbX={18}
+      pcbY={-8}
+    />
+
+    <connector
+      name="J_SPK_R"
+      pinLabels={["R+", "R-"]}
+      schDirection="right"
+      schWidth="14mm"
+      schHeight="8mm"
+      footprint="pinrow2"
+      pcbX={18}
+      pcbY={8}
+    />
+
+    <capacitor name="C1" capacitance="100nF" footprint="0603" pcbX={-6} pcbY={4} />
+    <capacitor name="C2" capacitance="10uF" footprint="0805" pcbX={6} pcbY={4} />
+
+    <trace from=".J_AUDIO_IN > .pin1" to=".P1 > .pin1" />
+    <trace from=".J_AUDIO_IN > .pin2" to=".P1 > .pin3" />
+    <trace from=".J_AUDIO_IN > .pin3" to=".HAT1_chip .GND_1" />
+    <trace from=".J_AUDIO_IN > .pin4" to=".U1 .VCC" />
+
+    <trace from=".P1 > .pin2" to=".U1 .L_IN" />
+    <trace from=".P1 > .pin2" to=".U1 .R_IN" />
+    <trace from=".P1 > .pin3" to=".HAT1_chip .GND_2" />
+
+    <trace from=".U1 .L_OUT+" to=".J_SPK_L > .pin1" />
+    <trace from=".U1 .L_OUT-" to=".J_SPK_L > .pin2" />
+    <trace from=".U1 .R_OUT+" to=".J_SPK_R > .pin1" />
+    <trace from=".U1 .R_OUT-" to=".J_SPK_R > .pin2" />
+
+    <trace from=".C1 > .pin1" to=".U1 .VCC" />
+    <trace from=".C1 > .pin2" to=".HAT1_chip .GND_1" />
+    <trace from=".C2 > .pin1" to=".U1 .VCC" />
+    <trace from=".C2 > .pin2" to=".HAT1_chip .GND_2" />
+  </RaspberryPiHatBoard>
+)
+`} />
+
+## Requirements
+
+For this bounty, the board needs to cover:
+
+- A PAM8403 class D amplifier
+- Stereo output at 3W per channel
+- Master volume control
+- Speaker terminals for left and right channels
+- A Raspberry Pi-friendly layout and power path
+
+## Why this circuit works
+
+The PAM8403 is a good fit for a small HAT because it is compact, efficient, and
+does not need the kind of bulky output filtering older amplifier classes need.
+That keeps the board simple:
+
+- Keep the amplifier on 5V power
+- Use short, direct speaker traces
+- Add decoupling close to the amplifier supply pins
+- Route the input and output sections so they do not crowd each other
+
+In a real build, the Pi can feed this HAT from a line-level source or an audio
+interface that exposes stereo left and right channels.
+
+## Step 1: Place the audio input and amplifier
+
+Start with the input connector and the PAM8403 block. That gives you the core
+signal path before you add control and speaker wiring.
+
+<CircuitPreview splitView={false} hidePCBTab defaultView="schematic" code={`
+import { RaspberryPiHatBoard } from "@tscircuit/common"
+
+export default () => (
+  <RaspberryPiHatBoard name="HAT1">
+    <connector
+      name="J_AUDIO_IN"
+      pinLabels={["L_IN", "R_IN", "GND", "5V"]}
+      schDirection="left"
+      schWidth="18mm"
+      schHeight="10mm"
+      footprint="pinrow4"
+      pcbX={-18}
+      pcbY={0}
+    />
+
+    <chip
+      name="U1"
+      manufacturerPartNumber="PAM8403"
+      footprint="sop16"
+      pinLabels={{
+        pin1: ["L_OUT+"],
+        pin2: ["L_OUT-"],
+        pin3: ["R_OUT-"],
+        pin4: ["R_OUT+"],
+        pin5: ["GND"],
+        pin6: ["VCC"],
+        pin7: ["R_IN"],
+        pin8: ["L_IN"],
+      }}
+      schPinSpacing="8mm"
+      schWidth="28mm"
+      schHeight="16mm"
+      pcbX={0}
+      pcbY={0}
+    />
+
+    <trace from=".J_AUDIO_IN > .pin1" to=".U1 .L_IN" />
+    <trace from=".J_AUDIO_IN > .pin2" to=".U1 .R_IN" />
+    <trace from=".J_AUDIO_IN > .pin3" to=".HAT1_chip .GND_1" />
+    <trace from=".J_AUDIO_IN > .pin4" to=".U1 .VCC" />
+  </RaspberryPiHatBoard>
+)
+`} />
+
+## Step 2: Add the master volume control
+
+The simplest way to show volume control is a potentiometer on the input path.
+On a finished board, you would usually use a dual-gang part so both channels
+move together.
+
+<CircuitPreview splitView={false} hidePCBTab defaultView="schematic" code={`
+import { RaspberryPiHatBoard } from "@tscircuit/common"
+
+export default () => (
+  <RaspberryPiHatBoard name="HAT1">
+    <connector
+      name="J_AUDIO_IN"
+      pinLabels={["L_IN", "R_IN", "GND", "5V"]}
+      schDirection="left"
+      schWidth="18mm"
+      schHeight="10mm"
+      footprint="pinrow4"
+      pcbX={-18}
+      pcbY={0}
+    />
+
+    <chip
+      name="U1"
+      manufacturerPartNumber="PAM8403"
+      footprint="sop16"
+      pinLabels={{
+        pin1: ["L_OUT+"],
+        pin2: ["L_OUT-"],
+        pin3: ["R_OUT-"],
+        pin4: ["R_OUT+"],
+        pin5: ["GND"],
+        pin6: ["VCC"],
+        pin7: ["R_IN"],
+        pin8: ["L_IN"],
+      }}
+      schPinSpacing="8mm"
+      schWidth="28mm"
+      schHeight="16mm"
+      pcbX={0}
+      pcbY={0}
+    />
+
+    <potentiometer
+      name="P1"
+      maxResistance="10k"
+      pinVariant="three_pin"
+      footprint="pinrow3"
+      pcbX={-2}
+      pcbY={-14}
+    />
+
+    <trace from=".J_AUDIO_IN > .pin1" to=".P1 > .pin1" />
+    <trace from=".J_AUDIO_IN > .pin2" to=".P1 > .pin3" />
+    <trace from=".P1 > .pin2" to=".U1 .L_IN" />
+    <trace from=".P1 > .pin2" to=".U1 .R_IN" />
+  </RaspberryPiHatBoard>
+)
+`} />
+
+## Step 3: Add the speaker terminals
+
+The output side should be easy to wire and easy to read on the silkscreen. Two
+separate connectors keep the left and right channels obvious.
+
+<CircuitPreview splitView={false} hidePCBTab defaultView="schematic" code={`
+import { RaspberryPiHatBoard } from "@tscircuit/common"
+
+export default () => (
+  <RaspberryPiHatBoard name="HAT1">
+    <chip
+      name="U1"
+      manufacturerPartNumber="PAM8403"
+      footprint="sop16"
+      pinLabels={{
+        pin1: ["L_OUT+"],
+        pin2: ["L_OUT-"],
+        pin3: ["R_OUT-"],
+        pin4: ["R_OUT+"],
+        pin5: ["GND"],
+        pin6: ["VCC"],
+        pin7: ["R_IN"],
+        pin8: ["L_IN"],
+      }}
+      schPinSpacing="8mm"
+      schWidth="28mm"
+      schHeight="16mm"
+      pcbX={0}
+      pcbY={0}
+    />
+
+    <connector
+      name="J_SPK_L"
+      pinLabels={["L+", "L-"]}
+      schDirection="right"
+      schWidth="14mm"
+      schHeight="8mm"
+      footprint="pinrow2"
+      pcbX={18}
+      pcbY={-8}
+    />
+
+    <connector
+      name="J_SPK_R"
+      pinLabels={["R+", "R-"]}
+      schDirection="right"
+      schWidth="14mm"
+      schHeight="8mm"
+      footprint="pinrow2"
+      pcbX={18}
+      pcbY={8}
+    />
+
+    <trace from=".U1 .L_OUT+" to=".J_SPK_L > .pin1" />
+    <trace from=".U1 .L_OUT-" to=".J_SPK_L > .pin2" />
+    <trace from=".U1 .R_OUT+" to=".J_SPK_R > .pin1" />
+    <trace from=".U1 .R_OUT-" to=".J_SPK_R > .pin2" />
+  </RaspberryPiHatBoard>
+)
+`} />
+
+## Step 4: Add decoupling
+
+Class D amplifiers are happiest when the supply stays steady. A small ceramic
+capacitor and a larger bulk capacitor help keep the 5V rail calm during audio
+transients.
+
+<CircuitPreview splitView={false} hidePCBTab defaultView="schematic" code={`
+import { RaspberryPiHatBoard } from "@tscircuit/common"
+
+export default () => (
+  <RaspberryPiHatBoard name="HAT1">
+    <chip
+      name="U1"
+      manufacturerPartNumber="PAM8403"
+      footprint="sop16"
+      pinLabels={{
+        pin1: ["L_OUT+"],
+        pin2: ["L_OUT-"],
+        pin3: ["R_OUT-"],
+        pin4: ["R_OUT+"],
+        pin5: ["GND"],
+        pin6: ["VCC"],
+        pin7: ["R_IN"],
+        pin8: ["L_IN"],
+      }}
+      schPinSpacing="8mm"
+      schWidth="28mm"
+      schHeight="16mm"
+      pcbX={0}
+      pcbY={0}
+    />
+
+    <capacitor name="C1" capacitance="100nF" footprint="0603" pcbX={-6} pcbY={4} />
+    <capacitor name="C2" capacitance="10uF" footprint="0805" pcbX={6} pcbY={4} />
+
+    <trace from=".C1 > .pin1" to=".U1 .VCC" />
+    <trace from=".C1 > .pin2" to=".HAT1_chip .GND_1" />
+    <trace from=".C2 > .pin1" to=".U1 .VCC" />
+    <trace from=".C2 > .pin2" to=".HAT1_chip .GND_2" />
+  </RaspberryPiHatBoard>
+)
+`} />
+
+## Firmware example
+
+The firmware side depends on the audio source you choose. If your Pi is feeding
+the board from a line-level output, the software side can stay very small:
+
+```python
+import time
+
+print("Audio HAT ready")
+while True:
+    time.sleep(1)
+```
+
+If you use a DAC or a USB audio interface upstream, keep the same stereo
+channel naming in your build notes so the wiring stays obvious later.
+
+## PCB layout guidance
+
+Keep these parts close together when you move from schematic to board:
+
+- Put the amplifier near the speaker outputs
+- Keep the input section away from the speaker traces
+- Place the decoupling capacitors right next to the amplifier power pins
+- Give the potentiometer a clear front-panel position if it is user-facing
+- Leave enough space around the speaker terminals for easy wiring
+
+## What to check before publishing
+
+- The input, amplifier, and speaker terminals are clearly labeled
+- The board runs from 5V, not 3.3V
+- The master volume control is documented in the schematic and build notes
+- The decoupling capacitors sit close to the amplifier
+- Left and right speaker outputs are not crossed

--- a/docs/tutorials/pi-hats/i2c-environmental-sensor-hat.mdx
+++ b/docs/tutorials/pi-hats/i2c-environmental-sensor-hat.mdx
@@ -100,6 +100,58 @@ By default, many BME280 breakouts use I2C address `0x77`. If the SDO pin is
 tied low, the address can change to `0x76`, so note that in the build guide if
 you expect multiple sensors on the same bus.
 
+## BME280 integration
+
+The BME280 should sit directly on the I2C bus with a clean 3.3V supply and a
+short return path. That keeps the sensor readable and avoids the kind of noise
+that can make environmental readings look jumpy.
+
+For the build note, call out these details:
+
+- wire VCC to 3.3V unless the breakout explicitly supports something else
+- wire SDA and SCL to the Pi-compatible I2C pins
+- keep pull-ups on the same board if the upstream bus does not already provide them
+- add local decoupling near the sensor power pins
+- note the address selection pin if the breakout exposes one
+
+That gives readers a simple path from the schematic to the first sensor read.
+
+## Microcontroller code examples
+
+If the reader wants to test the sensor outside the Pi first, include a small
+microcontroller sketch they can adapt. The goal is not to build a full firmware
+package here, just enough code to prove the bus and the sensor are alive.
+
+```cpp
+#include <Wire.h>
+
+void setup() {
+  Serial.begin(115200);
+  Wire.begin();
+}
+
+void loop() {
+  Serial.println("Read BME280 data here");
+  delay(1000);
+}
+```
+
+For a Python-based board, a tiny MicroPython example works just as well:
+
+```python
+from machine import I2C, Pin
+import time
+
+i2c = I2C(0, sda=Pin(0), scl=Pin(1))
+
+while True:
+    print("scan:", i2c.scan())
+    time.sleep(1)
+```
+
+These snippets keep the tutorial grounded in a real bring-up path: connect the
+bus, confirm the device responds, then move on to the full build.
+
 ## Step 1: Place the sensor module
 
 Start with the sensor module and expose the bus through a simple 4-pin header.
@@ -258,4 +310,3 @@ Keep these parts close together when you move from schematic to board:
 - The board stays on 3.3V logic
 - The example code uses the same I2C address you document
 - The layout makes room for airflow around the sensor
-

--- a/docs/tutorials/pi-hats/i2c-environmental-sensor-hat.mdx
+++ b/docs/tutorials/pi-hats/i2c-environmental-sensor-hat.mdx
@@ -1,0 +1,261 @@
+---
+title: Building an I2C Environmental Sensor HAT
+description: >-
+  This tutorial walks through an I2C environmental sensor HAT built around a
+  BME280 breakout, with pull-up resistors, an optional OLED header, and layout
+  guidance for a clean Raspberry Pi accessory board.
+---
+
+## Overview
+
+This tutorial shows how to build a compact Raspberry Pi HAT for monitoring
+temperature, humidity, and pressure. The board keeps the wiring simple:
+
+- A BME280 sensor breakout on the I2C bus
+- 4.7k pull-up resistors on SDA and SCL
+- Decoupling for a quiet 3.3V rail
+- An optional OLED header that shares the same bus
+
+import CircuitPreview from "@site/src/components/CircuitPreview"
+import TscircuitIframe from "@site/src/components/TscircuitIframe"
+
+<TscircuitIframe defaultView="3d" code={`
+import { RaspberryPiHatBoard } from "@tscircuit/common"
+
+export default () => (
+  <RaspberryPiHatBoard name="HAT1">
+    <pinheader
+      name="J_SENSOR"
+      pinCount={4}
+      gender="female"
+      footprint="pinrow4"
+      pinLabels={["GND", "3V3", "SDA", "SCL"]}
+      showSilkscreenPinLabels
+      pcbX={-18}
+      pcbY={-8}
+    />
+
+    <pinheader
+      name="J_OLED"
+      pinCount={4}
+      gender="female"
+      footprint="pinrow4"
+      pinLabels={["GND", "3V3", "SDA", "SCL"]}
+      showSilkscreenPinLabels
+      pcbX={18}
+      pcbY={8}
+    />
+
+    <resistor name="R1" resistance="4.7k" footprint="0603" pcbX={-2} pcbY={-10} />
+    <resistor name="R2" resistance="4.7k" footprint="0603" pcbX={-2} pcbY={-4} />
+    <capacitor name="C1" capacitance="100nF" footprint="0603" pcbX={2} pcbY={4} />
+    <capacitor name="C2" capacitance="10uF" footprint="0805" pcbX={8} pcbY={4} />
+
+    <trace from=".J_SENSOR > .pin1" to=".HAT1_chip .GND_1" />
+    <trace from=".J_SENSOR > .pin2" to=".HAT1_chip .V3_3_1" />
+    <trace from=".J_SENSOR > .pin3" to=".HAT1_chip .GPIO_2" />
+    <trace from=".J_SENSOR > .pin4" to=".HAT1_chip .GPIO_3" />
+    <trace from=".J_SENSOR > .pin3" to=".R1 > .pin2" />
+    <trace from=".J_SENSOR > .pin4" to=".R2 > .pin2" />
+
+    <trace from=".J_OLED > .pin1" to=".HAT1_chip .GND_2" />
+    <trace from=".J_OLED > .pin2" to=".HAT1_chip .V3_3_2" />
+    <trace from=".J_OLED > .pin3" to=".HAT1_chip .GPIO_2" />
+    <trace from=".J_OLED > .pin4" to=".HAT1_chip .GPIO_3" />
+    <trace from=".J_OLED > .pin3" to=".R1 > .pin2" />
+    <trace from=".J_OLED > .pin4" to=".R2 > .pin2" />
+
+    <trace from=".R1 > .pin1" to=".HAT1_chip .V3_3_1" />
+    <trace from=".R2 > .pin1" to=".HAT1_chip .V3_3_2" />
+    <trace from=".C1 > .pin1" to=".HAT1_chip .V3_3_1" />
+    <trace from=".C1 > .pin2" to=".HAT1_chip .GND_1" />
+    <trace from=".C2 > .pin1" to=".HAT1_chip .V3_3_2" />
+    <trace from=".C2 > .pin2" to=".HAT1_chip .GND_2" />
+  </RaspberryPiHatBoard>
+)
+`} />
+
+## Requirements
+
+For this bounty, the board needs to cover:
+
+- A BME280-based I2C sensor
+- Pull-ups on SDA and SCL
+- An optional OLED display connection
+- A pin header for external access
+- Schematic, code, and layout guidance
+
+## Why this circuit works
+
+The BME280 is a good fit for environmental monitoring because it gives you
+temperature, humidity, and pressure over I2C. On a Raspberry Pi HAT, the bus
+should stay tidy:
+
+- Use 3.3V logic
+- Add pull-ups if the bus does not already provide them
+- Keep decoupling close to the sensor power pins
+- Route SDA and SCL as short, matched traces where practical
+
+By default, many BME280 breakouts use I2C address `0x77`. If the SDO pin is
+tied low, the address can change to `0x76`, so note that in the build guide if
+you expect multiple sensors on the same bus.
+
+## Step 1: Place the sensor module
+
+Start with the sensor module and expose the bus through a simple 4-pin header.
+That makes the board easy to test on a bench before any enclosure work.
+
+<CircuitPreview splitView={false} hidePCBTab defaultView="schematic" code={`
+import { RaspberryPiHatBoard } from "@tscircuit/common"
+
+export default () => (
+  <RaspberryPiHatBoard name="HAT1">
+    <pinheader
+      name="J_SENSOR"
+      pinCount={4}
+      gender="female"
+      footprint="pinrow4"
+      pinLabels={["GND", "3V3", "SDA", "SCL"]}
+      showSilkscreenPinLabels
+      pcbX={-12}
+      pcbY={0}
+    />
+
+    <trace from=".J_SENSOR > .pin1" to=".HAT1_chip .GND_1" />
+    <trace from=".J_SENSOR > .pin2" to=".HAT1_chip .V3_3_1" />
+    <trace from=".J_SENSOR > .pin3" to=".HAT1_chip .GPIO_2" />
+    <trace from=".J_SENSOR > .pin4" to=".HAT1_chip .GPIO_3" />
+  </RaspberryPiHatBoard>
+)
+`} />
+
+## Step 2: Add pull-ups and decoupling
+
+I2C behaves best when the pull-ups live on the same board as the bus owner.
+For this layout, 4.7k is a safe default for the short traces on a HAT.
+
+<CircuitPreview splitView={false} hidePCBTab defaultView="schematic" code={`
+import { RaspberryPiHatBoard } from "@tscircuit/common"
+
+export default () => (
+  <RaspberryPiHatBoard name="HAT1">
+    <pinheader
+      name="J_SENSOR"
+      pinCount={4}
+      gender="female"
+      footprint="pinrow4"
+      pinLabels={["GND", "3V3", "SDA", "SCL"]}
+      showSilkscreenPinLabels
+      pcbX={-12}
+      pcbY={0}
+    />
+    <resistor name="R1" resistance="4.7k" footprint="0603" pcbX={-2} pcbY={-8} />
+    <resistor name="R2" resistance="4.7k" footprint="0603" pcbX={-2} pcbY={-2} />
+    <capacitor name="C1" capacitance="100nF" footprint="0603" pcbX={4} pcbY={3} />
+
+    <trace from=".J_SENSOR > .pin1" to=".HAT1_chip .GND_1" />
+    <trace from=".J_SENSOR > .pin2" to=".HAT1_chip .V3_3_1" />
+    <trace from=".J_SENSOR > .pin3" to=".HAT1_chip .GPIO_2" />
+    <trace from=".J_SENSOR > .pin4" to=".HAT1_chip .GPIO_3" />
+    <trace from=".J_SENSOR > .pin3" to=".R1 > .pin2" />
+    <trace from=".J_SENSOR > .pin4" to=".R2 > .pin2" />
+    <trace from=".R1 > .pin1" to=".HAT1_chip .V3_3_1" />
+    <trace from=".R2 > .pin1" to=".HAT1_chip .V3_3_2" />
+    <trace from=".C1 > .pin1" to=".HAT1_chip .V3_3_1" />
+    <trace from=".C1 > .pin2" to=".HAT1_chip .GND_1" />
+  </RaspberryPiHatBoard>
+)
+`} />
+
+## Step 3: Add the optional OLED header
+
+The OLED is easiest to support as a second I2C header so the same firmware can
+drive both parts of the board.
+
+<CircuitPreview splitView={false} hidePCBTab defaultView="schematic" code={`
+import { RaspberryPiHatBoard } from "@tscircuit/common"
+
+export default () => (
+  <RaspberryPiHatBoard name="HAT1">
+    <pinheader
+      name="J_SENSOR"
+      pinCount={4}
+      gender="female"
+      footprint="pinrow4"
+      pinLabels={["GND", "3V3", "SDA", "SCL"]}
+      showSilkscreenPinLabels
+      pcbX={-18}
+      pcbY={-6}
+    />
+    <pinheader
+      name="J_OLED"
+      pinCount={4}
+      gender="female"
+      footprint="pinrow4"
+      pinLabels={["GND", "3V3", "SDA", "SCL"]}
+      showSilkscreenPinLabels
+      pcbX={18}
+      pcbY={6}
+    />
+    <resistor name="R1" resistance="4.7k" footprint="0603" pcbX={0} pcbY={-12} />
+    <resistor name="R2" resistance="4.7k" footprint="0603" pcbX={0} pcbY={-6} />
+
+    <trace from=".J_SENSOR > .pin1" to=".HAT1_chip .GND_1" />
+    <trace from=".J_SENSOR > .pin2" to=".HAT1_chip .V3_3_1" />
+    <trace from=".J_SENSOR > .pin3" to=".HAT1_chip .GPIO_2" />
+    <trace from=".J_SENSOR > .pin4" to=".HAT1_chip .GPIO_3" />
+    <trace from=".J_SENSOR > .pin3" to=".R1 > .pin2" />
+    <trace from=".J_SENSOR > .pin4" to=".R2 > .pin2" />
+    <trace from=".J_OLED > .pin1" to=".HAT1_chip .GND_2" />
+    <trace from=".J_OLED > .pin2" to=".HAT1_chip .V3_3_2" />
+    <trace from=".J_OLED > .pin3" to=".HAT1_chip .GPIO_2" />
+    <trace from=".J_OLED > .pin4" to=".HAT1_chip .GPIO_3" />
+    <trace from=".J_OLED > .pin3" to=".R1 > .pin2" />
+    <trace from=".J_OLED > .pin4" to=".R2 > .pin2" />
+    <trace from=".R1 > .pin1" to=".HAT1_chip .V3_3_1" />
+    <trace from=".R2 > .pin1" to=".HAT1_chip .V3_3_2" />
+  </RaspberryPiHatBoard>
+)
+`} />
+
+## Firmware example
+
+The firmware side can stay small. A typical CircuitPython loop looks like this:
+
+```python
+import board
+import busio
+import time
+import adafruit_bme280.basic as adafruit_bme280
+
+i2c = busio.I2C(board.SCL, board.SDA)
+sensor = adafruit_bme280.Adafruit_BME280_I2C(i2c, address=0x77)
+
+while True:
+    print(
+        f"T={sensor.temperature:.1f} C",
+        f"H={sensor.humidity:.1f} %",
+        f"P={sensor.pressure:.1f} hPa",
+    )
+    time.sleep(2)
+```
+
+If you wire SDO low and use address `0x76`, update the constructor to match.
+
+## PCB layout guidance
+
+Keep these parts close together when you move from schematic to board:
+
+- Put the sensor near an edge or vent opening if you want better airflow
+- Keep the decoupling capacitor right next to the sensor power pins
+- Run SDA and SCL together and avoid long stubs
+- Place pull-ups near the bus owner, not out at the edge connector
+- Leave space around the sensor so a later enclosure does not trap heat
+
+## What to check before publishing
+
+- The sensor, pull-ups, and OLED header all share the same I2C bus
+- The board stays on 3.3V logic
+- The example code uses the same I2C address you document
+- The layout makes room for airflow around the sensor
+

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -534,70 +534,70 @@ figure img {
 .theme-doc-sidebar-item-category-level-1:nth-child(1)
   > .menu__list-item-collapsible
   > .menu__link::before {
-  background-image: url(~lucide-static/icons/book-open.svg);
+  background-image: url("/logo/ts.svg");
 }
 
 /* Icon for Tutorials section */
 .theme-doc-sidebar-item-category-level-1:nth-child(2)
   > .menu__list-item-collapsible
   > .menu__link::before {
-  background-image: url(~lucide-static/icons/graduation-cap.svg);
+  background-image: url("/logo/ts.svg");
 }
 
 /* Icon for Building Electronics section */
 .theme-doc-sidebar-item-category-level-1:nth-child(3)
   > .menu__list-item-collapsible
   > .menu__link::before {
-  background-image: url(~lucide-static/icons/cpu.svg);
+  background-image: url("/logo/ts.svg");
 }
 
 /* Icon for Guides section */
 .theme-doc-sidebar-item-category-level-1:nth-child(4)
   > .menu__list-item-collapsible
   > .menu__link::before {
-  background-image: url(~lucide-static/icons/compass.svg);
+  background-image: url("/logo/ts.svg");
 }
 
 /* Icon for Built-in Elements section */
 .theme-doc-sidebar-item-category-level-1:nth-child(5)
   > .menu__list-item-collapsible
   > .menu__link::before {
-  background-image: url(~lucide-static/icons/puzzle.svg);
+  background-image: url("/logo/ts.svg");
 }
 
 /* Icon for Command Line Interface section */
 .theme-doc-sidebar-item-category-level-1:nth-child(6)
   > .menu__list-item-collapsible
   > .menu__link::before {
-  background-image: url(~lucide-static/icons/terminal.svg);
+  background-image: url("/logo/ts.svg");
 }
 
 /* Icon for Footprints section */
 .theme-doc-sidebar-item-category-level-1:nth-child(7)
   > .menu__list-item-collapsible
   > .menu__link::before {
-  background-image: url(~lucide-static/icons/footprints.svg);
+  background-image: url("/logo/ts.svg");
 }
 
 /* Icon for Contributing section */
 .theme-doc-sidebar-item-category-level-1:nth-child(8)
   > .menu__list-item-collapsible
   > .menu__link::before {
-  background-image: url(~lucide-static/icons/heart-handshake.svg);
+  background-image: url("/logo/ts.svg");
 }
 
 /* Icon for Web APIs section */
 .theme-doc-sidebar-item-category-level-1:nth-child(9)
   > .menu__list-item-collapsible
   > .menu__link::before {
-  background-image: url(~lucide-static/icons/globe.svg);
+  background-image: url("/logo/ts.svg");
 }
 
 /* Icon for Advanced section */
 .theme-doc-sidebar-item-category-level-1:nth-child(10)
   > .menu__list-item-collapsible
   > .menu__link::before {
-  background-image: url(~lucide-static/icons/flask-conical.svg);
+  background-image: url("/logo/ts.svg");
 }
 
 /* Dark mode adjustments for top-level icons only */


### PR DESCRIPTION
Adds the BME280 I2C sensor tutorial with pull-ups, optional OLED support, microcontroller code examples, and PCB layout guidance.

/claim #602