### PR TITLE
Add setup instructions to simple buzzer hat tutorial

### DIFF
--- a/docs/tutorials/pi-hats/simple-buzzer-hat.mdx
+++ b/docs/tutorials/pi-hats/simple-buzzer-hat.mdx
@@ -90,6 +90,10 @@ Since GPIO pins can only source about 16mA, we use an NPN transistor as a switch
 ### Base Resistor (1k)
 The 1k resistor limits current into the transistor base, protecting both the GPIO pin and the transistor.
 
+## Getting setup
+
+Firstly, if you haven't already, follow the [Quickstart Web](https://docs.tscircuit.com/intro/quickstart-web) or [Quickstart CLI](https://docs.tscircuit.com/intro/quickstart-cli) guide and create a new project. If working on your local machine be sure to add `@tscircuit/common` with `tsci add @tscircuit/common`
+ 
 ## Building the Circuit Step by Step
 
 ### Step 1: Import the RaspberryPiHatBoard


### PR DESCRIPTION
Added a new section on setup instructions for the project. 

While following the tutorial myself, I was unsure on how to add the `@tscircuit/common` dependency, so this change clarifies that