### PR TITLE
Fix first search character disappearing on mobile

### DIFF
--- a/src/theme/Root.tsx
+++ b/src/theme/Root.tsx
@@ -6,6 +6,7 @@ const LEVEL_3_LINK_SELECTOR =
   ".theme-doc-sidebar-item-link-level-3 > .menu__link"
 const LEVEL_3_PADDING_CLASS = "menu__link--level-3"
 const SIDEBAR_MENU_SELECTOR = ".theme-doc-sidebar-menu"
+const DOCSEARCH_INPUT_SELECTOR = ".DocSearch-Input"
 const CRISP_WEBSITE_ID = "24b58135-86c7-4e4b-bf6e-cca862bc4b26"
 const CRISP_SCRIPT_SRC = "https://client.crisp.chat/l.js"
 
@@ -29,8 +30,67 @@ function applyLevel3PaddingClass() {
   })
 }
 
+function recoverDocSearchInputFocus(event: KeyboardEvent) {
+  // The lazy modal can be visible briefly while its trigger still owns focus.
+  // DocSearch otherwise consumes the first printable key without updating the input.
+  if (
+    !document.body.classList.contains("DocSearch--active") ||
+    event.defaultPrevented ||
+    event.isComposing ||
+    event.key.length !== 1 ||
+    event.altKey ||
+    event.ctrlKey ||
+    event.metaKey
+  ) {
+    return
+  }
+
+  const input = document.querySelector<HTMLInputElement>(
+    DOCSEARCH_INPUT_SELECTOR,
+  )
+  if (!input || document.activeElement === input) {
+    return
+  }
+
+  // Bypass React's value tracker so the input event below is treated as a change.
+  const setInputValue = Object.getOwnPropertyDescriptor(
+    HTMLInputElement.prototype,
+    "value",
+  )?.set
+  if (!setInputValue) {
+    return
+  }
+
+  event.preventDefault()
+  event.stopImmediatePropagation()
+  input.focus()
+
+  const selectionStart = input.selectionStart ?? input.value.length
+  const selectionEnd = input.selectionEnd ?? selectionStart
+  const nextValue = `${input.value.slice(0, selectionStart)}${event.key}${input.value.slice(selectionEnd)}`
+  const nextCursorPosition = selectionStart + event.key.length
+
+  setInputValue.call(input, nextValue)
+  input.setSelectionRange(nextCursorPosition, nextCursorPosition)
+  input.dispatchEvent(
+    new InputEvent("input", {
+      bubbles: true,
+      data: event.key,
+      inputType: "insertText",
+    }),
+  )
+}
+
 export default function Root({ children }: Props): ReactElement {
   const location = useLocation()
+
+  useEffect(() => {
+    window.addEventListener("keydown", recoverDocSearchInputFocus, true)
+
+    return () => {
+      window.removeEventListener("keydown", recoverDocSearchInputFocus, true)
+    }
+  }, [])
 
   useEffect(() => {
     if (typeof document === "undefined") {


### PR DESCRIPTION
- recover focus when the DocSearch modal opens while the search button still owns focus
- forward the first printable character to the search input
- preserve normal keyboard shortcuts and composition events

