### PR TITLE
fix: use interactive runframe for 3d preview in CircuitPreview

### DIFF
--- a/docs/intro/what-is-tscircuit.mdx
+++ b/docs/intro/what-is-tscircuit.mdx
@@ -24,11 +24,12 @@ flashlight that we make in [this tutorial](../tutorials/building-a-simple-usb-fl
 
 import CircuitPreview from "@site/src/components/CircuitPreview"
 
-<CircuitPreview defaultView="3d" code={`
+<CircuitPreview defaultView="3d" browser3dView={true} hideEditorLink={true} code={`
 import { PushButton } from "@tsci/seveibar.push-button"
 import { SmdUsbC } from "@tsci/seveibar.smd-usb-c"
 
 export default () => {
+  // trigger cache bust
   return (
     <board width="12mm" height="30mm">
       <SmdUsbC

--- a/src/components/CircuitPreview/CircuitPreview.tsx
+++ b/src/components/CircuitPreview/CircuitPreview.tsx
@@ -143,6 +143,7 @@ export default function CircuitPreview({
   projectBaseUrl = "https://docs.tscircuit.com/",
   leftView,
   rightView,
+  hideEditorLink = false,
   showSimulationGraph = false,
   simulationExperimentNames = [],
   defaultSimulationExperimentName,
@@ -165,6 +166,7 @@ export default function CircuitPreview({
   browser3dView?: boolean
   leftView?: CircuitPreviewView
   rightView?: CircuitPreviewView
+  hideEditorLink?: boolean
   projectBaseUrl?: string
   showSimulationGraph?: boolean
   simulationExperimentNames?: string[]
@@ -402,7 +404,7 @@ export default function CircuitPreview({
   const previewHeaderElm = (showViewTabs: boolean) => (
     <div className={tw("flex items-center justify-between gap-2 px-2")}>
       <div className={tw("flex min-w-0 items-center gap-2 mt-2 mb-2")}>
-        {editorUrl && <TryInEditorLink href={editorUrl} />}
+        {editorUrl && !hideEditorLink && <TryInEditorLink href={editorUrl} />}
         {showSimulationSelector && (
           <label className={tw("min-w-0")}>
             <select
@@ -617,13 +619,22 @@ export default function CircuitPreview({
         hasHeader: imageViewHasHeader,
         imageClassName: "w-full m-0 object-contain bg-white",
       })}
-      {renderPreviewImage({
-        src: threeDUrl,
-        alt: "3D Circuit Preview",
-        hidden: view !== "3d",
-        hasHeader: imageViewHasHeader,
-        imageClassName: "w-full m-0 object-cover bg-white",
-      })}
+      <div
+        className={tw(
+          `relative w-full ${getPreviewContentHeightCss(imageViewHasHeader)} ${
+            view !== "3d" ? "hidden" : ""
+          } bg-white overflow-hidden`,
+        )}
+      >
+        <div style={{ marginTop: "-64px", height: "calc(100% + 64px)" }}>
+          <TscircuitIframe
+            fsMap={fsMap}
+            code={typeof fsMapOrCode === "string" ? fsMapOrCode : undefined}
+            defaultView="3d"
+            showTabs={false}
+          />
+        </div>
+      </div>
       {showRunFrame && view === "runframe" && (
         <div
           className={tw(

--- a/src/components/TscircuitIframe.tsx
+++ b/src/components/TscircuitIframe.tsx
@@ -4,13 +4,20 @@ export interface TscircuitIframeProps {
   fsMap?: Record<string, string>
   entrypoint?: string
   code?: string
+  defaultView?: string
+  showTabs?: boolean
 }
 
 export const TscircuitIframe = (runFrameProps: TscircuitIframeProps) => {
   const iframeRef = useRef<HTMLIFrameElement>(null)
   const [isLoading, setIsLoading] = useState(true)
 
-  let additionalProps: Record<string, any> = { isWebEmbedded: true }
+  let additionalProps: Record<string, any> = {
+    isWebEmbedded: true,
+    hideHeader: true,
+    showHeader: false,
+    headerVisible: false,
+  }
 
   if (runFrameProps.code) {
     additionalProps = {
@@ -27,6 +34,14 @@ export const TscircuitIframe = (runFrameProps: TscircuitIframeProps) => {
       fsMap: runFrameProps.fsMap,
       entrypoint: runFrameProps.entrypoint,
     }
+  }
+
+  if (runFrameProps.defaultView) {
+    additionalProps.defaultView = runFrameProps.defaultView
+  }
+
+  if (runFrameProps.showTabs !== undefined) {
+    additionalProps.showTabs = runFrameProps.showTabs
   }
 
   useEffect(() => {


### PR DESCRIPTION
This PR replaces the static 3D image backend with the interactive `TscircuitIframe` runframe to fix 3D model alignment issues (like the SMD USB-C connector offset).
Before :
<img width="1445" height="1000" alt="area_2026-07-29_02-39-32" src="https://github.com/user-attachments/assets/8021c606-dc71-4829-9313-d77e8f760237" />
After :
<img width="1443" height="941" alt="area_2026-07-29_02-40-50" src="https://github.com/user-attachments/assets/c742d6ec-d61f-4b9c-a807-9d8d2f4ca8e4" />