### PR TITLE
Fix cropped 3D previews in circuit examples

### DIFF
--- a/src/components/CircuitPreview/CircuitPreview.tsx
+++ b/src/components/CircuitPreview/CircuitPreview.tsx
@@ -545,7 +545,7 @@ export default function CircuitPreview({
                   ? "bg-[#F5F1ED]"
                   : v === "pinout"
                     ? "bg-white"
-                    : "bg-white object-cover"
+                    : "bg-white"
             }`,
           })}
         </div>
@@ -622,7 +622,7 @@ export default function CircuitPreview({
         alt: "3D Circuit Preview",
         hidden: view !== "3d",
         hasHeader: imageViewHasHeader,
-        imageClassName: "w-full m-0 object-cover bg-white",
+        imageClassName: "w-full m-0 object-contain bg-white",
       })}
       {showRunFrame && view === "runframe" && (
         <div


### PR DESCRIPTION
## Summary
- render 3D preview images with `object-contain` instead of `object-cover`
- apply the behavior to both standard and explicit left/right preview layouts
- keep the complete generated board visible across documentation examples


Before
<img width="1440" height="900" alt="Screenshot 2026-07-29 at 11 57 14 PM" src="https://github.com/user-attachments/assets/90a0ebe0-649a-4ec3-aa82-4d7c97295c66" />

After:
<img width="1440" height="900" alt="Screenshot 2026-07-29 at 11 51 52 PM" src="https://github.com/user-attachments/assets/ad724e78-f291-4488-9dd2-b818028ef103" />



