### PR TITLE
Document 100-pin BGA bus breakout fanout

### DIFF
--- a/docs/elements/breakout.mdx
+++ b/docs/elements/breakout.mdx
@@ -14,9 +14,9 @@ connections that leave the breakout.
 
 import CircuitPreview from "@site/src/components/CircuitPreview"
 
-This 100-pin BGA breakout groups signals into four buses. The fanout phase sends
-each bus toward the side of the package where its connector is placed, then the
-default autorouter completes the routes.
+This 100-pin BGA breakout groups signals into four buses. The default fanout
+autorouter sends each bus toward the side of the package where its connector is
+placed, then completes the routes.
 
 <CircuitPreview defaultView="pcb" code={`
 const buses = [
@@ -61,17 +61,11 @@ export default () => (
     minViaHoleDiameter="0.2mm"
     minViaPadDiameter="0.5mm"
   >
-    <breakout name="BGA_BREAKOUT" padding="2mm">
-      <autoroutingphase
-        autorouter="fanout"
-        busFanoutDirections={{
-          DATA: "center_right",
-          ADDRESS: "center_left",
-          CONTROL: "top_center",
-          POWER: "bottom_center",
-        }}
-        fanoutBoundaryPadding="1.5mm"
-      />
+    <breakout
+      name="BGA_BREAKOUT"
+      padding="2mm"
+      fanoutBoundaryPadding="1.5mm"
+    >
       <chip
         name="U1"
         footprint="bga100_grid10x10_p0.8mm_pad0.35mm_circularpads"
@@ -123,10 +117,6 @@ export default () => (
   </board>
 )
 `} />
-
-The keys in `busFanoutDirections` match `<bus />` names. Direction values use
-nine-point anchors such as `center_right`, `top_center`, and `bottom_center`;
-use `center` when a bus can escape in any direction.
 
 ## Auto-Generated Breakout Points
 

--- a/docs/elements/breakout.mdx
+++ b/docs/elements/breakout.mdx
@@ -14,30 +14,119 @@ connections that leave the breakout.
 
 import CircuitPreview from "@site/src/components/CircuitPreview"
 
+This 100-pin BGA breakout groups signals into four buses. The fanout phase sends
+each bus toward the side of the package where its connector is placed, then the
+default autorouter completes the routes.
+
 <CircuitPreview defaultView="pcb" code={`
+const buses = [
+  {
+    name: "DATA",
+    signals: ["D0", "D1", "D2", "D3"],
+    pcbX: 12,
+    pcbY: 0,
+    pcbRotation: 90,
+  },
+  {
+    name: "ADDRESS",
+    signals: ["A0", "A1", "A2", "A3"],
+    pcbX: -12,
+    pcbY: 0,
+    pcbRotation: 90,
+  },
+  {
+    name: "CONTROL",
+    signals: ["CS", "CLK", "RESET", "IRQ"],
+    pcbX: 0,
+    pcbY: 12,
+    pcbRotation: 0,
+  },
+  {
+    name: "POWER",
+    signals: ["VDD0", "GND0", "VDD1", "GND1"],
+    pcbX: 0,
+    pcbY: -12,
+    pcbRotation: 0,
+  },
+]
+
 export default () => (
-  <board width="20mm" height="20mm">
-    <breakout autorouter="auto">
-      <resistor
-        name="R1"
-        resistance="1k"
-        footprint="0402"
-        pcbX={0}
-        pcbY={0}
+  <board
+    width="32mm"
+    height="32mm"
+    layers={2}
+    minTraceWidth="0.1mm"
+    minTraceToPadEdgeClearance="0.1mm"
+    minViaEdgeToPadEdgeClearance="0.1mm"
+    minViaHoleDiameter="0.2mm"
+    minViaPadDiameter="0.5mm"
+  >
+    <breakout name="BGA_BREAKOUT" padding="2mm">
+      <autoroutingphase
+        autorouter="fanout"
+        busFanoutDirections={{
+          DATA: "center_right",
+          ADDRESS: "center_left",
+          CONTROL: "top_center",
+          POWER: "bottom_center",
+        }}
+        fanoutBoundaryPadding="1.5mm"
       />
-      <capacitor
-        name="C1"
-        capacitance="1uF"
-        footprint="0402"
-        pcbX={2}
-        pcbY={0}
+      <chip
+        name="U1"
+        footprint="bga100_grid10x10_p0.8mm_pad0.35mm_circularpads"
+        pinLabels={{
+          pin39: "D0",
+          pin40: "D1",
+          pin49: "D2",
+          pin50: "D3",
+          pin31: "A0",
+          pin32: "A1",
+          pin41: "A2",
+          pin42: "A3",
+          pin85: "CS",
+          pin86: "CLK",
+          pin95: "RESET",
+          pin96: "IRQ",
+          pin5: "VDD0",
+          pin6: "GND0",
+          pin15: "VDD1",
+          pin16: "GND1",
+        }}
       />
-      <trace from="R1.2" to="C1.1" />
-      <breakoutpoint connection="R1.1" pcbX={5} pcbY={5} />
+      {buses.map((bus) => (
+        <pinheader
+          key={bus.name}
+          name={"J_" + bus.name}
+          pinCount={4}
+          footprint="pinrow4"
+          pinLabels={bus.signals}
+          pcbX={bus.pcbX}
+          pcbY={bus.pcbY}
+          pcbRotation={bus.pcbRotation}
+        />
+      ))}
+      {buses.map((bus) => (
+        <bus key={bus.name} name={bus.name} connections={bus.signals} />
+      ))}
+      {buses.flatMap((bus) =>
+        bus.signals.map((signal) => (
+          <trace
+            key={signal}
+            name={signal}
+            from={"U1." + signal}
+            to={"J_" + bus.name + "." + signal}
+          />
+        )),
+      )}
     </breakout>
   </board>
 )
 `} />
+
+The keys in `busFanoutDirections` match `<bus />` names. Direction values use
+nine-point anchors such as `center_right`, `top_center`, and `bottom_center`;
+use `center` when a bus can escape in any direction.
 
 ## Auto-Generated Breakout Points
 
@@ -121,4 +210,5 @@ export default () => (
 |----------|-------------|
 | `padding` | Uniform padding around the breakout region. |
 | `paddingLeft` / `paddingRight` / `paddingTop` / `paddingBottom` | Control padding for each side individually. |
-| `autorouter` | Autorouter configuration inherited by children. |
+| `autorouter` | Autorouter used to escape components inside the breakout. Defaults to `fanout`. |
+| `fanoutBoundaryPadding` | Padding between the source pads and the shared boundary where fanout traces terminate. |


### PR DESCRIPTION
## Summary

- replace the lead `<breakout />` example with a 100-pin BGA breakout
- group the routed signals into DATA, ADDRESS, CONTROL, and POWER buses
- rely on `<breakout>`'s default fanout autorouter, with connector placement guiding each bus toward its side of the package
- document the default fanout behavior and boundary padding

## Why

The previous lead example only showed a resistor, capacitor, and manual breakout point. The new example demonstrates the primary high-density breakout use case without requiring an explicit `<autoroutingphase />`.

## Validation

- compiled the extracted circuit with `tscircuit@0.0.2181` using `tsci build`; no autorouting errors
- generated and visually inspected the PCB snapshot; all four buses escape toward their connectors
- `bun run build`
- `bun run typecheck`
- `git diff --check`