### PR TITLE
Document multiple analog simulations

### DIFF
--- a/docs/elements/analogsimulation.mdx
+++ b/docs/elements/analogsimulation.mdx
@@ -40,14 +40,96 @@ export default () => (
 
 | Property | Description | Example |
 | --- | --- | --- |
+| `name` | User-facing experiment name. Use a unique name when defining multiple simulations. | `"Startup"` |
 | `duration` | Total simulation time. Accepts numbers or time strings. | `"10ms"` |
 | `timePerStep` | Time interval between simulation steps. | `"0.1ms"` |
 | `spiceEngine` | SPICE engine to use. Typically `"ngspice"` or `"spicey"`. | `"ngspice"` |
 | `graphIndependentAxes` | Give each voltage or current graph channel its own automatically scaled axis. | `true` |
 
-Use `<analogsimulation />` once per `<board />` to define how the simulation
-runs. Combine it with `<voltagesource />` and `<voltageprobe />` elements to
-create and observe waveforms.
+You can use `<analogsimulation />` more than once in the same board. Each
+element creates an independent experiment with its own duration, time step,
+SPICE options, and result graphs.
+
+## Multiple simulations and group scope
+
+Give each simulation a unique `name`. When more than one experiment is
+available, the simulation preview shows a selector for switching between its
+SVG results.
+
+A simulation placed directly in the board collects probes throughout that
+board, including probes inside groups. A simulation inside a `<group />`
+collects only the probes in its nearest containing group. The complete circuit
+is simulated in both cases; the group controls which result graphs are shown.
+
+<CircuitPreview
+  defaultView="schematic"
+  hidePCBTab={true}
+  hide3DTab={true}
+  verticalStack={true}
+  showSimulationGraph={true}
+  simulationExperimentNames={[
+    "Root Fast",
+    "Root Slow",
+    "Input Group",
+    "Output Group",
+  ]}
+  defaultSimulationExperimentName="Root Fast"
+  code={`
+export default () => (
+  <board routingDisabled>
+    <voltagesource name="V1" voltage="5V" />
+    <resistor name="R1" resistance="1k" />
+    <resistor name="R2" resistance="2k" />
+    <resistor name="R3" resistance="3k" />
+
+    <trace from=".V1 > .pin1" to=".R1 > .pin1" />
+    <trace from=".R1 > .pin2" to=".R2 > .pin1" />
+    <trace from=".R2 > .pin2" to=".R3 > .pin1" />
+    <trace from=".R3 > .pin2" to=".V1 > .pin2" />
+
+    <voltageprobe name="ROOT_PROBE" connectsTo=".V1 > .pin1" />
+    <analogsimulation
+      name="Root Fast"
+      duration="1ms"
+      timePerStep="100us"
+      spiceEngine="ngspice"
+    />
+    <analogsimulation
+      name="Root Slow"
+      duration="2ms"
+      timePerStep="200us"
+      spiceEngine="ngspice"
+    />
+
+    <group name="first-stage">
+      <voltageprobe
+        name="FIRST_STAGE_PROBE"
+        connectsTo=".R1 > .pin2"
+      />
+      <analogsimulation
+        name="Input Group"
+        duration="3ms"
+        timePerStep="300us"
+        spiceEngine="ngspice"
+      />
+    </group>
+
+    <group name="second-stage">
+      <voltageprobe
+        name="SECOND_STAGE_PROBE"
+        connectsTo=".R2 > .pin2"
+      />
+      <analogsimulation
+        name="Output Group"
+        duration="4ms"
+        timePerStep="400us"
+        spiceEngine="ngspice"
+      />
+    </group>
+  </board>
+)
+`}
+/>
 
 ## Multi-axis scope display
 

--- a/src/components/CircuitPreview/CircuitPreview.tsx
+++ b/src/components/CircuitPreview/CircuitPreview.tsx
@@ -526,16 +526,7 @@ export default function CircuitPreview({
       <div className={tw("flex min-w-0 items-center gap-2 mt-2 mb-2")}>
         {editorUrl && <TryInEditorLink href={editorUrl} />}
         {showSimulationSelector && (
-          <label
-            className={tw(
-              `flex min-w-0 items-center gap-2 rounded-md px-2 py-1 text-sm ${
-                !isDarkTheme
-                  ? "bg-slate-100 text-slate-700"
-                  : "bg-slate-800 text-slate-200"
-              }`,
-            )}
-          >
-            <span className={tw("font-semibold")}>Simulation</span>
+          <label className={tw("min-w-0")}>
             <select
               aria-label="Select analog simulation"
               value={selectedSimulationExperimentName ?? ""}
@@ -552,7 +543,7 @@ export default function CircuitPreview({
             >
               {simulationExperimentNames.map((name) => (
                 <option key={name} value={name}>
-                  {name}
+                  Simulation: {name}
                 </option>
               ))}
             </select>

--- a/src/components/CircuitPreview/CircuitPreview.tsx
+++ b/src/components/CircuitPreview/CircuitPreview.tsx
@@ -173,6 +173,8 @@ export default function CircuitPreview({
   leftView,
   rightView,
   showSimulationGraph = false,
+  simulationExperimentNames = [],
+  defaultSimulationExperimentName,
   verticalStack = false,
   showCourtyards = false,
 }: {
@@ -194,6 +196,8 @@ export default function CircuitPreview({
   rightView?: CircuitPreviewView
   projectBaseUrl?: string
   showSimulationGraph?: boolean
+  simulationExperimentNames?: string[]
+  defaultSimulationExperimentName?: string
   verticalStack?: boolean
   showCourtyards?: boolean
 }) {
@@ -213,6 +217,19 @@ export default function CircuitPreview({
   const [editingFiles, setEditingFiles] = useState<Record<string, boolean>>({})
   const [hasEditedCode, setHasEditedCode] = useState(false)
   const [loadingUrls, setLoadingUrls] = useState<Record<string, boolean>>({})
+  const simulationExperimentNamesKey = simulationExperimentNames.join("\0")
+  const [
+    selectedSimulationExperimentName,
+    setSelectedSimulationExperimentName,
+  ] = useState(
+    defaultSimulationExperimentName ?? simulationExperimentNames[0] ?? null,
+  )
+
+  useEffect(() => {
+    setSelectedSimulationExperimentName(
+      defaultSimulationExperimentName ?? simulationExperimentNames[0] ?? null,
+    )
+  }, [defaultSimulationExperimentName, simulationExperimentNamesKey])
 
   useEffect(() => {
     setEditableCode(
@@ -277,19 +294,33 @@ export default function CircuitPreview({
     const separator = basePcbUrl.includes("?") ? "&" : "?"
     return `${basePcbUrl}${separator}show_courtyards=true`
   }, [fsMapOrCode, mainComponentPath, showCourtyards])
-  const schUrl = useMemo(
-    () =>
-      addMainComponentPath(
-        createSvgUrl(
-          fsMapOrCode,
-          showSimulationGraph ? "schsim" : "schematic",
-          {
-            simulationExperimentId: "simulation_experiment_0",
-          },
-        ),
+  const schUrl = useMemo(() => {
+    const baseUrl = addMainComponentPath(
+      createSvgUrl(
+        fsMapOrCode,
+        showSimulationGraph ? "schsim" : "schematic",
+        showSimulationGraph && !selectedSimulationExperimentName
+          ? { simulationExperimentId: "simulation_experiment_0" }
+          : undefined,
       ),
-    [fsMapOrCode, mainComponentPath, showSimulationGraph],
-  )
+    )
+
+    if (!showSimulationGraph || !selectedSimulationExperimentName) {
+      return baseUrl
+    }
+
+    const url = new URL(baseUrl)
+    url.searchParams.set(
+      "simulation_experiment_name",
+      selectedSimulationExperimentName,
+    )
+    return url.toString()
+  }, [
+    fsMapOrCode,
+    mainComponentPath,
+    selectedSimulationExperimentName,
+    showSimulationGraph,
+  ])
   const pinoutUrl = useMemo(
     () => addMainComponentPath(createSvgUrl(fsMapOrCode, "pinout")),
     [fsMapOrCode, mainComponentPath],
@@ -359,6 +390,8 @@ export default function CircuitPreview({
   }, [hasEditedCode, pcbUrl, schUrl, pinoutUrl, threeDUrl])
 
   const shouldSplitCode = _splitView && windowSize !== "mobile"
+  const showSimulationSelector =
+    showSimulationGraph && simulationExperimentNames.length > 1
 
   const currentCode = editableFsMap?.[currentFile] ?? editableCode
   const currentFileKey = currentFile ?? "__code"
@@ -490,8 +523,41 @@ export default function CircuitPreview({
 
   const previewHeaderElm = (showViewTabs: boolean) => (
     <div className={tw("flex items-center justify-between gap-2 px-2")}>
-      <div className={tw("flex min-w-0 items-center mt-2 mb-2")}>
+      <div className={tw("flex min-w-0 items-center gap-2 mt-2 mb-2")}>
         {editorUrl && <TryInEditorLink href={editorUrl} />}
+        {showSimulationSelector && (
+          <label
+            className={tw(
+              `flex min-w-0 items-center gap-2 rounded-md px-2 py-1 text-sm ${
+                !isDarkTheme
+                  ? "bg-slate-100 text-slate-700"
+                  : "bg-slate-800 text-slate-200"
+              }`,
+            )}
+          >
+            <span className={tw("font-semibold")}>Simulation</span>
+            <select
+              aria-label="Select analog simulation"
+              value={selectedSimulationExperimentName ?? ""}
+              onChange={(event) =>
+                setSelectedSimulationExperimentName(event.target.value)
+              }
+              className={tw(
+                `min-w-0 max-w-full rounded border px-2 py-0.5 text-sm ${
+                  !isDarkTheme
+                    ? "border-slate-300 bg-white text-slate-950"
+                    : "border-slate-600 bg-slate-900 text-white"
+                }`,
+              )}
+            >
+              {simulationExperimentNames.map((name) => (
+                <option key={name} value={name}>
+                  {name}
+                </option>
+              ))}
+            </select>
+          </label>
+        )}
       </div>
       {showViewTabs && (
         <div
@@ -594,11 +660,15 @@ export default function CircuitPreview({
             }`,
           )} circuit-preview-pane circuit-preview-pane-${v}`}
         >
-          {hasPreviewHeader && previewHeaderElm(false)}
+          {(hasPreviewHeader || showSimulationSelector) &&
+            previewHeaderElm(false)}
           {renderPreviewImage({
             src,
-            alt: `${v.toUpperCase()} Circuit Preview`,
-            hasHeader: hasPreviewHeader,
+            alt:
+              v === "schematic" && selectedSimulationExperimentName
+                ? `Schematic simulation preview: ${selectedSimulationExperimentName}`
+                : `${v.toUpperCase()} Circuit Preview`,
+            hasHeader: hasPreviewHeader || showSimulationSelector,
             imageClassName: `w-full m-0 object-contain ${
               v === "pcb"
                 ? "bg-black flex items-center justify-center"
@@ -634,7 +704,8 @@ export default function CircuitPreview({
     renderCodePane("border-r")
 
   const imageViewHasHeader =
-    shouldSplitCode && (Boolean(editorUrl) || _showTabs)
+    shouldSplitCode &&
+    (Boolean(editorUrl) || _showTabs || showSimulationSelector)
 
   const ImageView = (view === "pcb" ||
     view === "schematic" ||
@@ -663,7 +734,9 @@ export default function CircuitPreview({
       })}
       {renderPreviewImage({
         src: schUrl,
-        alt: "Schematic Circuit Preview",
+        alt: selectedSimulationExperimentName
+          ? `Schematic simulation preview: ${selectedSimulationExperimentName}`
+          : "Schematic Circuit Preview",
         hidden: view !== "schematic",
         hasHeader: imageViewHasHeader,
         imageClassName: "w-full m-0 object-contain bg-[#F5F1ED]",
@@ -702,7 +775,9 @@ export default function CircuitPreview({
         } rounded-lg mb-8 overflow-hidden`,
       )}
     >
-      {((_showTabs && !shouldSplitCode) || (editorUrl && !shouldSplitCode)) &&
+      {((_showTabs && !shouldSplitCode) ||
+        (editorUrl && !shouldSplitCode) ||
+        (showSimulationSelector && !shouldSplitCode)) &&
         previewHeaderElm(_showTabs)}
       <div
         className={tw(


### PR DESCRIPTION
<img width="1780" height="1238" alt="image" src="https://github.com/user-attachments/assets/aefb677e-2c8f-4b9a-927a-727a8587ff81" />

## Summary

- add a simulation selector to `CircuitPreview` for examples with multiple analog experiments
- request one named `schsim` SVG whenever the selected experiment changes
- document unique simulation names, multiple root simulations, group-scoped result graphs, and a four-experiment ngspice example
- leave the CLI documentation unchanged

## Why

A circuit can now contain multiple analog simulations, so showing only the first generated SVG hides the other experiment results. The preview selector presents those SVGs in one compact documentation example, similar to switching schematic sheets.

## User impact

Readers can switch among two board-level and two group-level simulation results directly from the `<analogsimulation />` documentation. Documentation previews opt in by providing their experiment names.

Depends on https://github.com/tscircuit/svg.tscircuit.com/pull/1827 for named SVG selection.

## Validation

- `bun run typecheck`
- `bun run build`
- changed-source Biome format check
- inspected the generated `analogsimulation` HTML for all four selector options and the named simulation URL
