### PR TITLE
Document copper pour thermal reliefs

### DIFF
--- a/docs/elements/copperpour.mdx
+++ b/docs/elements/copperpour.mdx
@@ -21,25 +21,35 @@ maintaining a clearance gap that you control.
 ## Basic Usage
 
 Add a copper pour to any board by connecting it to a net—most commonly
-`net.GND`. The example below shows a top-layer pour surrounding a chip, with a
-few traces stitching components back to ground.
+`net.GND`. Set `useThermalReliefs` to connect same-net plated holes through
+thermal spokes instead of merging each hole directly into the surrounding
+copper. The example below shows four grounded through-holes with thermal
+reliefs.
 
 <CircuitPreview defaultView="pcb" code={`
   export default () => (
-    <board
-      width="30mm"
-      height="20mm"
-    >
-      <chip name="U1" footprint="soic8" pcbX={-6} pcbY={0} />
-      <resistor name="R1" resistance="10k" footprint="0402" pcbX={6} pcbY={4} />
-      <capacitor name="C1" capacitance="100nF" footprint="0402" pcbX={6} pcbY={-4} />
-      <trace from=".R1 > .pin2" to="net.GND" />
-      <trace from=".C1 > .pin2" to="net.GND" />
-      <trace from=".U1 > .pin4" to="net.GND" />
-      <copperpour connectsTo="net.GND" layer="top" clearance="0.15mm" />
+    <board width="18mm" height="10mm">
+      <pinheader
+        name="J1"
+        pinCount={4}
+        footprint="pinrow4"
+      />
+      <trace name="J1_GND_1" from=".J1 > .pin1" to="net.GND" />
+      <trace name="J1_GND_2" from=".J1 > .pin2" to="net.GND" />
+      <trace name="J1_GND_3" from=".J1 > .pin3" to="net.GND" />
+      <trace name="J1_GND_4" from=".J1 > .pin4" to="net.GND" />
+      <copperpour
+        connectsTo="net.GND"
+        layer="top"
+        padMargin="0.45mm"
+        useThermalReliefs
+      />
     </board>
   )
 `} />
+
+Thermal reliefs currently use four `0.3mm` spokes. Plated holes on other nets
+continue to receive the normal clearance from the pour.
 
 ## Copper Pour Properties
 
@@ -52,7 +62,7 @@ few traces stitching components back to ground.
 | `traceMargin` | Minimum distance from traces on other nets. Overrides `clearance`. | `"0.1mm"` |
 | `boardEdgeMargin` | Minimum distance from the board edge. Overrides `clearance`. | `"2mm"` |
 | `cutoutMargin` | Minimum distance from board cutouts. Overrides `clearance`. | `"0.1mm"` |
-| `thermalRelief` | Configure spoke width/count when attaching to pads. | `{ spokeWidth: "0.3mm", spokeCount: 4 }` |
+| `useThermalReliefs` | Connect same-net plated holes through four thermal spokes instead of solid copper. | `true` |
 | `outline` | Optional polygon describing a custom pour boundary. | `[{ x: -10, y: -8 }, { x: 10, y: -8 }, ...]` |
 
 ## Creating Pours on Multiple Layers

--- a/docs/elements/copperpour.mdx
+++ b/docs/elements/copperpour.mdx
@@ -23,8 +23,8 @@ maintaining a clearance gap that you control.
 Add a copper pour to any board by connecting it to a net—most commonly
 `net.GND`. Set `useThermalReliefs` to connect same-net plated holes through
 thermal spokes instead of merging each hole directly into the surrounding
-copper. The example below shows four grounded through-holes with thermal
-reliefs.
+copper. The example below shows two grounded through-holes with thermal reliefs
+beside two unconnected holes.
 
 <CircuitPreview defaultView="pcb" code={`
   export default () => (
@@ -36,8 +36,6 @@ reliefs.
       />
       <trace name="J1_GND_1" from=".J1 > .pin1" to="net.GND" />
       <trace name="J1_GND_2" from=".J1 > .pin2" to="net.GND" />
-      <trace name="J1_GND_3" from=".J1 > .pin3" to="net.GND" />
-      <trace name="J1_GND_4" from=".J1 > .pin4" to="net.GND" />
       <copperpour
         connectsTo="net.GND"
         layer="top"
@@ -48,8 +46,9 @@ reliefs.
   )
 `} />
 
-Thermal reliefs currently use four `0.3mm` spokes. Plated holes on other nets
-continue to receive the normal clearance from the pour.
+Thermal reliefs currently use four `0.3mm` spokes. Unconnected plated holes and
+plated holes on other nets continue to receive the normal clearance from the
+pour.
 
 ## Copper Pour Properties
 


### PR DESCRIPTION
## Summary

- replace the stale configurable `thermalRelief` entry with the released `useThermalReliefs` boolean
- update the primary `<copperpour />` example to show grounded plated holes connected through visible thermal spokes
- document the current four-spoke, 0.3 mm behavior and clarify that other-net holes retain normal clearance

## Why

Thermal relief support is now available downstream in `tscircuit@0.0.2346` through `@tscircuit/core@^0.0.1693`, so the copper-pour page should demonstrate the public API users can use today.

## Validation

- built the example with `bunx --package tscircuit@0.0.2346 tsci build ... --pcb-svgs`
- visually inspected the generated PCB SVG and confirmed four spokes around each plated hole
- `bun run typecheck`
- `bun run build`