### PR TITLE
Document Biscuit Board clad wrappers

### DIFF
--- a/docs/guides/tscircuit-essentials/how-to-use-biscuit-board.mdx
+++ b/docs/guides/tscircuit-essentials/how-to-use-biscuit-board.mdx
@@ -1,17 +1,16 @@
 ---
 title: How to use Biscuit Board templates
-description: Choose a Biscuit Board template and use it as the board wrapper for a tscircuit design.
+description: Choose and import a Biscuit Board clad wrapper for a tscircuit design.
 ---
 
 import CircuitPreview from "@site/src/components/CircuitPreview"
 
 # How to use Biscuit Board templates
 
-Biscuit Board is a family of prefabricated copper-clad templates, not a single
-board. The `biscuitboard` package provides one tscircuit wrapper for each
-physical template. Choose the wrapper whose outline, connectors, and fixed vias
-match the product you want to build, then place ordinary tscircuit components
-and traces inside it.
+The `biscuitboard` package exports clad wrappers for several prefabricated
+board layouts. Each wrapper supplies its board outline, mounting features,
+connectors, and fixed vias. Choose a wrapper, then place ordinary tscircuit
+components and traces inside it.
 
 ## Install the package
 
@@ -19,7 +18,7 @@ and traces inside it.
 bun add biscuitboard
 ```
 
-Each wrapper is a complete `<board>`, so use one wrapper as the root of a
+Each clad wrapper is a complete `<board>`, so use one as the root of your
 circuit:
 
 ```tsx
@@ -32,34 +31,28 @@ export default () => (
 )
 ```
 
-## Product names and numbers
+## Choose a clad wrapper
 
-Catalog numbers keep the physical product name separate from its TypeScript
-API. The hundreds digit identifies the use-case family, the tens digit
-identifies a form factor, and the final digit is reserved for physical variants.
+| Wrapper | Size | Best suited for |
+| --- | --- | --- |
+| `BiscuitBoard` | 75 mm × 55 mm | General circuits using large fixed through vias |
+| `BreadboardClad` | 75 mm × 55 mm | Plug-in, breadboard-style prototypes with custom routed connections |
+| `Clad40x40` | 40 mm × 40 mm | Compact modules and sensor boards |
+| `ArduinoShieldClad` | 75 mm × 55 mm | Arduino UNO R3-compatible shields |
+| `BoosterPackClad` | 75 mm × 55 mm | TI LaunchPad BoosterPack-compatible add-ons |
+| `XiaoCladWithPinHeaders` | 17.8 mm × 21 mm | XIAO-sized boards using through-hole headers |
+| `XiaoCladWithPerforatedPinHeaders` | 17.8 mm × 21 mm | XIAO-sized boards with perforated edge header pads |
+| `FeatherCladWithPinHeaders` | 22.86 mm × 50.8 mm | Adafruit Feather-compatible boards |
 
-| Number | Product name | TypeScript wrapper | Best suited for |
-| --- | --- | --- | --- |
-| `BB-100` | Biscuit Board 100 — General Purpose 75 | `BiscuitBoard` | General 75 mm × 55 mm circuits with large fixed through vias |
-| `BB-110` | Biscuit Board 110 — Breadboard 75 | `BreadboardClad` | Plug-in, breadboard-style prototypes with custom routed connections |
-| `BB-120` | Biscuit Board 120 — Square 40 | `Clad40x40` | Compact 40 mm × 40 mm modules and sensor boards |
-| `BB-200` | Biscuit Board 200 — Arduino UNO R3 | `ArduinoShieldClad` | Arduino UNO R3-compatible shields |
-| `BB-210` | Biscuit Board 210 — TI BoosterPack | `BoosterPackClad` | TI LaunchPad BoosterPack-compatible add-ons |
-| `BB-300` | Biscuit Board 300 — XIAO Header | `XiaoCladWithPinHeaders` | XIAO-sized boards using ordinary through-hole headers |
-| `BB-301` | Biscuit Board 301 — XIAO Perforated | `XiaoCladWithPerforatedPinHeaders` | XIAO-sized boards with perforated, edge-mounted header pads |
-| `BB-310` | Biscuit Board 310 — Feather Header | `FeatherCladWithPinHeaders` | Adafruit Feather-compatible boards |
+Every preview below contains the same USB-C connector, 0603 resistor, and 0603
+LED. Comparing those familiar parts against each outline makes the relative
+board sizes easier to understand.
 
-The catalog number is the stable product identifier. The descriptive suffix can
-be refined without changing code or manufacturing records.
+### `BiscuitBoard`
 
-## Choose a template
-
-### Biscuit Board 100 — General Purpose 75 (`BB-100`)
-
-Use `BiscuitBoard` when none of the connector-specific formats apply. It is a
-75 mm × 55 mm, two-layer board with mounting holes and a field of large fixed
-through vias. This example places a top-layer resistor and a bottom-layer LED;
-the default autorouter must use one of the existing vias to change layers.
+Use the general 75 mm × 55 mm wrapper when none of the connector-specific clad
+layouts apply. Its autorouter changes layers only at its large prefabricated
+through vias.
 
 <CircuitPreview
   leftView="code"
@@ -69,32 +62,26 @@ import { BiscuitBoard } from "biscuitboard"
 
 export default () => (
   <BiscuitBoard>
+    <connector name="J_USB" standard="usb_c" pcbX={10} pcbY={0} />
     <resistor
       name="R1"
       resistance="1k"
       footprint="0603"
-      pcbX={-8}
-      pcbY={0}
+      pcbX={19}
+      pcbY={2}
     />
-    <led
-      name="LED1"
-      footprint="0603"
-      layer="bottom"
-      pcbX={8}
-      pcbY={0}
-    />
+    <led name="LED1" footprint="0603" pcbX={19} pcbY={-2} />
     <trace from=".R1 > .pin2" to=".LED1 > .anode" />
   </BiscuitBoard>
 )
 `}
 />
 
