### PR TITLE
feat: add USB-PD Trigger, I2C Sensor, and Class D Audio Amp tutorials

### DIFF
--- a/docs/tutorials/class-d-audio-amplifier-hat.mdx
+++ b/docs/tutorials/class-d-audio-amplifier-hat.mdx
@@ -1,0 +1,185 @@
+---
+title: Class D Audio Amplifier HAT
+description: Learn how to build a 3W stereo Class D audio amplifier HAT using the PAM8403 amplifier chip, speaker terminals, and volume control with tscircuit.
+---
+
+## Overview
+
+In this tutorial, we will build a **Class D Audio Amplifier HAT**. This board takes stereo line-level audio input and amplifies it to drive two 3W speakers (Left and Right channels) with excellent efficiency and minimal heat output.
+
+Unlike traditional analog amplifiers (such as Class A or AB) which dissipate excess power as heat, **Class D amplifiers** work by converting the analog input into a high-frequency PWM (Pulse Width Modulation) signal. The output MOSFETs switch fully ON or fully OFF rapidly, leading to efficiencies up to 90%, making them perfect for battery-powered or compact projects like Raspberry Pi audio HATs.
+
+We will use the **PAM8403** Class D amplifier chip, which is a filterless 3W stereo amplifier requiring minimal external components.
+
+---
+
+## 📋 Components Checklist
+
+Our amplifier HAT will consist of:
+1. **PAM8403 Class D Amplifier (U1)** — 3W stereo audio amplifier in an SOP-16 package.
+2. **Dual-Gang 10kΩ Potentiometer (RV1)** — Standard stereo volume control dial.
+3. **2x 2-pin Screw Terminals (J1, J2)** — Speaker output blocks for Left and Right speakers.
+4. **40-pin Raspberry Pi Header (J3)** — Pi HAT connector for power (5V) and audio line signals.
+5. **Bulk Decoupling Capacitor (C1)** — 470µF electrolytic capacitor to buffer high-current speaker transients.
+6. **Filtering Capacitors (C2, C3, C4, C5)** — Small ceramic capacitors (0.1µF to 1µF) to filter power supply noise and input signals.
+
+---
+
+## 🛠️ Step-by-Step Implementation
+
+Create a new file in your project or editor and paste the following tscircuit design code.
+
+### Complete Circuit Code
+
+import TscircuitIframe from "@site/src/components/TscircuitIframe"
+
+<TscircuitIframe defaultView="schematic" code={`
+export default () => {
+  return (
+    <board width="65mm" height="56mm">
+      {/* 40-pin Raspberry Pi Hat Header */}
+      <chip
+        name="J3"
+        manufacturerPartNumber="RPI-HAT-HEADER-40P"
+        schX={-20}
+        schY={0}
+        pinLabels={{
+          pin2: "5V",
+          pin6: "GND",
+          pin12: "AUDIO_L",
+          pin35: "AUDIO_R",
+        }}
+      />
+
+      {/* PAM8403 Class D Amplifier */}
+      <chip
+        name="U1"
+        manufacturerPartNumber="PAM8403"
+        schX={10}
+        schY={0}
+        pinLabels={{
+          pin1: "+OUT_L",
+          pin2: "PGND_L",
+          pin3: "-OUT_L",
+          pin4: "PVDD_L",
+          pin5: "MUTE",
+          pin6: "VDD",
+          pin7: "IN_L",
+          pin8: "SNS",
+          pin9: "BYP",
+          pin10: "IN_R",
+          pin11: "SHDN",
+          pin12: "PVDD_R",
+          pin13: "-OUT_R",
+          pin14: "PGND_R",
+          pin15: "+OUT_R",
+          pin16: "VREF",
+        }}
+      />
+
+      {/* 10k Dual-Gang Potentiometer for volume control */}
+      <chip
+        name="RV1"
+        manufacturerPartNumber="POT-STEREO-10K"
+        schX={-5}
+        schY={-12}
+        pinLabels={{
+          pin1: "L_IN",
+          pin2: "L_WIPER",
+          pin3: "L_GND",
+          pin4: "R_IN",
+          pin5: "R_WIPER",
+          pin6: "R_GND",
+        }}
+      />
+
+      {/* Speaker Output Screw Terminals */}
+      <chip
+        name="J1"
+        manufacturerPartNumber="SCREW-TERMINAL-2PIN"
+        schX={25}
+        schY={10}
+        pinLabels={{
+          pin1: "SPK_L+",
+          pin2: "SPK_L-",
+        }}
+      />
+      <chip
+        name="J2"
+        manufacturerPartNumber="SCREW-TERMINAL-2PIN"
+        schX={25}
+        schY={-10}
+        pinLabels={{
+          pin1: "SPK_R+",
+          pin2: "SPK_R-",
+        }}
+      />
+
+      {/* Input Coupling Capacitors */}
+      <capacitor name="C4" capacitance="1uF" schX={0} schY={0} />
+      <capacitor name="C5" capacitance="1uF" schX={0} schY={-5} />
+
+      {/* Decoupling & Bypass Capacitors */}
+      <capacitor name="C1" capacitance="470uF" schX={5} schY={12} />
+      <capacitor name="C2" capacitance="0.1uF" schX={10} schY={12} />
+      <capacitor name="C3" capacitance="1uF" schX={15} schY={12} />
+
+      {/* Connections */}
+      {/* Power Rails (5V & GND) */}
+      <trace from=".J3 .pin2" to="net.5V" />
+      <trace from=".J3 .pin6" to="net.GND" />
+
+      {/* PAM8403 Power Pin connections */}
+      <trace from="net.5V" to=".U1 .pin4" />  {/* PVDD_L */}
+      <trace from="net.5V" to=".U1 .pin12" /> {/* PVDD_R */}
+      <trace from="net.5V" to=".U1 .pin6" />  {/* VDD */}
+      <trace from="net.5V" to=".U1 .pin5" />  {/* MUTE disabled (pulled high) */}
+      <trace from="net.5V" to=".U1 .pin11" /> {/* SHDN disabled (pulled high) */}
+
+      <trace from="net.GND" to=".U1 .pin2" />  {/* PGND_L */}
+      <trace from="net.GND" to=".U1 .pin14" /> {/* PGND_R */}
+      
+      {/* Power Filtering Caps */}
+      <trace from="net.5V" to=".C1 .pin1" />
+      <trace from=".C1 .pin2" to="net.GND" />
+      <trace from="net.5V" to=".C2 .pin1" />
+      <trace from=".C2 .pin2" to="net.GND" />
+
+      {/* Bypass Reference Capacitor */}
+      <trace from=".U1 .pin9" to=".C3 .pin1" />
+      <trace from=".C3 .pin2" to="net.GND" />
+
+      {/* Audio Input Left Connection */}
+      <trace from=".J3 .pin12" to=".RV1 .pin1" />
+      <trace from=".RV1 .pin3" to="net.GND" />
+      <trace from=".RV1 .pin2" to=".C4 .pin1" />
+      <trace from=".C4 .pin2" to=".U1 .pin7" /> {/* IN_L */}
+
+      {/* Audio Input Right Connection */}
+      <trace from=".J3 .pin35" to=".RV1 .pin4" />
+      <trace from=".RV1 .pin6" to="net.GND" />
+      <trace from=".RV1 .pin5" to=".C5 .pin1" />
+      <trace from=".C5 .pin2" to=".U1 .pin10" /> {/* IN_R */}
+
+      {/* Left Speaker Output */}
+      <trace from=".U1 .pin1" to=".J1 .pin1" />
+      <trace from=".U1 .pin3" to=".J1 .pin2" />
+
+      {/* Right Speaker Output */}
+      <trace from=".U1 .pin15" to=".J2 .pin1" />
+      <trace from=".U1 .pin13" to=".J2 .pin2" />
+    </board>
+  )
+}
+`} />
+
+---
+
+## 🔊 Important Audio Circuit Design Notes
+
+1. **Input Coupling Capacitors (C4, C5)**:
+   - These DC-blocking input capacitors are absolutely critical. They block any DC bias voltage from the host audio source while allowing the AC audio waveform to pass into the PAM8403 input pins.
+2. **Bulk Capacitance (C1)**:
+   - Class D amplifiers switch high currents to drive speakers. A large bulk decoupling capacitor (like the 470µF **C1**) must be placed as close to the power pins as possible to handle sudden current draws and prevent power sag.
+3. **Filterless Design**:
+   - The PAM8403 uses a filterless modulation architecture. The inductance of the speaker coils acts as a low-pass filter to recover the audio signal from the PWM carrier, meaning you do not need bulky LC filters at the speaker outputs for short wire lengths.

