### PR TITLE
Document via-in-pad board option

### DIFF
--- a/docs/elements/board.mdx
+++ b/docs/elements/board.mdx
@@ -66,6 +66,7 @@ import CircuitPreview from '@site/src/components/CircuitPreview'
 | `minBoardEdgeClearance` | `string \| number` | Minimum clearance between routed copper features and the board edge. |
 | `minViaHoleDiameter` | `string \| number` | Smallest via drill diameter the router may use. |
 | `minViaPadDiameter` | `string \| number` | Smallest via pad diameter the router may use. |
+| `isViaInPadAllowed` | `boolean` | Allow intentional vias inside PCB pads to pass DRC. Defaults to `false`. |
 | `partsEngine` | `object` | Override the parts lookup engine used to resolve bill of materials. |
 | `circuitJson` | `any[]` | Provide precompiled circuit JSON to embed or reuse as the board contents. |
 | `pcbStyle` | `object` | Style configuration object for PCB elements. See [Global Silkscreen Text Size](#global-silkscreen-text-size-adjustment) below. |
@@ -186,6 +187,46 @@ For boards that require components on both sides, set `doubleSidedAssembly={true
 
 This informs manufacturing that components will be placed on both the top and
 bottom layers of the board.
+
+### Allowing Vias Inside Pads
+
+Set `isViaInPadAllowed` when a design intentionally places vias inside component
+pads. The prop defaults to `false`; setting it to `true` marks via-in-pad
+placement as allowed for the board's design-rule checks.
+
+<CircuitPreview defaultView="pcb" hideSchematicTab code={`
+  export default () => (
+    <board width="10mm" height="10mm" isViaInPadAllowed>
+      <chip
+        name="U1"
+        footprint={
+          <footprint>
+            <smtpad
+              pcbX={0}
+              pcbY={0}
+              layer="top"
+              shape="circle"
+              radius="1mm"
+              portHints={["pin1"]}
+            />
+          </footprint>
+        }
+      />
+      <via
+        pcbX={0}
+        pcbY={0}
+        fromLayer="top"
+        toLayer="bottom"
+        holeDiameter="0.3mm"
+        outerDiameter="0.6mm"
+        connectsTo=".U1 > .pin1"
+      />
+    </board>
+  )
+`} />
+
+Via-in-pad fabrication commonly requires filled and capped vias. Confirm that
+the selected PCB manufacturer supports the process before using this option.
 
 ### Rounding Board Corners with `borderRadius`
 

--- a/docs/elements/board.mdx
+++ b/docs/elements/board.mdx
@@ -188,46 +188,6 @@ For boards that require components on both sides, set `doubleSidedAssembly={true
 This informs manufacturing that components will be placed on both the top and
 bottom layers of the board.
 
-### Allowing Vias Inside Pads
-
-Set `isViaInPadAllowed` when a design intentionally places vias inside component
-pads. The prop defaults to `false`; setting it to `true` marks via-in-pad
-placement as allowed for the board's design-rule checks.
-
-<CircuitPreview defaultView="pcb" hideSchematicTab code={`
-  export default () => (
-    <board width="10mm" height="10mm" isViaInPadAllowed>
-      <chip
-        name="U1"
-        footprint={
-          <footprint>
-            <smtpad
-              pcbX={0}
-              pcbY={0}
-              layer="top"
-              shape="circle"
-              radius="1mm"
-              portHints={["pin1"]}
-            />
-          </footprint>
-        }
-      />
-      <via
-        pcbX={0}
-        pcbY={0}
-        fromLayer="top"
-        toLayer="bottom"
-        holeDiameter="0.3mm"
-        outerDiameter="0.6mm"
-        connectsTo=".U1 > .pin1"
-      />
-    </board>
-  )
-`} />
-
-Via-in-pad fabrication commonly requires filled and capped vias. Confirm that
-the selected PCB manufacturer supports the process before using this option.
-
 ### Rounding Board Corners with `borderRadius`
 
 To soften sharp corners on a rectangular board, set the optional `borderRadius`


### PR DESCRIPTION
## What changed

- add `isViaInPadAllowed` to the `<board />` property reference
- explain its default DRC behavior concisely in the property table

## Why

The supported `isViaInPadAllowed` board prop was missing from the docs, making intentional via-in-pad designs difficult to discover and configure correctly.

## Validation

- confirmed `isViaInPadAllowed?: boolean` in `@tscircuit/props` and its propagation to `is_via_in_pad_allowed` in `@tscircuit/core`
- typechecked the example against `tscircuit@0.0.2336` with `bunx tsc --noEmit`
- built the example with `bunx tsci build via-in-pad.circuit.tsx` and confirmed generated Circuit JSON contains `is_via_in_pad_allowed: true`
- `bun run typecheck`
- `bun run format:check`
- `bun run build`