-### Biscuit Board 110 — Breadboard 75 (`BB-110`)
+### `BreadboardClad`
 
-Use `BreadboardClad` for plug-in prototypes and DIP-style layouts. It provides
-210 individually routable A1–J21 sockets plus four power/header rails. Unlike a
-solderless breadboard, the sockets are not pre-connected; your traces define
-the copper connections.
+Use the breadboard wrapper for plug-in prototypes and DIP-style layouts. Its
+210 A1–J21 sockets and four power/header rails are individually routable rather
+than pre-connected like a solderless breadboard.
 
 <CircuitPreview
   leftView="code"
@@ -103,16 +90,26 @@ the copper connections.
 import { BreadboardClad } from "biscuitboard"
 
 export default () => (
-  <BreadboardClad routingDisabled markHeadersNoConnect />
+  <BreadboardClad markHeadersNoConnect>
+    <connector name="J_USB" standard="usb_c" pcbX={0} pcbY={0} />
+    <resistor
+      name="R1"
+      resistance="1k"
+      footprint="0603"
+      pcbX={-10}
+      pcbY={0}
+    />
+    <led name="LED1" footprint="0603" pcbX={10} pcbY={0} />
+    <trace from=".R1 > .pin2" to=".LED1 > .anode" />
+  </BreadboardClad>
 )
 `}
 />
 
-### Biscuit Board 120 — Square 40 (`BB-120`)
+### `Clad40x40`
 
-Use `Clad40x40` for a compact custom module. The 40 mm square outline has two
-mounting holes and three concentric rings containing 72 fixed vias, leaving room
-around the rings for small components.
+Use the 40 mm square wrapper for a compact custom module. It has two mounting
+holes and three concentric rings containing 72 fixed vias.
 
 <CircuitPreview
   leftView="code"
@@ -120,15 +117,28 @@ around the rings for small components.
   code={`
 import { Clad40x40 } from "biscuitboard"
 
-export default () => <Clad40x40 routingDisabled />
+export default () => (
+  <Clad40x40>
+    <connector name="J_USB" standard="usb_c" pcbX={0} pcbY={-10} />
+    <resistor
+      name="R1"
+      resistance="1k"
+      footprint="0603"
+      pcbX={-3}
+      pcbY={8}
+    />
+    <led name="LED1" footprint="0603" pcbX={3} pcbY={8} />
+    <trace from=".R1 > .pin2" to=".LED1 > .anode" />
+  </Clad40x40>
+)
 `}
 />
 
-### Biscuit Board 200 — Arduino UNO R3 (`BB-200`)
+### `ArduinoShieldClad`
 
-Use `ArduinoShieldClad` to build a shield for an Arduino UNO R3-compatible host.
-It includes the power, analog, digital, I²C, and ICSP connector geometry plus
-fixed via fields arranged around those headers.
+Use the Arduino wrapper for a shield that mates with an Arduino UNO
+R3-compatible host. It supplies the power, analog, digital, I²C, and ICSP
+connector geometry.
 
 <CircuitPreview
   leftView="code"
@@ -137,16 +147,27 @@ fixed via fields arranged around those headers.
 import { ArduinoShieldClad } from "biscuitboard"
 
 export default () => (
-  <ArduinoShieldClad routingDisabled markHeadersNoConnect />
+  <ArduinoShieldClad markHeadersNoConnect>
+    <connector name="J_USB" standard="usb_c" pcbX={6} pcbY={0} />
+    <resistor
+      name="R1"
+      resistance="1k"
+      footprint="0603"
+      pcbX={6}
+      pcbY={8}
+    />
+    <led name="LED1" footprint="0603" pcbX={12} pcbY={8} />
+    <trace from=".R1 > .pin2" to=".LED1 > .anode" />
+  </ArduinoShieldClad>
 )
 `}
 />
 
-### Biscuit Board 210 — TI BoosterPack (`BB-210`)
+### `BoosterPackClad`
 
-Use `BoosterPackClad` for a TI LaunchPad add-on. It provides the 40-pin
+Use the BoosterPack wrapper for a TI LaunchPad add-on. It includes the 40-pin
 BoosterPack mating pattern, an additional edge header, and dense fixed-via
-fields while retaining the 75 mm × 55 mm Biscuit Board outline.
+fields.
 
 <CircuitPreview
   leftView="code"
@@ -154,15 +175,27 @@ fields while retaining the 75 mm × 55 mm Biscuit Board outline.
   code={`
 import { BoosterPackClad } from "biscuitboard"
 
-export default () => <BoosterPackClad routingDisabled />
+export default () => (
+  <BoosterPackClad>
+    <connector name="J_USB" standard="usb_c" pcbX={0} pcbY={-5} />
+    <resistor
+      name="R1"
+      resistance="1k"
+      footprint="0603"
+      pcbX={-3}
+      pcbY={7}
+    />
+    <led name="LED1" footprint="0603" pcbX={3} pcbY={7} />
+    <trace from=".R1 > .pin2" to=".LED1 > .anode" />
+  </BoosterPackClad>
+)
 `}
 />
 
-### Biscuit Board 300 — XIAO Header (`BB-300`)
+### `XiaoCladWithPinHeaders`
 
-Use `XiaoCladWithPinHeaders` for a compact board that mates through the classic
-two-row XIAO header pattern. It preserves a central component area and marks the
-USB end with `UP`.
+Use this XIAO wrapper for a compact board that mates through the classic two-row
+through-hole header pattern. The central area remains available for components.
 
 <CircuitPreview
   leftView="code"
