### PR TITLE
docs: add missing footprint to schematicrect examples

### DIFF
--- a/docs/elements/schematicrect.mdx
+++ b/docs/elements/schematicrect.mdx
@@ -27,6 +27,7 @@ export default () => (
   <board width="10mm" height="10mm">
     <chip
       name="U1"
+      footprint="soic8"
       symbol={
         <symbol>
           <schematicrect
@@ -58,6 +59,7 @@ export default () => (
   <board width="10mm" height="10mm">
     <chip
       name="U1"
+      footprint="soic8"
       symbol={
         <symbol>
           <schematicrect
@@ -92,6 +94,7 @@ export default () => (
   <board width="10mm" height="10mm">
     <chip
       name="U1"
+      footprint="soic8"
       symbol={
         <symbol>
           <schematicrect
@@ -124,6 +127,7 @@ export default () => (
   <board width="10mm" height="10mm">
     <chip
       name="U1"
+      footprint="soic8"
       symbol={
         <symbol>
           <schematicrect


### PR DESCRIPTION
Added `footprint="soic8"` to the `<chip>` elements in the `<schematicrect>` examples. This fixes the `pcb_missing_footprint_error` that occurs when users copy these snippets into the tscircuit editor and view the PCB layout.


Before Fix:
<img width="1438" height="644" alt="Screenshot 2026-07-27 at 12 50 50 AM" src="https://github.com/user-attachments/assets/8928e83a-e4a4-41d2-a772-c88acb086b84" />

<img width="967" height="440" alt="Screenshot 2026-07-27 at 12 50 37 AM" src="https://github.com/user-attachments/assets/773edc99-559c-46d4-9407-c789167cafe6" />

After:

<img width="1404" height="600" alt="Screenshot 2026-07-27 at 12 49 04 AM" src="https://github.com/user-attachments/assets/94c28429-3707-4a2d-88e2-5102c2130c85" />

<img width="924" height="470" alt="Screenshot 2026-07-27 at 12 48 45 AM" src="https://github.com/user-attachments/assets/b12f72a9-9bf1-43c9-89f0-48d016fa068f" />