### PR TITLE
Link quickstart to AI prompting guide

### DIFF
--- a/docs/guides/circuit-generation/generating-circuit-boards-with-ai.mdx
+++ b/docs/guides/circuit-generation/generating-circuit-boards-with-ai.mdx
@@ -30,13 +30,7 @@ export default () => (
 
 ## Start with the tscircuit skill
 
-Install the [`tscircuit` skill](https://github.com/tscircuit/skill) so your AI assistant has the syntax, CLI workflows, component-selection guidance, and layout conventions it needs:
-
-```bash
-bunx skills add tscircuit/skill
-```
-
-The skill is especially useful when the task involves importing parts, choosing footprints, running `tsci build`, inspecting placement, or iterating on a real board. See [Use tscircuit with AI](/advanced/ai-context) for the general setup.
+[Install the `tscircuit` skill](https://skills.sh/tscircuit/skill/tscircuit) for tscircuit syntax, CLI workflows, component guidance, and layout conventions.
 
 ## A useful prompt structure
 

--- a/docs/intro/quickstart-web.md
+++ b/docs/intro/quickstart-web.md
@@ -44,6 +44,6 @@ When you're ready to order your board, check out the [ordering prototypes guide]
 electronics fully assembled and ready to use from the many services that accept
 our standard fabrication files.
 
-## Using the AI Assistant
+## Using an AI Assistant
 
-Our AI assistant is available in beta but is undergoing a big overhaul. We'll update this section when we're happy with it!
+See [how to prompt AI to build tscircuit circuits](../guides/circuit-generation/generating-circuit-boards-with-ai.mdx) for a simple prompt structure and examples.


### PR DESCRIPTION
## Summary

- link the Web Quickstart to the AI prompting guide
- simplify the prompting guide's skill setup to a single canonical Skills page link
- remove the Bun-only installation snippet so readers can choose the installation method that fits their AI assistant

## Why

This makes the AI prompting guidance easier to discover while keeping the skill setup copy light and installation-method agnostic.

## Validation

- `bun run typecheck`
- `bun run build`