@@ -171,16 +204,27 @@ USB end with `UP`.
 import { XiaoCladWithPinHeaders } from "biscuitboard"
 
 export default () => (
-  <XiaoCladWithPinHeaders routingDisabled markHeadersNoConnect />
+  <XiaoCladWithPinHeaders markHeadersNoConnect>
+    <connector name="J_USB" standard="usb_c" pcbX={0} pcbY={5} />
+    <resistor
+      name="R1"
+      resistance="1k"
+      footprint="0603"
+      pcbX={-2}
+      pcbY={-5}
+    />
+    <led name="LED1" footprint="0603" pcbX={2} pcbY={-5} />
+    <trace from=".R1 > .pin2" to=".LED1 > .anode" />
+  </XiaoCladWithPinHeaders>
 )
 `}
 />
 
-### Biscuit Board 301 — XIAO Perforated (`BB-301`)
+### `XiaoCladWithPerforatedPinHeaders`
 
-Use `XiaoCladWithPerforatedPinHeaders` when the XIAO header pads should extend
-to perforations on the board edge. It uses the same outline and pin centers as
-`BB-300`, so the final digit identifies this physical header variant.
+Use the perforated XIAO wrapper when its header pads should extend to notches on
+the board edge. It has the same outline and pin centers as the ordinary XIAO
+header wrapper.
 
 <CircuitPreview
   leftView="code"
@@ -189,19 +233,27 @@ to perforations on the board edge. It uses the same outline and pin centers as
 import { XiaoCladWithPerforatedPinHeaders } from "biscuitboard"
 
 export default () => (
-  <XiaoCladWithPerforatedPinHeaders
-    routingDisabled
-    markHeadersNoConnect
-  />
+  <XiaoCladWithPerforatedPinHeaders markHeadersNoConnect>
+    <connector name="J_USB" standard="usb_c" pcbX={0} pcbY={5} />
+    <resistor
+      name="R1"
+      resistance="1k"
+      footprint="0603"
+      pcbX={-2}
+      pcbY={-5}
+    />
+    <led name="LED1" footprint="0603" pcbX={2} pcbY={-5} />
+    <trace from=".R1 > .pin2" to=".LED1 > .anode" />
+  </XiaoCladWithPerforatedPinHeaders>
 )
 `}
 />
 
-### Biscuit Board 310 — Feather Header (`BB-310`)
+### `FeatherCladWithPinHeaders`
 
-Use `FeatherCladWithPinHeaders` for an Adafruit Feather-compatible board. It
-includes the classic 1×16 and 1×12 header rows, four mounting holes, an open
-central component field, and an `UP` mark at the USB edge.
+Use the Feather wrapper for an Adafruit Feather-compatible board. It includes
+the classic 1×16 and 1×12 header rows, four mounting holes, and an open central
+component field.
 
 <CircuitPreview
   leftView="code"
@@ -210,20 +262,30 @@ central component field, and an `UP` mark at the USB edge.
 import { FeatherCladWithPinHeaders } from "biscuitboard"
 
 export default () => (
-  <FeatherCladWithPinHeaders routingDisabled markHeadersNoConnect />
+  <FeatherCladWithPinHeaders markHeadersNoConnect>
+    <connector name="J_USB" standard="usb_c" pcbX={0} pcbY={18} />
+    <resistor
+      name="R1"
+      resistance="1k"
+      footprint="0603"
+      pcbX={-3}
+      pcbY={8}
+    />
+    <led name="LED1" footprint="0603" pcbX={3} pcbY={8} />
+    <trace from=".R1 > .pin2" to=".LED1 > .anode" />
+  </FeatherCladWithPinHeaders>
 )
 `}
 />
 
-The bare-template previews use `routingDisabled` and, where available,
-`markHeadersNoConnect` so every prefabricated feature can be inspected without
-adding a circuit. For a real design, remove those preview props, add components
-and traces as children, and explicitly mark only genuinely unused connector
-pins as unconnected.
+`markHeadersNoConnect` is useful in these small previews because none of the
+host or breadboard headers are part of the three-component example. In a real
+design, remove that prop and connect the header pins you use, or mark only the
+remaining pins as unconnected.
 
 ## Tune routing when needed
 
-All templates accept the usual children plus the same routing controls:
+All clad wrappers accept the usual children plus the same routing controls:
 
 - `nominalTraceWidth` sets the preferred routed trace width.
 - `minTraceWidth` sets the enforced minimum trace width.
@@ -232,19 +294,7 @@ All templates accept the usual children plus the same routing controls:
 - `routingDisabled` keeps the board geometry and vias but skips automatic
   routing.
 
-For example:
-
-```tsx
-<Clad40x40
-  nominalTraceWidth={0.2}
-  minTraceWidth={0.15}
-  autorouterOptions={{ routeOrder: "adaptive" }}
->
-  {/* components and traces */}
-</Clad40x40>
-```
-
-Build your project normally after choosing a template:
+Build your project normally after choosing a wrapper:
 
 ```bash
 bunx tsci build

