### PR TITLE
Add Crisp chat to docs

### DIFF
--- a/src/theme/Root.tsx
+++ b/src/theme/Root.tsx
@@ -6,6 +6,15 @@ const LEVEL_3_LINK_SELECTOR =
   ".theme-doc-sidebar-item-link-level-3 > .menu__link"
 const LEVEL_3_PADDING_CLASS = "menu__link--level-3"
 const SIDEBAR_MENU_SELECTOR = ".theme-doc-sidebar-menu"
+const CRISP_WEBSITE_ID = "24b58135-86c7-4e4b-bf6e-cca862bc4b26"
+const CRISP_SCRIPT_SRC = "https://client.crisp.chat/l.js"
+
+declare global {
+  interface Window {
+    $crisp?: unknown[]
+    CRISP_WEBSITE_ID?: string
+  }
+}
 
 function applyLevel3PaddingClass() {
   if (typeof document === "undefined") {
@@ -22,6 +31,24 @@ function applyLevel3PaddingClass() {
 
 export default function Root({ children }: Props): ReactElement {
   const location = useLocation()
+
+  useEffect(() => {
+    if (typeof document === "undefined") {
+      return
+    }
+
+    window.$crisp = window.$crisp ?? []
+    window.CRISP_WEBSITE_ID = CRISP_WEBSITE_ID
+
+    if (document.querySelector(`script[src="${CRISP_SCRIPT_SRC}"]`)) {
+      return
+    }
+
+    const script = document.createElement("script")
+    script.src = CRISP_SCRIPT_SRC
+    script.async = true
+    document.head.appendChild(script)
+  }, [])
 
   useEffect(() => {
     if (typeof document === "undefined") {


### PR DESCRIPTION
### Motivation
- Add Crisp live chat to the documentation site so visitors can contact support directly from docs pages.
- Load Crisp only on the client to avoid server-side rendering issues and prevent multiple script injections.
- Provide minimal TypeScript typings for the injected globals to avoid type errors.

### Description
- Added `CRISP_WEBSITE_ID` and `CRISP_SCRIPT_SRC` constants and a global `Window` declaration in `src/theme/Root.tsx`.
- Added a client-only `useEffect` that initializes `window.$crisp`, sets `window.CRISP_WEBSITE_ID`, and appends the async Crisp loader script if it is not already present.
- Preserved existing sidebar mutation-observer logic and kept changes scoped to the Docusaurus root theme component (`src/theme/Root.tsx`).

### Testing
- Ran `bun run typecheck` and it completed successfully.
- Ran `bun run format:check src/theme/Root.tsx` and no formatting fixes were required.
- Ran `bun run build` which produced a successful production build.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a4118c18f54832797fc9f4980629c92)