### PR TITLE
fix: adjust copy page dropdown alignment breakpoint 

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -1399,7 +1399,7 @@ article,
 }
 
 /* Responsive adjustments */
-@media (max-width: 500px) {
+@media (max-width: 800px) {
   .copy-page-dropdown {
     right: auto;
     left: 0;


### PR DESCRIPTION

### Problem
When resizing the screen below 800px width, the "Copy page" button shifts to relative positioning on the left side of the page, but the dropdown menu maintained `right: 0`, causing it to overflow past the left margin of the screen.
### Solution
Updated the responsive CSS breakpoint for `.copy-page-dropdown` from `500px` to `800px` so the dropdown aligns to `left: 0` whenever the button shifts to the left layout.

Before:
<img width="266" height="282" alt="Screenshot 2026-07-26 at 12 21 50 PM" src="https://github.com/user-attachments/assets/4e69abbe-b919-45b2-8bc7-c499258e1aec" />



After :
<img width="435" height="355" alt="Screenshot 2026-07-26 at 12 40 39 PM" src="https://github.com/user-attachments/assets/ca125204-ee66-406e-b444-52af28ae884f" />




