### PR TITLE
docs: add courtyard anchor alignment examples

### DIFF
--- a/docs/elements/courtyardoutline.mdx
+++ b/docs/elements/courtyardoutline.mdx
@@ -75,3 +75,47 @@ export default () => (
 )
 `}
 />
+
+## Anchored Courtyard Example
+
+When the same courtyard needs to be placed from a different reference point,
+combine `boardAnchorPosition` with `anchorAlignment`.
+
+<CircuitPreview
+  showCourtyards
+  defaultView="pcb"
+  hideSchematicTab
+  hide3DTab
+  code={`
+export default () => (
+  <board
+    width="30mm"
+    height="24mm"
+    boardAnchorPosition={{ x: 0, y: 0 }}
+    anchorAlignment="bottom_left"
+  >
+    <chip
+      name="U2"
+      footprint={
+        <footprint>
+          <platedhole shape="circle" pcbX={-4} pcbY={-2.5} outerDiameter={2.2} holeDiameter={1.1} />
+          <platedhole shape="circle" pcbX={-4} pcbY={2.5} outerDiameter={2.2} holeDiameter={1.1} />
+          <platedhole shape="circle" pcbX={4} pcbY={-2.5} outerDiameter={2.2} holeDiameter={1.1} />
+          <platedhole shape="circle" pcbX={4} pcbY={2.5} outerDiameter={2.2} holeDiameter={1.1} />
+          <courtyardoutline
+            outline={[
+              { x: -6, y: -5 },
+              { x: 6, y: -5 },
+              { x: 6, y: 5 },
+              { x: 0, y: 7 },
+              { x: -6, y: 5 },
+            ]}
+          />
+        </footprint>
+      }
+    />
+    <fabricationnotetext text="anchor: bottom_left" anchorAlignment="bottom_left" fontSize="0.5mm" pcbX={-5} pcbY={-9} />
+  </board>
+)
+`}
+/>

--- a/docs/elements/courtyardrect.mdx
+++ b/docs/elements/courtyardrect.mdx
@@ -71,3 +71,42 @@ export default () => (
 )
 `}
 />
+
+## Anchored Rectangle Example
+
+The rectangle can use the same anchor controls as the board itself. This is
+useful when you want the courtyard to stay aligned to a specific corner.
+
+<CircuitPreview
+  showCourtyards
+  defaultView="pcb"
+  hideSchematicTab
+  hide3DTab
+  code={`
+export default () => (
+  <board
+    width="30mm"
+    height="24mm"
+    boardAnchorPosition={{ x: 0, y: 0 }}
+    anchorAlignment="top_right"
+  >
+    <chip
+      name="J2"
+      footprint={
+        <footprint>
+          <platedhole shape="circle" pcbX={-3} pcbY={0} outerDiameter={2.2} holeDiameter={1.1} />
+          <platedhole shape="circle" pcbX={3} pcbY={0} outerDiameter={2.2} holeDiameter={1.1} />
+          <courtyardrect
+            pcbX={0}
+            pcbY={0}
+            width={14}
+            height={10}
+            strokeWidth={0.1}
+          />
+        </footprint>
+      }
+    />
+  </board>
+)
+`}
+/>


### PR DESCRIPTION
/claim #498`n`nAdd courtyard outline and courtyard rect examples that demonstrate board anchor alignment controls with clear anchor-position notes.