--- a/docs/tutorials/i2c-environmental-sensor.mdx
+++ b/docs/tutorials/i2c-environmental-sensor.mdx
@@ -1,0 +1,146 @@
+---
+title: I2C Environmental Sensor Module
+description: Learn how to design a compact environmental monitoring module with a BME280 sensor, SSD1306 OLED display, and I2C bus pull-ups using tscircuit.
+---
+
+## Overview
+
+In this tutorial, we will build a compact **I2C Environmental Sensor Module**. This board is designed to measure ambient temperature, relative humidity, and barometric pressure, and display the live readings on a local OLED screen.
+
+We will use **I2C (Inter-Integrated Circuit)**, which is a popular serial communication protocol that allows multiple slave devices (the BME280 sensor and SSD1306 OLED) to communicate with a single master host using only two signal wires:
+- **SDA** (Serial Data)
+- **SCL** (Serial Clock)
+
+---
+
+## 📋 Components Checklist
+
+Our module will consist of:
+1. **BME280 Environmental Sensor (U1)** — Digital sensor for temperature, humidity, and pressure in an LGA-8 package.
+2. **SSD1306 OLED Display (U2)** — Standard 0.96-inch 128x64 I2C display panel.
+3. **I2C Pull-Up Resistors (R1, R2)** — 4.7kΩ resistors to pull the SDA and SCL signal lines high.
+4. **Decoupling Capacitors (C1, C2)** — 0.1µF capacitors to stabilize power supply inputs.
+5. **4-pin Male Header (J1)** — Connecting interface for power (VCC/GND) and communication (SDA/SCL) to a host microcontroller.
+
+---
+
+## 🛠️ Step-by-Step Implementation
+
+Create a new file in your project or editor and paste the following tscircuit design code.
+
+### Complete Circuit Code
+
+import TscircuitIframe from "@site/src/components/TscircuitIframe"
+
+<TscircuitIframe defaultView="schematic" code={`
+export default () => {
+  return (
+    <board width="40mm" height="30mm">
+      {/* 4-pin Host Connection Header */}
+      <chip
+        name="J1"
+        manufacturerPartNumber="HDR-1X4"
+        schX={-15}
+        schY={0}
+        pinLabels={{
+          pin1: "VCC",
+          pin2: "GND",
+          pin3: "SCL",
+          pin4: "SDA",
+        }}
+      />
+
+      {/* BME280 Sensor */}
+      <chip
+        name="U1"
+        manufacturerPartNumber="BME280"
+        schX={0}
+        schY={-8}
+        pinLabels={{
+          pin1: "VDD",
+          pin2: "GND",
+          pin3: "VDDIO",
+          pin4: "SDO",
+          pin5: "SDA",
+          pin6: "SCL",
+          pin7: "CSB",
+          pin8: "GND_IO",
+        }}
+      />
+
+      {/* SSD1306 128x64 OLED Display (I2C interface) */}
+      <chip
+        name="U2"
+        manufacturerPartNumber="SSD1306-0.96-OLED"
+        schX={15}
+        schY={0}
+        pinLabels={{
+          pin1: "GND",
+          pin2: "VCC",
+          pin3: "SCL",
+          pin4: "SDA",
+        }}
+      />
+
+      {/* I2C Pull-Up Resistors */}
+      <resistor name="R1" resistance="4.7k" schX={-5} schY={8} />
+      <resistor name="R2" resistance="4.7k" schX={5} schY={8} />
+
+      {/* Decoupling Capacitors */}
+      <capacitor name="C1" capacitance="0.1uF" schX={-8} schY={-15} />
+      <capacitor name="C2" capacitance="0.1uF" schX={10} schY={-15} />
+
+      {/* Connections */}
+      {/* Power Rail (VCC / GND) */}
+      <trace from=".J1 .pin1" to="net.VCC" />
+      <trace from=".J1 .pin2" to="net.GND" />
+
+      {/* BME280 Power */}
+      <trace from="net.VCC" to=".U1 .pin1" />   {/* VDD */}
+      <trace from="net.VCC" to=".U1 .pin3" />   {/* VDDIO */}
+      <trace from="net.VCC" to=".U1 .pin7" />   {/* CSB high enables I2C mode */}
+      <trace from=".U1 .pin4" to="net.GND" />   {/* SDO to GND selects address 0x76 */}
+      <trace from=".U1 .pin2" to="net.GND" />
+      <trace from=".U1 .pin8" to="net.GND" />
+
+      {/* OLED Power */}
+      <trace from="net.VCC" to=".U2 .pin2" />
+      <trace from="net.GND" to=".U2 .pin1" />
+
+      {/* Decoupling Caps */}
+      <trace from="net.VCC" to=".C1 .pin1" />
+      <trace from=".C1 .pin2" to="net.GND" />
+      <trace from="net.VCC" to=".C2 .pin1" />
+      <trace from=".C2 .pin2" to="net.GND" />
+
+      {/* SCL Bus */}
+      <trace from=".J1 .pin3" to="net.SCL" />
+      <trace from="net.SCL" to=".U1 .pin6" />
+      <trace from="net.SCL" to=".U2 .pin3" />
+      
+      {/* SDA Bus */}
+      <trace from=".J1 .pin4" to="net.SDA" />
+      <trace from="net.SDA" to=".U1 .pin5" />
+      <trace from="net.SDA" to=".U2 .pin4" />
+
+      {/* I2C Pull-Up Connections */}
+      <trace from="net.VCC" to=".R1 .pin1" />
+      <trace from=".R1 .pin2" to="net.SCL" />
+      
+      <trace from="net.VCC" to=".R2 .pin1" />
+      <trace from=".R2 .pin2" to="net.SDA" />
+    </board>
+  )
+}
+`} />
+
+---
+
+## 💡 Crucial Hardware Design Notes
+
+1. **CSB & SDO Configuration**:
+   - The BME280 requires the **CSB (Chip Select Bar)** pin to be pulled to **VCC** to enable the **I2C communication interface** (pulling it low selects SPI mode).
+   - **SDO** is the address select pin. Connecting it to GND sets the 7-bit slave address to `0x76`. Connecting it to VCC sets it to `0x77`.
+2. **I2C Bus Pull-Ups**:
+   - The I2C protocol uses open-drain/open-collector outputs. This means the lines can only pull down to GND; they cannot pull high themselves.
+   - External pull-up resistors (like **R1** and **R2**) are mandatory to pull SCL and SDA lines up to VCC. Without these, the signals will stay low and the bus will not function.

