### PR TITLE
Remove auto-cloud from docs

### DIFF
--- a/docs/command-line/tsci-login.md
+++ b/docs/command-line/tsci-login.md
@@ -1,6 +1,6 @@
 ---
 title: tsci login
-description: Sign in to the tscircuit registry to enable publishing and cloud tools
+description: Sign in to the tscircuit registry to enable publishing tools
 sidebar_position: 1
 ---
 
@@ -8,7 +8,6 @@ sidebar_position: 1
 login to tscircuit to use any tools, but logging in does enable the following
 great features:
 
-- Cloud Autorouting (`autorouter="auto-cloud"`)
 - Package Management (publishing and automatic bundling)
 
 :::info
@@ -17,7 +16,7 @@ You don't need a tscircuit account to download and use other people's packages
 
 `tsci login` will take you to a login page where you'll sign in with Github.
 After the login flow you'll have have token on your machine that authenticates
-you to publish packages or use the cloud autorouter.
+you to publish packages.
 
 ## Logout
 

--- a/docs/elements/board.mdx
+++ b/docs/elements/board.mdx
@@ -288,7 +288,7 @@ Use lower values while iterating quickly, then increase effort for dense boards
 or final route attempts.
 
 ```tsx
-<board width="30mm" height="20mm" autorouter="sequential-trace" autorouterEffortLevel="10x">
+<board width="30mm" height="20mm" autorouter="auto" autorouterEffortLevel="10x">
   <chip name="U1" footprint="qfn32" pcbX={-4} pcbY={0} />
   <chip name="U2" footprint="qfn32" pcbX={4} pcbY={0} />
   <trace from=".U1 > .pin1" to=".U2 > .pin1" />

--- a/docs/elements/board.mdx
+++ b/docs/elements/board.mdx
@@ -32,7 +32,7 @@ import CircuitPreview from '@site/src/components/CircuitPreview'
 | `width`, `height` | `string \| number` | Define the board's bounding box dimensions in millimeters. |
 | `borderRadius` | `string \| number` | Round the corners of rectangular outlines by the specified radius. |
 | `layers` | `1 \| 2 \| 4 \| 6 \| 8` | Specify the number of copper layers in the board stackup. Defaults to 2 layers. |
-| `autorouter` | `'auto' \| 'sequential-trace' \| 'auto-local' \| 'auto-cloud' \| 'laser_prefab' \| 'auto_jumper' \| AutorouterConfig` | Select a built-in autorouter preset or provide a configuration object. |
+| `autorouter` | `'auto' \| 'sequential-trace' \| 'auto-local' \| 'laser_prefab' \| 'auto_jumper' \| AutorouterConfig` | Select a built-in autorouter preset or provide a configuration object. |
 | `autorouterEffortLevel` | `'1x' \| '2x' \| '5x' \| '10x' \| '100x'` | Increase autorouter compute effort for harder routing problems (higher values are slower and can improve completion rate). |
 | `autorouterVersion` | `'v1' \| 'v2' \| 'v3' \| 'v4' \| 'v5' \| 'latest'` | Pin routing to a specific autorouter implementation when comparing routing behavior across versions. |
 | `routingDisabled` | `boolean` | Skip routing to speed up development. |
@@ -269,13 +269,8 @@ Usually you'll want to use an autorouter preset:
 - `autorouter="auto"` - Uses the [platform configuration](../guides/running-tscircuit/platform-configuration.md). For tscircuit.com this defaults to `sequential-trace`.
 - `autorouter="sequential-trace"` - Iterate over each trace and use tscircuit's fast built-in autorouter. This method is fast and deterministic but often fails with over 50 traces.
 - `autorouter="auto-local"` - Use the platform configuration, but only route locally (do not make API calls)
-- `autorouter="auto-cloud"` - Use the platform configuration for
 - `autorouter="laser_prefab"` - Reserve prefabricated vias that can be reassigned during routing. Ideal for rapid-turn PCBs produced with laser ablation and mechanical drilling templates. See the [ViaGrid / Prefabricated Vias guide](../guides/tscircuit-essentials/using-viagrid-prefabricated-vias-with-autorouter.mdx) for a complete walkthrough.
 - `autorouter="auto_jumper"` - Route single-layer boards by inserting jumper wires when traces would otherwise cross. See the [Single Layer Jumper Autorouting guide](../guides/tscircuit-essentials/single-layer-jumper-autorouting.mdx) for a complete walkthrough.
-
-For complex boards with over 50 traces, you should use `autorouter="auto-cloud"`
-to take advantage of tscircuit's cloud autorouters, which internally use the popular
-[freerouting](https://github.com/freerouting/freerouting) library.
 
 ### Tuning Router Work with `autorouterEffortLevel`
 
@@ -293,7 +288,7 @@ Use lower values while iterating quickly, then increase effort for dense boards
 or final route attempts.
 
 ```tsx
-<board width="30mm" height="20mm" autorouter="auto-cloud" autorouterEffortLevel="10x">
+<board width="30mm" height="20mm" autorouter="sequential-trace" autorouterEffortLevel="10x">
   <chip name="U1" footprint="qfn32" pcbX={-4} pcbY={0} />
   <chip name="U2" footprint="qfn32" pcbX={4} pcbY={0} />
   <trace from=".U1 > .pin1" to=".U2 > .pin1" />

--- a/docs/elements/subcircuit.mdx
+++ b/docs/elements/subcircuit.mdx
@@ -75,7 +75,7 @@ To specify a custom autorouter configuration, just set the `autorouter` property
 on a `<subcircuit />` element.
 
 ```tsx
-<subcircuit autorouter="sequential-trace">
+<subcircuit autorouter="auto">
   <resistor name="R1" resistance="1k" footprint="0402" />
   <resistor name="R2" resistance="1k" footprint="0402" />
   {/* ... */}
@@ -86,4 +86,3 @@ Specifying custom autorouter settings for subcircuits can be extremely useful
 when you have a tricky section of components that have special requirements.
 
 Read more about [the autorouter prop here](./board.mdx#setting-the-autorouter).
-

--- a/docs/elements/subcircuit.mdx
+++ b/docs/elements/subcircuit.mdx
@@ -75,7 +75,7 @@ To specify a custom autorouter configuration, just set the `autorouter` property
 on a `<subcircuit />` element.
 
 ```tsx
-<subcircuit autorouter="auto-cloud">
+<subcircuit autorouter="sequential-trace">
   <resistor name="R1" resistance="1k" footprint="0402" />
   <resistor name="R2" resistance="1k" footprint="0402" />
   {/* ... */}
@@ -86,5 +86,4 @@ Specifying custom autorouter settings for subcircuits can be extremely useful
 when you have a tricky section of components that have special requirements.
 
 Read more about [the autorouter prop here](./board.mdx#setting-the-autorouter).
-
 


### PR DESCRIPTION
## Summary

- remove `auto-cloud` from the documented autorouter presets
- remove login and complex-board guidance that recommends cloud autorouting through this preset
- update board and subcircuit examples to use `auto`

## Why

The `auto-cloud` preset is no longer supported, so the documentation should not advertise it as an available option.

## Impact

Users will only see supported autorouter presets and examples. Documentation for configurable autorouting APIs remains unchanged.

## Validation

- repository-wide search confirms there are no remaining `auto-cloud` references
- `git diff --check`
- verified the remote branch changes only the three intended documentation files