### PR TITLE
update tsci add docs

### DIFF
--- a/docs/command-line/tsci-add.mdx
+++ b/docs/command-line/tsci-add.mdx
@@ -13,10 +13,6 @@ and it has the same effect.
 tsci add <packageSpecs...>
 ```
 
-You can pass one or more package specifiers in a single command. Supported
-package specifiers include tscircuit registry packages, GitHub repository URLs,
-and versioned package names such as `author/package@version`.
-
 ## Examples
 
 ```bash

--- a/docs/command-line/tsci-add.mdx
+++ b/docs/command-line/tsci-add.mdx
@@ -1,15 +1,28 @@
 ---
 title: tsci add
-description: Install tscircuit registry packages using the tsci add command
+description: Install one or more tscircuit packages using the tsci add command
 ---
 
 `tsci add` is the same as `npm add` or `bun add`, but defaults to the tscircuit
 registry. If your project has the [tsci `.npmrc`](../web-apis/the-registry-api.md#using-the-tscircuit-npm-registry), you can just do `bun add @tsci/<author>.<package>`
 and it has the same effect.
 
+## Usage
+
+```bash
+tsci add <packageSpecs...>
 ```
-> tsci add seveibar/PICO_W
-# Added @tsci/seveibar.PICO_W@0.0.1
+
+You can pass one or more package specifiers in a single command. Supported
+package specifiers include tscircuit registry packages, GitHub repository URLs,
+and versioned package names such as `author/package@version`.
+
+## Examples
+
+```bash
+$ tsci add @tsci/seveibar.PICO @tsci/seveibar.Key
+# Adding @tsci/seveibar.PICO @tsci/seveibar.Key...
+# ✓ Added @tsci/seveibar.PICO @tsci/seveibar.Key successfully
 ```
 
 You can then import the module and use it for your board!

--- a/docs/intro/installation.md
+++ b/docs/intro/installation.md
@@ -50,7 +50,7 @@ CLI for developing tscircuit packages
 #   export [options] <file>      Export tscircuit code to various formats
 #   build [options] [file]       Run tscircuit eval and output circuit json
 #   transpile [file]             Transpile TypeScript/TSX to JavaScript
-#   add <packageSpec>            Add a tscircuit component package
+#   add <packageSpecs...>        Add tscircuit component packages to your project
 #   remove <component>           Remove a tscircuit component package
 #   snapshot [options] [path]    Generate schematic/PCB snapshots
 #   setup                        Setup utilities like GitHub Actions
@@ -83,7 +83,7 @@ tsci
 #     tsci config - Manage tscircuit CLI configuration
 #     tsci export - Export tscircuit code to various formats
 #     tsci build - Run tscircuit eval and output circuit json
-#     tsci add - Add a tscircuit component package
+#     tsci add - Add tscircuit component packages to your project
 #     tsci snapshot - Generate schematic and PCB snapshots
 #     tsci doctor - Run diagnostic checks
 #     tsci search - Search for footprints, CAD models or packages


### PR DESCRIPTION
  ## Summary

  Updates the docs to match the recent CLI change that allows `tsci add` to accept multiple package specifiers in one command.

  ## What changed

  - updated the `tsci add` command reference to show `tsci add <packageSpecs...>`
  - added an example showing multiple packages installed in a single command
  - updated the installation page help output to match current CLI wording
  - aligned the `tsci add` description with the current command behavior

  ## Why

  The CLI now supports adding multiple packages in one invocation, but the docs still described `tsci add` as a single-package command in some places. This created avoidable confusion when following the
  command reference and installation docs.

  ## User impact

  Users can now see the correct `tsci add` syntax and a working multi-package example directly in the docs, which makes the CLI behavior easier to discover and use correctly.