--- a/docs/guides/tscircuit-essentials/how-to-use-biscuit-board.mdx
+++ b/docs/guides/tscircuit-essentials/how-to-use-biscuit-board.mdx
@@ -61,17 +61,25 @@ through vias.
 import { BiscuitBoard } from "biscuitboard"
 
 export default () => (
-  <BiscuitBoard>
-    <connector name="J_USB" standard="usb_c" pcbX={10} pcbY={0} />
+  <BiscuitBoard autorouter="laser_prefab">
+    <connector
+      name="J_USB"
+      standard="usb_c"
+      footprint="jlcpcb:C456012"
+      pcbX={10}
+      pcbY={-23.75}
+    />
     <resistor
       name="R1"
       resistance="1k"
       footprint="0603"
-      pcbX={19}
-      pcbY={2}
+      pcbX={6}
+      pcbY={-17}
     />
-    <led name="LED1" footprint="0603" pcbX={19} pcbY={-2} />
-    <trace from=".R1 > .pin2" to=".LED1 > .anode" />
+    <led name="LED1" footprint="0603" pcbX={14} pcbY={-17} />
+    <trace name="vbus_to_resistor" from=".J_USB > .VBUS1" to=".R1 > .pin1" />
+    <trace name="resistor_to_led" from=".R1 > .pin2" to=".LED1 > .anode" />
+    <trace name="led_to_ground" from=".LED1 > .cathode" to=".J_USB > .GND1" />
   </BiscuitBoard>
 )
 `}
@@ -90,17 +98,37 @@ than pre-connected like a solderless breadboard.
 import { BreadboardClad } from "biscuitboard"
 
 export default () => (
-  <BreadboardClad markHeadersNoConnect>
-    <connector name="J_USB" standard="usb_c" pcbX={0} pcbY={0} />
+  <BreadboardClad
+    autorouter="laser_prefab"
+    nominalTraceWidth={0.15}
+    markHeadersNoConnect
+  >
+    <connector
+      name="J_USB"
+      standard="usb_c"
+      footprint="jlcpcb:C456012"
+      pcbX={-34}
+      pcbY={0}
+      pcbRotation={270}
+    />
     <resistor
       name="R1"
       resistance="1k"
       footprint="0603"
-      pcbX={-10}
-      pcbY={0}
+      pcbX={-30}
+      pcbY={7}
+      pcbRotation={90}
     />
-    <led name="LED1" footprint="0603" pcbX={10} pcbY={0} />
-    <trace from=".R1 > .pin2" to=".LED1 > .anode" />
+    <led
+      name="LED1"
+      footprint="0603"
+      pcbX={-30}
+      pcbY={10}
+      pcbRotation={90}
+    />
+    <trace name="vbus_to_resistor" from=".J_USB > .VBUS1" to=".R1 > .pin1" />
+    <trace name="resistor_to_led" from=".R1 > .pin2" to=".LED1 > .anode" />
+    <trace name="led_to_ground" from=".LED1 > .cathode" to=".J_USB > .GND1" />
   </BreadboardClad>
 )
 `}
@@ -118,17 +146,25 @@ holes and three concentric rings containing 72 fixed vias.
 import { Clad40x40 } from "biscuitboard"
 
 export default () => (
-  <Clad40x40>
-    <connector name="J_USB" standard="usb_c" pcbX={0} pcbY={-10} />
+  <Clad40x40 autorouter="laser_prefab">
+    <connector
+      name="J_USB"
+      standard="usb_c"
+      footprint="jlcpcb:C456012"
+      pcbX={0}
+      pcbY={-16.55}
+    />
     <resistor
       name="R1"
       resistance="1k"
       footprint="0603"
-      pcbX={-3}
-      pcbY={8}
+      pcbX={-2}
+      pcbY={-10.5}
     />
-    <led name="LED1" footprint="0603" pcbX={3} pcbY={8} />
-    <trace from=".R1 > .pin2" to=".LED1 > .anode" />
+    <led name="LED1" footprint="0603" pcbX={2} pcbY={-10.5} />
+    <trace name="vbus_to_resistor" from=".J_USB > .VBUS1" to=".R1 > .pin1" />
+    <trace name="resistor_to_led" from=".R1 > .pin2" to=".LED1 > .anode" />
+    <trace name="led_to_ground" from=".LED1 > .cathode" to=".J_USB > .GND1" />
   </Clad40x40>
 )
 `}
@@ -147,17 +183,26 @@ connector geometry.
 import { ArduinoShieldClad } from "biscuitboard"
 
 export default () => (
-  <ArduinoShieldClad markHeadersNoConnect>
-    <connector name="J_USB" standard="usb_c" pcbX={6} pcbY={0} />
+  <ArduinoShieldClad autorouter="laser_prefab" markHeadersNoConnect>
+    <connector
+      name="J_USB"
+      standard="usb_c"
+      footprint="jlcpcb:C456012"
+      pcbX={-34}
+      pcbY={0}
+      pcbRotation={270}
+    />
     <resistor
       name="R1"
       resistance="1k"
       footprint="0603"
-      pcbX={6}
-      pcbY={8}
+      pcbX={-29}
+      pcbY={-2}
     />
-    <led name="LED1" footprint="0603" pcbX={12} pcbY={8} />
-    <trace from=".R1 > .pin2" to=".LED1 > .anode" />
+    <led name="LED1" footprint="0603" pcbX={-29} pcbY={2} />
+    <trace name="vbus_to_resistor" from=".J_USB > .VBUS1" to=".R1 > .pin1" />
+    <trace name="resistor_to_led" from=".R1 > .pin2" to=".LED1 > .anode" />
+    <trace name="led_to_ground" from=".LED1 > .cathode" to=".J_USB > .GND1" />
   </ArduinoShieldClad>
 )
 `}
