### PR TITLE
Add Default column to Board Properties table

### DIFF
--- a/docs/elements/board.mdx
+++ b/docs/elements/board.mdx
@@ -27,48 +27,48 @@ import CircuitPreview from '@site/src/components/CircuitPreview'
 
 ## Board Properties
 
-| Prop | Type | Description |
-| --- | --- | --- |
-| `width`, `height` | `string \| number` | Define the board's bounding box dimensions in millimeters. |
-| `borderRadius` | `string \| number` | Round the corners of rectangular outlines by the specified radius. |
-| `layers` | `1 \| 2 \| 4 \| 6 \| 8` | Specify the number of copper layers in the board stackup. Defaults to 2 layers. |
-| `autorouter` | `'auto' \| 'sequential-trace' \| 'auto-local' \| 'auto-cloud' \| 'laser_prefab' \| 'auto_jumper' \| AutorouterConfig` | Select a built-in autorouter preset or provide a configuration object. |
-| `autorouterEffortLevel` | `'1x' \| '2x' \| '5x' \| '10x' \| '100x'` | Increase autorouter compute effort for harder routing problems (higher values are slower and can improve completion rate). |
-| `autorouterVersion` | `'v1' \| 'v2' \| 'v3' \| 'v4' \| 'v5' \| 'latest'` | Pin routing to a specific autorouter implementation when comparing routing behavior across versions. |
-| `routingDisabled` | `boolean` | Skip routing to speed up development. |
-| `bomDisabled` | `boolean` | Skip bill-of-material generation for this board. |
-| `schematicDisabled` | `boolean` | Skip schematic generation for boards that only need the PCB view. |
-| `schAutoLayoutEnabled` | `boolean` | Enable automatic schematic layout for supported grouped circuits. |
-| `schTraceAutoLabelEnabled` | `boolean` | Automatically create schematic net labels for complex traces. |
-| `schMaxTraceDistance` | `string \| number` | Maximum span a schematic trace can travel before the auto layout prefers labels or different routing. |
-| `outline` | `Array<{ x: number, y: number }>` | Supply a custom polygon to replace the default rectangular outline. |
-| `outlineOffsetX`, `outlineOffsetY` | `string \| number` | Offset a custom outline relative to the bounding box origin. |
-| `material` | `'fr4' \| 'fr1'` | PCB substrate material. Defaults to 'fr4'. |
-| `thickness` | `string \| number` | Board thickness in millimeters. |
-| `title` | `string` | Title for the board, displayed in documentation and exports. |
-| `solderMaskColor` | `string` | Color applied to both top and bottom solder masks. |
-| `topSolderMaskColor` | `string` | Color of the top solder mask. |
-| `bottomSolderMaskColor` | `string` | Color of the bottom solder mask. |
-| `silkscreenColor` | `string` | Color applied to both top and bottom silkscreens. |
-| `topSilkscreenColor` | `string` | Color of the top silkscreen. |
-| `bottomSilkscreenColor` | `string` | Color of the bottom silkscreen. |
-| `doubleSidedAssembly` | `boolean` | Whether the board should be assembled on both sides. Defaults to false. |
-| `boardAnchorPosition` | `{ x: number, y: number }` | Moves the board's anchor point to the specified coordinates. |
-| `anchorAlignment` | `'center' \| 'top_left' \| 'top_right' \| 'bottom_left' \| 'bottom_right' \| 'center_left' \| 'center_right' \| 'top_center' \| 'bottom_center'` | Preferred prop for choosing which part of the board should sit on `boardAnchorPosition`. |
-| `manualEdits` | `object` | Apply a serialized set of manual routing or layout edits to the board. |
-| `defaultTraceWidth` | `string \| number` | Default width for traces within this board. |
-| `minTraceWidth` | `string \| number` | Minimum allowed trace width for routing. |
-| `nominalTraceWidth` | `string \| number` | Preferred trace width used by routers when no trace-specific width is set. |
-| `minViaHoleEdgeToViaHoleEdgeClearance` | `string \| number` | Minimum drill-edge clearance between vias. |
-| `minPlatedHoleDrillEdgeToDrillEdgeClearance` | `string \| number` | Minimum drill-edge clearance between plated holes. |
-| `minTraceToPadEdgeClearance` | `string \| number` | Minimum copper-to-pad-edge clearance during routing. |
-| `minPadEdgeToPadEdgeClearance` | `string \| number` | Minimum pad-edge clearance between nearby pads. |
-| `minBoardEdgeClearance` | `string \| number` | Minimum clearance between routed copper features and the board edge. |
-| `minViaHoleDiameter` | `string \| number` | Smallest via drill diameter the router may use. |
-| `minViaPadDiameter` | `string \| number` | Smallest via pad diameter the router may use. |
-| `partsEngine` | `object` | Override the parts lookup engine used to resolve bill of materials. |
-| `circuitJson` | `any[]` | Provide precompiled circuit JSON to embed or reuse as the board contents. |
-| `pcbStyle` | `object` | Style configuration object for PCB elements. See [Global Silkscreen Text Size](#global-silkscreen-text-size-adjustment) below. |
+| Prop | Type | Default | Description |
+| --- | --- | --- | --- |
+| `width`, `height` | `string \| number` | - | Define the board's bounding box dimensions in millimeters. |
+| `borderRadius` | `string \| number` | - | Round the corners of rectangular outlines by the specified radius. |
+| `layers` | `1 \| 2 \| 4 \| 6 \| 8` | `2` | Specify the number of copper layers in the board stackup. |
+| `autorouter` | `'auto' \| 'sequential-trace' \| 'auto-local' \| 'auto-cloud' \| 'laser_prefab' \| 'auto_jumper' \| AutorouterConfig` | - | Select a built-in autorouter preset or provide a configuration object. |
+| `autorouterEffortLevel` | `'1x' \| '2x' \| '5x' \| '10x' \| '100x'` | - | Increase autorouter compute effort for harder routing problems (higher values are slower and can improve completion rate). |
+| `autorouterVersion` | `'v1' \| 'v2' \| 'v3' \| 'v4' \| 'v5' \| 'latest'` | - | Pin routing to a specific autorouter implementation when comparing routing behavior across versions. |
+| `routingDisabled` | `boolean` | - | Skip routing to speed up development. |
+| `bomDisabled` | `boolean` | - | Skip bill-of-material generation for this board. |
+| `schematicDisabled` | `boolean` | - | Skip schematic generation for boards that only need the PCB view. |
+| `schAutoLayoutEnabled` | `boolean` | - | Enable automatic schematic layout for supported grouped circuits. |
+| `schTraceAutoLabelEnabled` | `boolean` | - | Automatically create schematic net labels for complex traces. |
+| `schMaxTraceDistance` | `string \| number` | - | Maximum span a schematic trace can travel before the auto layout prefers labels or different routing. |
+| `outline` | `Array<{ x: number, y: number }>` | - | Supply a custom polygon to replace the default rectangular outline. |
+| `outlineOffsetX`, `outlineOffsetY` | `string \| number` | - | Offset a custom outline relative to the bounding box origin. |
+| `material` | `'fr4' \| 'fr1'` | `'fr4'` | PCB substrate material. |
+| `thickness` | `string \| number` | - | Board thickness in millimeters. |
+| `title` | `string` | - | Title for the board, displayed in documentation and exports. |
+| `solderMaskColor` | `string` | - | Color applied to both top and bottom solder masks. |
+| `topSolderMaskColor` | `string` | - | Color of the top solder mask. |
+| `bottomSolderMaskColor` | `string` | - | Color of the bottom solder mask. |
+| `silkscreenColor` | `string` | - | Color applied to both top and bottom silkscreens. |
+| `topSilkscreenColor` | `string` | - | Color of the top silkscreen. |
+| `bottomSilkscreenColor` | `string` | - | Color of the bottom silkscreen. |
+| `doubleSidedAssembly` | `boolean` | `false` | Whether the board should be assembled on both sides. |
+| `boardAnchorPosition` | `{ x: number, y: number }` | - | Moves the board's anchor point to the specified coordinates. |
+| `anchorAlignment` | `'center' \| 'top_left' \| 'top_right' \| 'bottom_left' \| 'bottom_right' \| 'center_left' \| 'center_right' \| 'top_center' \| 'bottom_center'` | - | Preferred prop for choosing which part of the board should sit on `boardAnchorPosition`. |
+| `manualEdits` | `object` | - | Apply a serialized set of manual routing or layout edits to the board. |
+| `defaultTraceWidth` | `string \| number` | - | Default width for traces within this board. |
+| `minTraceWidth` | `string \| number` | - | Minimum allowed trace width for routing. |
+| `nominalTraceWidth` | `string \| number` | - | Preferred trace width used by routers when no trace-specific width is set. |
+| `minViaHoleEdgeToViaHoleEdgeClearance` | `string \| number` | - | Minimum drill-edge clearance between vias. |
+| `minPlatedHoleDrillEdgeToDrillEdgeClearance` | `string \| number` | - | Minimum drill-edge clearance between plated holes. |
+| `minTraceToPadEdgeClearance` | `string \| number` | - | Minimum copper-to-pad-edge clearance during routing. |
+| `minPadEdgeToPadEdgeClearance` | `string \| number` | - | Minimum pad-edge clearance between nearby pads. |
+| `minBoardEdgeClearance` | `string \| number` | - | Minimum clearance between routed copper features and the board edge. |
+| `minViaHoleDiameter` | `string \| number` | - | Smallest via drill diameter the router may use. |
+| `minViaPadDiameter` | `string \| number` | - | Smallest via pad diameter the router may use. |
+| `partsEngine` | `object` | - | Override the parts lookup engine used to resolve bill of materials. |
+| `circuitJson` | `any[]` | - | Provide precompiled circuit JSON to embed or reuse as the board contents. |
+| `pcbStyle` | `object` | - | Style configuration object for PCB elements. See [Global Silkscreen Text Size](#global-silkscreen-text-size-adjustment) below. |
 
 ### Customizing the Size of the Board
 


### PR DESCRIPTION
## Summary
- Added a `Default` column to the Board Properties table in `docs/elements/board.mdx`
- Removed redundant "Defaults to X" sentences from descriptions (now shown in the new column)
- Defaults sourced from `@tscircuit/props` (`lib/components/board.ts`): `layers=2`, `material='fr4'`, `doubleSidedAssembly=false`

Faster lookup — users see the default at a glance without reading the description sentence.
Consistency — matches the format already used in other element docs (pinheader.mdx, via.mdx, fiducial.mdx, hole.mdx).
Scannable — easier to spot which props have implicit behavior vs. which require a value.