### PR TITLE
Document tsci snapshot --simulation-only and --layer flags; correct 3D snapshot file extension

### DIFF
--- a/docs/command-line/tsci-snapshot.md
+++ b/docs/command-line/tsci-snapshot.md
@@ -17,8 +17,8 @@ tsci snapshot [options] [path]
 - `--3d` – also generate 3D preview snapshots.
 - `--pcb-only` – generate only PCB snapshots.
 - `--schematic-only` – generate only schematic snapshots.
-- `--simulation-only` – generate only simulation snapshots. Cannot be combined with `--pcb-only`, `--schematic-only`, `--layer`, `--3d`, or `--camera-preset`.
-- `--layer <layer>` – generate a PCB snapshot for a single layer, either `top` or `bottom` (implies `--pcb-only`).
+- `--simulation-only` – generate only simulation snapshots.
+- `--layer <layer>` – generate a PCB snapshot for a single layer, either `top` or `bottom`.
 - `--disable-parts-engine` – disable the parts engine while rendering snapshots.
 - `--show-courtyards` – show courtyard outlines in PCB snapshots.
 - `--camera-preset <preset>` – choose the camera angle preset for 3D snapshots. This also implies `--3d`.
@@ -45,14 +45,5 @@ __snapshots__/test.board-schematic.snap.svg
 ```
 
 If `--3d` is specified, a `-3d.snap.png` is also produced.
-
-With `--simulation-only`, simulation snapshots are written instead:
-
-```
-__snapshots__/test.board-simulation.snap.svg
-__snapshots__/test.board-schematic-simulation.snap.svg
-```
-
-With `--layer top` or `--layer bottom`, the PCB snapshot is named after the layer, for example `test.board-top.snap.svg`.
 
 Running without `--update` verifies that the generated output matches the existing snapshots. Differences cause a non-zero exit code.

--- a/docs/command-line/tsci-snapshot.md
+++ b/docs/command-line/tsci-snapshot.md
@@ -17,6 +17,8 @@ tsci snapshot [options] [path]
 - `--3d` – also generate 3D preview snapshots.
 - `--pcb-only` – generate only PCB snapshots.
 - `--schematic-only` – generate only schematic snapshots.
+- `--simulation-only` – generate only simulation snapshots. Cannot be combined with `--pcb-only`, `--schematic-only`, `--layer`, `--3d`, or `--camera-preset`.
+- `--layer <layer>` – generate a PCB snapshot for a single layer, either `top` or `bottom` (implies `--pcb-only`).
 - `--disable-parts-engine` – disable the parts engine while rendering snapshots.
 - `--show-courtyards` – show courtyard outlines in PCB snapshots.
 - `--camera-preset <preset>` – choose the camera angle preset for 3D snapshots. This also implies `--3d`.
@@ -42,6 +44,15 @@ __snapshots__/test.board-pcb.snap.svg
 __snapshots__/test.board-schematic.snap.svg
 ```
 
-If `--3d` is specified, a `-3d.snap.svg` is also produced.
+If `--3d` is specified, a `-3d.snap.png` is also produced.
+
+With `--simulation-only`, simulation snapshots are written instead:
+
+```
+__snapshots__/test.board-simulation.snap.svg
+__snapshots__/test.board-schematic-simulation.snap.svg
+```
+
+With `--layer top` or `--layer bottom`, the PCB snapshot is named after the layer, for example `test.board-top.snap.svg`.
 
 Running without `--update` verifies that the generated output matches the existing snapshots. Differences cause a non-zero exit code.


### PR DESCRIPTION
Updates the `tsci snapshot` command reference to match the current CLI.

### Changes
- Document the `--simulation-only` flag, including its mutual-exclusivity with `--pcb-only`, `--schematic-only`, `--layer`, `--3d`, and `--camera-preset`.
- Document the `--layer <top|bottom>` flag (implies `--pcb-only`).
- Correct the 3D snapshot output extension from `.snap.svg` to `.snap.png` (the CLI writes a binary PNG).
- Add `*.circuit.json` to the list of file patterns the command snapshots.
- Document the simulation snapshot output filenames (`-simulation.snap.svg`, `-schematic-simulation.snap.svg`) and per-layer PCB filenames (`-top.snap.svg` / `-bottom.snap.svg`).

### Verification
Option names, flag constraints, file patterns, and output filenames were cross-checked against the CLI source (`cli/snapshot/register.ts`, `lib/shared/process-snapshot-file.ts`, `lib/shared/find-board-files.ts`) and the CLI's snapshot test suite.