@@ -176,17 +221,26 @@ fields.
 import { BoosterPackClad } from "biscuitboard"
 
 export default () => (
-  <BoosterPackClad>
-    <connector name="J_USB" standard="usb_c" pcbX={0} pcbY={-5} />
+  <BoosterPackClad autorouter="laser_prefab">
+    <connector
+      name="J_USB"
+      standard="usb_c"
+      footprint="jlcpcb:C456012"
+      pcbX={34}
+      pcbY={0}
+      pcbRotation={90}
+    />
     <resistor
       name="R1"
       resistance="1k"
       footprint="0603"
-      pcbX={-3}
-      pcbY={7}
+      pcbX={29}
+      pcbY={-2}
     />
-    <led name="LED1" footprint="0603" pcbX={3} pcbY={7} />
-    <trace from=".R1 > .pin2" to=".LED1 > .anode" />
+    <led name="LED1" footprint="0603" pcbX={29} pcbY={2} />
+    <trace name="vbus_to_resistor" from=".J_USB > .VBUS1" to=".R1 > .pin1" />
+    <trace name="resistor_to_led" from=".R1 > .pin2" to=".LED1 > .anode" />
+    <trace name="led_to_ground" from=".LED1 > .cathode" to=".J_USB > .GND1" />
   </BoosterPackClad>
 )
 `}
@@ -204,17 +258,30 @@ through-hole header pattern. The central area remains available for components.
 import { XiaoCladWithPinHeaders } from "biscuitboard"
 
 export default () => (
-  <XiaoCladWithPinHeaders markHeadersNoConnect>
-    <connector name="J_USB" standard="usb_c" pcbX={0} pcbY={5} />
+  <XiaoCladWithPinHeaders
+    autorouter="laser_prefab"
+    markHeadersNoConnect
+    showUsbLabel={false}
+  >
+    <connector
+      name="J_USB"
+      standard="usb_c"
+      footprint="jlcpcb:C456012"
+      pcbX={0}
+      pcbY={7.05}
+      pcbRotation={180}
+    />
     <resistor
       name="R1"
       resistance="1k"
       footprint="0603"
       pcbX={-2}
-      pcbY={-5}
+      pcbY={2}
     />
-    <led name="LED1" footprint="0603" pcbX={2} pcbY={-5} />
-    <trace from=".R1 > .pin2" to=".LED1 > .anode" />
+    <led name="LED1" footprint="0603" pcbX={2} pcbY={2} />
+    <trace name="vbus_to_resistor" from=".J_USB > .VBUS1" to=".R1 > .pin1" />
+    <trace name="resistor_to_led" from=".R1 > .pin2" to=".LED1 > .anode" />
+    <trace name="led_to_ground" from=".LED1 > .cathode" to=".J_USB > .GND1" />
   </XiaoCladWithPinHeaders>
 )
 `}
@@ -224,29 +291,50 @@ export default () => (
 
 Use the perforated XIAO wrapper when its header pads should extend to notches on
 the board edge. It has the same outline and pin centers as the ordinary XIAO
-header wrapper.
+header wrapper. The accompanying config disables placement DRC for this preview
+because the intentional edge perforations overlap their cutouts; routing and
+the remaining checks stay enabled.
 
 <CircuitPreview
   leftView="code"
   rightView="pcb"
-  code={`
-import { XiaoCladWithPerforatedPinHeaders } from "biscuitboard"
+  entrypoint="index.circuit.tsx"
+  mainComponentPath="index.circuit.tsx"
+  fsMap={{
+    "index.circuit.tsx": `import { XiaoCladWithPerforatedPinHeaders } from "biscuitboard"
 
 export default () => (
-  <XiaoCladWithPerforatedPinHeaders markHeadersNoConnect>
-    <connector name="J_USB" standard="usb_c" pcbX={0} pcbY={5} />
+  <XiaoCladWithPerforatedPinHeaders
+    autorouter="laser_prefab"
+    markHeadersNoConnect
+    showUsbLabel={false}
+  >
+    <connector
+      name="J_USB"
+      standard="usb_c"
+      pcbX={0}
+      pcbY={7.05}
+      pcbRotation={180}
+    />
     <resistor
       name="R1"
       resistance="1k"
       footprint="0603"
       pcbX={-2}
-      pcbY={-5}
+      pcbY={2}
     />
-    <led name="LED1" footprint="0603" pcbX={2} pcbY={-5} />
-    <trace from=".R1 > .pin2" to=".LED1 > .anode" />
+    <led name="LED1" footprint="0603" pcbX={2} pcbY={2} />
+    <trace name="vbus_to_resistor" from=".J_USB > .VBUS1" to=".R1 > .pin1" />
+    <trace name="resistor_to_led" from=".R1 > .pin2" to=".LED1 > .anode" />
+    <trace name="led_to_ground" from=".LED1 > .cathode" to=".J_USB > .GND1" />
   </XiaoCladWithPerforatedPinHeaders>
-)
-`}
+)`,
+    "tscircuit.config.ts": `export default {
+  platformConfig: {
+    placementDrcChecksDisabled: true,
+  },
+}`,
+  }}
 />
 
 ### `FeatherCladWithPinHeaders`
@@ -262,17 +350,30 @@ component field.
 import { FeatherCladWithPinHeaders } from "biscuitboard"
 
 export default () => (
-  <FeatherCladWithPinHeaders markHeadersNoConnect>
-    <connector name="J_USB" standard="usb_c" pcbX={0} pcbY={18} />
+  <FeatherCladWithPinHeaders
+    autorouter="laser_prefab"
+    markHeadersNoConnect
+    showUsbLabel={false}
+  >
+    <connector
+      name="J_USB"
+      standard="usb_c"
+      footprint="jlcpcb:C456012"
+      pcbX={0}
+      pcbY={21.95}
+      pcbRotation={180}
+    />
     <resistor
       name="R1"
       resistance="1k"
       footprint="0603"
-      pcbX={-3}
-      pcbY={8}
+      pcbX={-2}
+      pcbY={16}
     />
-    <led name="LED1" footprint="0603" pcbX={3} pcbY={8} />
-    <trace from=".R1 > .pin2" to=".LED1 > .anode" />
+    <led name="LED1" footprint="0603" pcbX={2} pcbY={16} />
+    <trace name="vbus_to_resistor" from=".J_USB > .VBUS1" to=".R1 > .pin1" />
+    <trace name="resistor_to_led" from=".R1 > .pin2" to=".LED1 > .anode" />
+    <trace name="led_to_ground" from=".LED1 > .cathode" to=".J_USB > .GND1" />
   </FeatherCladWithPinHeaders>
 )
 `}

--- a/docs/guides/tscircuit-essentials/how-to-use-biscuit-board.mdx
+++ b/docs/guides/tscircuit-essentials/how-to-use-biscuit-board.mdx
@@ -1,16 +1,17 @@
 ---
-title: How to use Biscuit Board
-description: Build a tscircuit design on a prefabricated Biscuit Board and route through its fixed vias.
+title: How to use Biscuit Board templates
+description: Choose a Biscuit Board template and use it as the board wrapper for a tscircuit design.
 ---
 
 import CircuitPreview from "@site/src/components/CircuitPreview"
 
-# How to use Biscuit Board
+# How to use Biscuit Board templates
 
-The `biscuitboard` package provides reusable tscircuit wrappers for
-prefabricated copper-clad boards. `BiscuitBoard` is a 75 mm × 55 mm, two-layer
-board with mounting holes and a fixed set of through vias. Its default
-autorouter changes layers only at those prefabricated vias.
+Biscuit Board is a family of prefabricated copper-clad templates, not a single
+board. The `biscuitboard` package provides one tscircuit wrapper for each
+physical template. Choose the wrapper whose outline, connectors, and fixed vias
+match the product you want to build, then place ordinary tscircuit components
+and traces inside it.
 
 ## Install the package
 
@@ -18,15 +19,47 @@ autorouter changes layers only at those prefabricated vias.
 bun add biscuitboard
 ```
 
