### PR TITLE
fix: link docs logo to tscircuit landing page

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -169,6 +169,7 @@ const config: Config = {
       logo: {
         alt: "tscircuit logo",
         src: "logo/logo.svg",
+        href: "https://tscircuit.com/",
       },
       items: [
         {


### PR DESCRIPTION
## Summary

Make the Docs navbar logo open the main tscircuit landing page instead of routing to the Docs home page.

Before:

https://github.com/user-attachments/assets/d6ff61f7-b04c-49e9-9108-df31b0da62f9



After:

https://github.com/user-attachments/assets/ac04bd98-fd23-488e-bf5e-47f0bc770a25