--- a/docs/tutorials/usb-pd-trigger-hat.mdx
+++ b/docs/tutorials/usb-pd-trigger-hat.mdx
@@ -1,0 +1,168 @@
+---
+title: USB Power Delivery Trigger HAT
+description: Design and build a USB Power Delivery Trigger HAT using tscircuit to negotiate voltages from 5V to 20V from a USB-PD power source.
+---
+
+## Overview
+
+In this tutorial, we will build a **USB Power Delivery (PD) Trigger HAT**. This board negotiates voltages (5V, 9V, 12V, 15V, or 20V) from any standard USB PD charger or battery pack and routes that power to a high-current terminal block.
+
+This board is extremely useful for powering hobbyist projects, single-board computers, or DC motors directly from a USB-PD wall adapter.
+
+We will use the **CH224K** USB PD sink controller, which handles the CC (Configuration Channel) negotiation protocol automatically without requiring a microcontroller.
+
+---
+
+## 📋 Components Checklist
+
+Our circuit will consist of:
+1. **CH224K PD Controller (U1)** — Low-cost USB PD sink chip in an ESSOP-10 package.
+2. **USB Type-C Female Port (J1)** — Input receptacle for USB-PD source.
+3. **DIP Switch (SW1)** — 3-position switch to select the requested voltage.
+4. **2-pin Screw Terminal (J2)** — High-current output terminal for external devices.
+5. **Decoupling Capacitors (C1, C2)** — Filtering capacitors to stabilize VBUS and internal VDD.
+6. **LED Indicator (D1) & Current Limiting Resistor (R1)** — Visual feedback for power output.
+
+---
+
+## 🛠️ Step-by-Step Implementation
+
+Create a new file in your project or editor and paste the following tscircuit design code.
+
+### Complete Circuit Code
+
+import TscircuitIframe from "@site/src/components/TscircuitIframe"
+
+<TscircuitIframe defaultView="schematic" code={`
+export default () => {
+  return (
+    <board width="50mm" height="35mm">
+      {/* USB-C Input Port */}
+      <chip
+        name="J1"
+        manufacturerPartNumber="USB-C-16PIN"
+        schX={-15}
+        schY={0}
+        pinLabels={{
+          pin1: "GND",
+          pin2: "VBUS",
+          pin3: "CC1",
+          pin4: "CC2",
+          pin5: "D+",
+          pin6: "D-",
+          pin7: "SBU1",
+          pin8: "SBU2",
+        }}
+      />
+
+      {/* CH224K USB-PD Controller */}
+      <chip
+        name="U1"
+        manufacturerPartNumber="CH224K"
+        schX={0}
+        schY={0}
+        pinLabels={{
+          pin1: "CFG1",
+          pin2: "CFG2",
+          pin3: "CFG3",
+          pin4: "GND",
+          pin5: "VBUS",
+          pin6: "VDD",
+          pin7: "CC2",
+          pin8: "CC1",
+          pin9: "D+",
+          pin10: "D-",
+        }}
+      />
+
+      {/* DIP Switch for Configuration */}
+      <chip
+        name="SW1"
+        manufacturerPartNumber="DIP-SWITCH-3POS"
+        schX={0}
+        schY={12}
+        pinLabels={{
+          pin1: "CFG1_SW",
+          pin2: "CFG2_SW",
+          pin3: "CFG3_SW",
+          pin4: "GND1",
+          pin5: "GND2",
+          pin6: "GND3",
+        }}
+      />
+
+      {/* Output Terminal Block */}
+      <chip
+        name="J2"
+        manufacturerPartNumber="SCREW-TERMINAL-2PIN"
+        schX={15}
+        schY={0}
+        pinLabels={{
+          pin1: "VOUT",
+          pin2: "GND",
+        }}
+      />
+
+      {/* Status LED & Resistor */}
+      <led name="D1" color="green" schX={10} schY={-8} />
+      <resistor name="R1" resistance="1k" schX={5} schY={-8} />
+
+      {/* Decoupling Capacitors */}
+      <capacitor name="C1" capacitance="10uF" schX={-8} schY={-8} />
+      <capacitor name="C2" capacitance="0.1uF" schX={-5} schY={-8} />
+
+      {/* Connections */}
+      {/* Power Rails */}
+      <trace from=".J1 .pin1" to=".U1 .pin4" />
+      <trace from=".U1 .pin4" to="net.GND" />
+      
+      <trace from=".J1 .pin2" to=".U1 .pin5" />
+      <trace from=".U1 .pin5" to="net.VBUS" />
+
+      {/* CC Line Negotiation */}
+      <trace from=".J1 .pin3" to=".U1 .pin8" />
+      <trace from=".J1 .pin4" to=".U1 .pin7" />
+
+      {/* VDD Internal LDO Capacitor */}
+      <trace from=".U1 .pin6" to=".C2 .pin1" />
+      <trace from=".C2 .pin2" to="net.GND" />
+
+      {/* Input Filtering */}
+      <trace from="net.VBUS" to=".C1 .pin1" />
+      <trace from=".C1 .pin2" to="net.GND" />
+
+      {/* Output Connections */}
+      <trace from="net.VBUS" to=".J2 .pin1" />
+      <trace from=".J2 .pin2" to="net.GND" />
+
+      {/* DIP Switch CC Configuration */}
+      <trace from=".U1 .pin1" to=".SW1 .pin1" />
+      <trace from=".U1 .pin2" to=".SW1 .pin2" />
+      <trace from=".U1 .pin3" to=".SW1 .pin3" />
+      
+      <trace from=".SW1 .pin4" to="net.GND" />
+      <trace from=".SW1 .pin5" to="net.GND" />
+      <trace from=".SW1 .pin6" to="net.GND" />
+
+      {/* LED Indicator Connection */}
+      <trace from="net.VBUS" to=".R1 .pin1" />
+      <trace from=".R1 .pin2" to=".D1 .pin1" />
+      <trace from=".D1 .pin2" to="net.GND" />
+    </board>
+  )
+}
+`} />
+
+---
+
+## ⚡ How the Voltage Negotiation Works
+
+The CH224K chip negotiates voltages based on the state of the configuration pins (**CFG1**, **CFG2**, and **CFG3**). By toggling the DIP switch, you pull these pins to GND (LOW) or leave them floating (HIGH).
+
+| CFG1 | CFG2 | CFG3 | Negotiated Voltage |
+| :---: | :---: | :---: | :--- |
+| Floating | GND | Floating | **5V** (Default USB voltage) |
+| GND | GND | Floating | **9V** |
+| Floating | Floating | GND | **12V** |
+| GND | Floating | GND | **15V** |
+| GND | Floating | Floating | **20V** |


### PR DESCRIPTION
This PR adds three comprehensive hardware tutorials as requested by bounties #601, #602, and #603.

- USB Power Delivery Trigger HAT: detailed step-by-step design using CH224K PD controller.
- I2C Environmental Sensor Module: step-by-step tutorial using BME280 sensor and I2C OLED display.
- Class D Audio Amplifier HAT: step-by-step guide with PAM8403.

All tutorials build successfully and have been verified locally with Docusaurus.