-## Add your circuit
+Each wrapper is a complete `<board>`, so use one wrapper as the root of a
+circuit:
 
-Import `BiscuitBoard`, then place ordinary tscircuit components and traces
-inside it. You do not need to create the board outline, mounting holes, or via
-field yourself.
+```tsx
+import { Clad40x40 } from "biscuitboard"
 
-In this example, the resistor is on the top layer and the LED is on the bottom
-layer. The route must therefore use one of the board's existing vias to change
-layers.
+export default () => (
+  <Clad40x40>
+    {/* components and traces */}
+  </Clad40x40>
+)
+```
+
+## Product names and numbers
+
+Catalog numbers keep the physical product name separate from its TypeScript
+API. The hundreds digit identifies the use-case family, the tens digit
+identifies a form factor, and the final digit is reserved for physical variants.
+
+| Number | Product name | TypeScript wrapper | Best suited for |
+| --- | --- | --- | --- |
+| `BB-100` | Biscuit Board 100 — General Purpose 75 | `BiscuitBoard` | General 75 mm × 55 mm circuits with large fixed through vias |
+| `BB-110` | Biscuit Board 110 — Breadboard 75 | `BreadboardClad` | Plug-in, breadboard-style prototypes with custom routed connections |
+| `BB-120` | Biscuit Board 120 — Square 40 | `Clad40x40` | Compact 40 mm × 40 mm modules and sensor boards |
+| `BB-200` | Biscuit Board 200 — Arduino UNO R3 | `ArduinoShieldClad` | Arduino UNO R3-compatible shields |
+| `BB-210` | Biscuit Board 210 — TI BoosterPack | `BoosterPackClad` | TI LaunchPad BoosterPack-compatible add-ons |
+| `BB-300` | Biscuit Board 300 — XIAO Header | `XiaoCladWithPinHeaders` | XIAO-sized boards using ordinary through-hole headers |
+| `BB-301` | Biscuit Board 301 — XIAO Perforated | `XiaoCladWithPerforatedPinHeaders` | XIAO-sized boards with perforated, edge-mounted header pads |
+| `BB-310` | Biscuit Board 310 — Feather Header | `FeatherCladWithPinHeaders` | Adafruit Feather-compatible boards |
+
+The catalog number is the stable product identifier. The descriptive suffix can
+be refined without changing code or manufacturing records.
+
+## Choose a template
+
+### Biscuit Board 100 — General Purpose 75 (`BB-100`)
+
+Use `BiscuitBoard` when none of the connector-specific formats apply. It is a
+75 mm × 55 mm, two-layer board with mounting holes and a field of large fixed
+through vias. This example places a top-layer resistor and a bottom-layer LED;
+the default autorouter must use one of the existing vias to change layers.
 
 <CircuitPreview
   leftView="code"
