### PR TITLE
fix(tutorials): update trace selectors from .HAT1_chip to .HAT1

### DIFF
--- a/codetestingplayground/pi-hat-buzzer.circuit.tsx
+++ b/codetestingplayground/pi-hat-buzzer.circuit.tsx
@@ -38,18 +38,18 @@ export default () => (
     />
 
     {/* Connect GPIO18 (PWM) to base resistor */}
-    <trace from=".HAT1_chip .GPIO_18" to=".R1 > .pin1" />
+    <trace from=".HAT1 > .GPIO_18" to=".R1 > .pin1" />
 
     {/* Connect resistor to transistor base */}
-    <trace from=".R1 > .pin2" to=".Q1 .B" />
+    <trace from=".R1 > .pin2" to=".Q1 > .B" />
 
     {/* Connect transistor emitter to ground */}
-    <trace from=".Q1 .E" to=".HAT1_chip .GND_1" />
+    <trace from=".Q1 > .E" to=".HAT1 > .GND_1" />
 
     {/* Connect buzzer positive to 5V */}
-    <trace from=".BZ1 > .pin1" to=".HAT1_chip .V5_1" />
+    <trace from=".BZ1 > .pin1" to=".HAT1 > .V5_1" />
 
     {/* Connect buzzer negative to transistor collector */}
-    <trace from=".BZ1 > .pin2" to=".Q1 .C" />
+    <trace from=".BZ1 > .pin2" to=".Q1 > .C" />
   </RaspberryPiHatBoard>
 )

--- a/docs/tutorials/pi-hats/simple-buzzer-hat.mdx
+++ b/docs/tutorials/pi-hats/simple-buzzer-hat.mdx
@@ -47,19 +47,19 @@ export default () => (
     <resistor name="R1" resistance="1k" footprint="0402" pcbX={-10} pcbY={-10} />
 
     {/* GPIO18 (PWM) to base resistor */}
-    <trace from=".HAT1_chip .GPIO_18" to=".R1 > .pin1" />
+    <trace from=".HAT1 > .GPIO_18" to=".R1 > .pin1" />
 
     {/* Resistor to transistor base */}
-    <trace from=".R1 > .pin2" to=".Q1 .B" />
+    <trace from=".R1 > .pin2" to=".Q1 > .B" />
 
     {/* Transistor emitter to ground */}
-    <trace from=".Q1 .E" to=".HAT1_chip .GND_1" />
+    <trace from=".Q1 > .E" to=".HAT1 > .GND_1" />
 
     {/* Buzzer positive to 5V */}
-    <trace from=".BZ1 > .pin1" to=".HAT1_chip .V5_1" />
+    <trace from=".BZ1 > .pin1" to=".HAT1 > .V5_1" />
 
     {/* Buzzer negative to transistor collector */}
-    <trace from=".BZ1 > .pin2" to=".Q1 .C" />
+    <trace from=".BZ1 > .pin2" to=".Q1 > .C" />
   </RaspberryPiHatBoard>
 )
 `} />
@@ -227,19 +227,19 @@ export default () => (
     <resistor name="R1" resistance="1k" footprint="0402" pcbX={-10} pcbY={-10} />
 
     {/* GPIO18 (PWM) to base resistor */}
-    <trace from=".HAT1_chip .GPIO_18" to=".R1 > .pin1" />
+    <trace from=".HAT1 > .GPIO_18" to=".R1 > .pin1" />
 
     {/* Resistor to transistor base */}
-    <trace from=".R1 > .pin2" to=".Q1 .B" />
+    <trace from=".R1 > .pin2" to=".Q1 > .B" />
 
     {/* Transistor emitter to ground */}
-    <trace from=".Q1 .E" to=".HAT1_chip .GND_1" />
+    <trace from=".Q1 > .E" to=".HAT1 > .GND_1" />
 
     {/* Buzzer positive to 5V */}
-    <trace from=".BZ1 > .pin1" to=".HAT1_chip .V5_1" />
+    <trace from=".BZ1 > .pin1" to=".HAT1 > .V5_1" />
 
     {/* Buzzer negative to transistor collector */}
-    <trace from=".BZ1 > .pin2" to=".Q1 .C" />
+    <trace from=".BZ1 > .pin2" to=".Q1 > .C" />
   </RaspberryPiHatBoard>
 )
 `} />
@@ -290,11 +290,11 @@ export default () => (
     />
     <resistor name="R1" resistance="1k" footprint="0402" pcbX={-10} pcbY={-10} />
 
-    <trace from=".HAT1_chip .GPIO_18" to=".R1 > .pin1" />
-    <trace from=".R1 > .pin2" to=".Q1 .B" />
-    <trace from=".Q1 .E" to=".HAT1_chip .GND_1" />
-    <trace from=".BZ1 > .pin1" to=".HAT1_chip .V5_1" />
-    <trace from=".BZ1 > .pin2" to=".Q1 .C" />
+    <trace from=".HAT1 > .GPIO_18" to=".R1 > .pin1" />
+    <trace from=".R1 > .pin2" to=".Q1 > .B" />
+    <trace from=".Q1 > .E" to=".HAT1 > .GND_1" />
+    <trace from=".BZ1 > .pin1" to=".HAT1 > .V5_1" />
+    <trace from=".BZ1 > .pin2" to=".Q1 > .C" />
   </RaspberryPiHatBoard>
 )
 `} />


### PR DESCRIPTION
## Issue
The PCB interactive preview on the "Building a Simple Buzzer HAT" tutorial page throws 3 `source_trace_not_connected_error` errors (`Component ".HAT1_chip" not found`). 

This happens because the `<RaspberryPiHatBoard>` is named `HAT1`, but the trace selectors were referencing `.HAT1_chip`.

## Fix
- Updated trace selectors from `.HAT1_chip` to `.HAT1` (`.HAT1 .GPIO_18`, `.HAT1 .GND_1`, `.HAT1 .V5_1`).
- Fixed trace selectors in `docs/tutorials/pi-hats/simple-buzzer-hat.mdx` and `codetestingplayground/pi-hat-buzzer.circuit.tsx`.