### PR TITLE
Hide black schematic view for silkscreen circle and make the pcb view as default

### DIFF
--- a/docs/footprints/silkscreencircle.mdx
+++ b/docs/footprints/silkscreencircle.mdx
@@ -9,7 +9,10 @@ Silkscreen circles are often used to indicate "pin1" on a chip.
 
 import CircuitPreview from "@site/src/components/CircuitPreview"
 
-<CircuitPreview code={`
+<CircuitPreview 
+  defaultView="pcb"
+  hideSchematicTab
+  code={`
   export default () => (
   <board width="5mm" height="5mm">
     <group>


### PR DESCRIPTION
# Before 
<img width="989" height="580" src="https://github.com/user-attachments/assets/113b6ca6-c208-46db-9222-51d1f8ec0bf2" />

# After

<img width="965" height="801" src="https://github.com/user-attachments/assets/ab6c115e-9447-44b1-a9b0-2d510ef5769f" />