@@ -56,13 +89,144 @@ export default () => (
 `}
 />
 
+### Biscuit Board 110 — Breadboard 75 (`BB-110`)
+
+Use `BreadboardClad` for plug-in prototypes and DIP-style layouts. It provides
+210 individually routable A1–J21 sockets plus four power/header rails. Unlike a
+solderless breadboard, the sockets are not pre-connected; your traces define
+the copper connections.
+
+<CircuitPreview
+  leftView="code"
+  rightView="pcb"
+  code={`
+import { BreadboardClad } from "biscuitboard"
+
+export default () => (
+  <BreadboardClad routingDisabled markHeadersNoConnect />
+)
+`}
+/>
+
+### Biscuit Board 120 — Square 40 (`BB-120`)
+
+Use `Clad40x40` for a compact custom module. The 40 mm square outline has two
+mounting holes and three concentric rings containing 72 fixed vias, leaving room
+around the rings for small components.
+
+<CircuitPreview
+  leftView="code"
+  rightView="pcb"
+  code={`
+import { Clad40x40 } from "biscuitboard"
+
+export default () => <Clad40x40 routingDisabled />
+`}
+/>
+
+### Biscuit Board 200 — Arduino UNO R3 (`BB-200`)
+
+Use `ArduinoShieldClad` to build a shield for an Arduino UNO R3-compatible host.
+It includes the power, analog, digital, I²C, and ICSP connector geometry plus
+fixed via fields arranged around those headers.
+
+<CircuitPreview
+  leftView="code"
+  rightView="pcb"
+  code={`
+import { ArduinoShieldClad } from "biscuitboard"
+
+export default () => (
+  <ArduinoShieldClad routingDisabled markHeadersNoConnect />
+)
+`}
+/>
+
+### Biscuit Board 210 — TI BoosterPack (`BB-210`)
+
+Use `BoosterPackClad` for a TI LaunchPad add-on. It provides the 40-pin
+BoosterPack mating pattern, an additional edge header, and dense fixed-via
+fields while retaining the 75 mm × 55 mm Biscuit Board outline.
+
+<CircuitPreview
+  leftView="code"
+  rightView="pcb"
+  code={`
+import { BoosterPackClad } from "biscuitboard"
+
+export default () => <BoosterPackClad routingDisabled />
+`}
+/>
+
+### Biscuit Board 300 — XIAO Header (`BB-300`)
+
+Use `XiaoCladWithPinHeaders` for a compact board that mates through the classic
+two-row XIAO header pattern. It preserves a central component area and marks the
+USB end with `UP`.
+
+<CircuitPreview
+  leftView="code"
+  rightView="pcb"
+  code={`
+import { XiaoCladWithPinHeaders } from "biscuitboard"
+
+export default () => (
+  <XiaoCladWithPinHeaders routingDisabled markHeadersNoConnect />
+)
+`}
+/>
+
+### Biscuit Board 301 — XIAO Perforated (`BB-301`)
+
+Use `XiaoCladWithPerforatedPinHeaders` when the XIAO header pads should extend
+to perforations on the board edge. It uses the same outline and pin centers as
+`BB-300`, so the final digit identifies this physical header variant.
+
+<CircuitPreview
+  leftView="code"
+  rightView="pcb"
+  code={`
+import { XiaoCladWithPerforatedPinHeaders } from "biscuitboard"
+
+export default () => (
+  <XiaoCladWithPerforatedPinHeaders
+    routingDisabled
+    markHeadersNoConnect
+  />
+)
+`}
+/>
+
+### Biscuit Board 310 — Feather Header (`BB-310`)
+
+Use `FeatherCladWithPinHeaders` for an Adafruit Feather-compatible board. It
+includes the classic 1×16 and 1×12 header rows, four mounting holes, an open
+central component field, and an `UP` mark at the USB edge.
+
+<CircuitPreview
+  leftView="code"
+  rightView="pcb"
+  code={`
+import { FeatherCladWithPinHeaders } from "biscuitboard"
+
+export default () => (
+  <FeatherCladWithPinHeaders routingDisabled markHeadersNoConnect />
+)
+`}
+/>
+
+The bare-template previews use `routingDisabled` and, where available,
+`markHeadersNoConnect` so every prefabricated feature can be inspected without
+adding a circuit. For a real design, remove those preview props, add components
+and traces as children, and explicitly mark only genuinely unused connector
+pins as unconnected.
+
 ## Tune routing when needed
 
-`BiscuitBoard` accepts the usual children plus a few routing controls:
+All templates accept the usual children plus the same routing controls:
 
-- `nominalTraceWidth` sets the preferred routed trace width. It defaults to
-  0.3 mm.
-- `minTraceWidth` sets the board's enforced minimum trace width.
+- `nominalTraceWidth` sets the preferred routed trace width.
+- `minTraceWidth` sets the enforced minimum trace width.
 - `autorouterOptions` tunes route ordering, grid spacing, rip-up limits, and
   search effort.
 - `routingDisabled` keeps the board geometry and vias but skips automatic
@@ -71,24 +235,16 @@ export default () => (
 For example:
 
 ```tsx
-<BiscuitBoard
-  nominalTraceWidth={0.25}
+<Clad40x40
+  nominalTraceWidth={0.2}
   minTraceWidth={0.15}
   autorouterOptions={{ routeOrder: "adaptive" }}
 >
   {/* components and traces */}
-</BiscuitBoard>
+</Clad40x40>
 ```
 
-## Use another clad format
-
-The same package also exports `ArduinoShieldClad`, `BoosterPackClad`,
-`BreadboardClad`, `Clad40x40`, `FeatherCladWithPinHeaders`,
-`XiaoCladWithPinHeaders`, and `XiaoCladWithPerforatedPinHeaders`. Each wrapper
-provides its board geometry and prefabricated connection points while accepting
-normal tscircuit children.
-
-Build your project normally after choosing a wrapper:
+Build your project normally after choosing a template:
 
 ```bash
 bunx tsci build

--- a/docs/guides/tscircuit-essentials/how-to-use-biscuit-board.mdx
+++ b/docs/guides/tscircuit-essentials/how-to-use-biscuit-board.mdx
@@ -12,6 +12,10 @@ board layouts. Each wrapper supplies its board outline, mounting features,
 connectors, and fixed vias. Choose a wrapper, then place ordinary tscircuit
 components and traces inside it.
 
+The wrappers also supply the Biscuit Board autorouter by default. Leave the
+`autorouter` prop unset when using a clad wrapper so routes use its fixed-via
+layout; use `autorouterOptions` only when you need to tune that router.
+
 ## Install the package
 
 ```bash
@@ -61,7 +65,7 @@ through vias.
 import { BiscuitBoard } from "biscuitboard"
 
 export default () => (
-  <BiscuitBoard autorouter="laser_prefab">
+  <BiscuitBoard>
     <connector
       name="J_USB"
       standard="usb_c"
@@ -99,7 +103,6 @@ import { BreadboardClad } from "biscuitboard"
 
 export default () => (
   <BreadboardClad
-    autorouter="laser_prefab"
     nominalTraceWidth={0.15}
     markHeadersNoConnect
   >
@@ -146,7 +149,7 @@ holes and three concentric rings containing 72 fixed vias.
 import { Clad40x40 } from "biscuitboard"
 
 export default () => (
-  <Clad40x40 autorouter="laser_prefab">
+  <Clad40x40>
     <connector
       name="J_USB"
       standard="usb_c"
@@ -183,7 +186,7 @@ connector geometry.
 import { ArduinoShieldClad } from "biscuitboard"
 
 export default () => (
-  <ArduinoShieldClad autorouter="laser_prefab" markHeadersNoConnect>
+  <ArduinoShieldClad markHeadersNoConnect>
     <connector
       name="J_USB"
       standard="usb_c"
@@ -221,7 +224,7 @@ fields.
 import { BoosterPackClad } from "biscuitboard"
 
 export default () => (
-  <BoosterPackClad autorouter="laser_prefab">
+  <BoosterPackClad>
     <connector
       name="J_USB"
       standard="usb_c"
@@ -235,9 +238,9 @@ export default () => (
       resistance="1k"
       footprint="0603"
       pcbX={29}
-      pcbY={-2}
+      pcbY={-4}
     />
-    <led name="LED1" footprint="0603" pcbX={29} pcbY={2} />
+    <led name="LED1" footprint="0603" pcbX={29} pcbY={-6} />
     <trace name="vbus_to_resistor" from=".J_USB > .VBUS1" to=".R1 > .pin1" />
     <trace name="resistor_to_led" from=".R1 > .pin2" to=".LED1 > .anode" />
     <trace name="led_to_ground" from=".LED1 > .cathode" to=".J_USB > .GND1" />
@@ -259,7 +262,6 @@ import { XiaoCladWithPinHeaders } from "biscuitboard"
 
 export default () => (
   <XiaoCladWithPinHeaders
-    autorouter="laser_prefab"
     markHeadersNoConnect
     showUsbLabel={false}
   >
@@ -305,13 +307,13 @@ the remaining checks stay enabled.
 
 export default () => (
   <XiaoCladWithPerforatedPinHeaders
-    autorouter="laser_prefab"
     markHeadersNoConnect
     showUsbLabel={false}
   >
     <connector
       name="J_USB"
       standard="usb_c"
+      footprint="jlcpcb:C456012"
       pcbX={0}
       pcbY={7.05}
       pcbRotation={180}
@@ -351,7 +353,6 @@ import { FeatherCladWithPinHeaders } from "biscuitboard"
 
 export default () => (
   <FeatherCladWithPinHeaders
-    autorouter="laser_prefab"
     markHeadersNoConnect
     showUsbLabel={false}
   >

--- a/docs/guides/tscircuit-essentials/how-to-use-biscuit-board.mdx
+++ b/docs/guides/tscircuit-essentials/how-to-use-biscuit-board.mdx
@@ -1,0 +1,95 @@
+---
+title: How to use Biscuit Board
+description: Build a tscircuit design on a prefabricated Biscuit Board and route through its fixed vias.
+---
+
+import CircuitPreview from "@site/src/components/CircuitPreview"
+
+# How to use Biscuit Board
+
+The `biscuitboard` package provides reusable tscircuit wrappers for
+prefabricated copper-clad boards. `BiscuitBoard` is a 75 mm × 55 mm, two-layer
+board with mounting holes and a fixed set of through vias. Its default
+autorouter changes layers only at those prefabricated vias.
+
+## Install the package
+
+```bash
+bun add biscuitboard
+```
+
+## Add your circuit
+
+Import `BiscuitBoard`, then place ordinary tscircuit components and traces
+inside it. You do not need to create the board outline, mounting holes, or via
+field yourself.
+
+In this example, the resistor is on the top layer and the LED is on the bottom
+layer. The route must therefore use one of the board's existing vias to change
+layers.
+
+<CircuitPreview
+  leftView="code"
+  rightView="pcb"
+  code={`
+import { BiscuitBoard } from "biscuitboard"
+
+export default () => (
+  <BiscuitBoard>
+    <resistor
+      name="R1"
+      resistance="1k"
+      footprint="0603"
+      pcbX={-8}
+      pcbY={0}
+    />
+    <led
+      name="LED1"
+      footprint="0603"
+      layer="bottom"
+      pcbX={8}
+      pcbY={0}
+    />
+    <trace from=".R1 > .pin2" to=".LED1 > .anode" />
+  </BiscuitBoard>
+)
+`}
+/>
+
+## Tune routing when needed
+
+`BiscuitBoard` accepts the usual children plus a few routing controls:
+
+- `nominalTraceWidth` sets the preferred routed trace width. It defaults to
+  0.3 mm.
+- `minTraceWidth` sets the board's enforced minimum trace width.
+- `autorouterOptions` tunes route ordering, grid spacing, rip-up limits, and
+  search effort.
+- `routingDisabled` keeps the board geometry and vias but skips automatic
+  routing.
+
+For example:
+
+```tsx
+<BiscuitBoard
+  nominalTraceWidth={0.25}
+  minTraceWidth={0.15}
+  autorouterOptions={{ routeOrder: "adaptive" }}
+>
+  {/* components and traces */}
+</BiscuitBoard>
+```
+
+## Use another clad format
+
+The same package also exports `ArduinoShieldClad`, `BoosterPackClad`,
+`BreadboardClad`, `Clad40x40`, `FeatherCladWithPinHeaders`,
+`XiaoCladWithPinHeaders`, and `XiaoCladWithPerforatedPinHeaders`. Each wrapper
+provides its board geometry and prefabricated connection points while accepting
+normal tscircuit children.
+
+Build your project normally after choosing a wrapper:
+
+```bash
+bunx tsci build
+```


### PR DESCRIPTION
## What changed

- Add a “How to use Biscuit Board templates” guide under tscircuit essentials.
- List every exported clad wrapper with its dimensions and intended use case.
- Give all eight wrappers an import example and live PCB preview.
- Populate every preview with the same USB-C connector, 1 kΩ 0603 resistor, 0603 LED, and short routed trace so readers can compare board sizes directly.

## Why

The `biscuitboard` package provides several clad wrappers rather than one canonical board. Users need a simple way to choose the appropriate wrapper and see how familiar components fit within each physical layout.

## Impact

Users can install the package, import a real wrapper by name, compare the complete set of layouts, and start placing ordinary tscircuit components inside the selected clad.

## Validation

- `bun run typecheck`
- `bun run build`
- All eight populated snippets render through the svg.tscircuit.com integration test
- The populated `BiscuitBoard` example is covered by an SVG snapshot
- All generated PCB previews were inspected for component placement and relative scale

## Coordination

- Live package import support (merged): https://github.com/tscircuit/svg.tscircuit.com/pull/2068
- Populated wrapper-preview regression coverage: https://github.com/tscircuit/svg.tscircuit.com/pull/2069
